### PR TITLE
Clarify source adapter registration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ python3 -m manga_watch.runner
 - `manga_watch/urls.txt`: watchlist
 - `docker-compose.yml`: 本番想定の単一コンテナ起動定義
 
+## Adding a source adapter
+
+source adapter の registration contract は `manga_watch/sources/registry.py` の
+`REGISTERED_ADAPTER_TYPES` です。新しい source を追加するときは次の順に行います。
+
+1. `manga_watch/sources/<source>.py` に `SourceAdapter` 実装を追加する
+2. その adapter class を `REGISTERED_ADAPTER_TYPES` に追加する
+
+未登録の adapter module が増えると `tests/test_sources.py` の registry test が失敗します。
+追加後は次で確認します。
+
+```bash
+python3 -m unittest tests.test_sources tests.test_check tests.test_runner
+```
+
 ## Security notes
 
 - Discord token はコミットしない
@@ -99,4 +114,4 @@ python3 -m manga_watch.runner
 ## Maintenance tips
 
 - サイトの HTML が変わって検知が止まったら `python3 -m manga_watch.check manga_watch/urls.txt` を実行して例外を確認する
-- 新しいサイトを足すときは `manga_watch/sources/` に adapter を追加し、`registry.py` に登録する
+- 新しいサイトを足すときは `Adding a source adapter` の 2-step contract に従う

--- a/manga_watch/sources/registry.py
+++ b/manga_watch/sources/registry.py
@@ -1,14 +1,19 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple, Type
 
 from .base import HttpClient, LatestEpisode, RequestsHttpClient, SourceAdapter, WorkDescriptor
 from .comic_action import ComicActionAdapter
 from .comic_walker import ComicWalkerAdapter
 from .kakuyomu import KakuyomuAdapter
 
-DEFAULT_ADAPTERS = (
-    ComicWalkerAdapter(),
-    ComicActionAdapter(),
-    KakuyomuAdapter(),
+# Single source of truth for supported adapters. Add new adapter classes here.
+REGISTERED_ADAPTER_TYPES: Tuple[Type[SourceAdapter], ...] = (
+    ComicWalkerAdapter,
+    ComicActionAdapter,
+    KakuyomuAdapter,
+)
+
+DEFAULT_ADAPTERS: Tuple[SourceAdapter, ...] = tuple(
+    adapter_type() for adapter_type in REGISTERED_ADAPTER_TYPES
 )
 
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,8 +1,14 @@
+import importlib
+import inspect
+import pkgutil
 import unittest
 
+import manga_watch.sources as sources_package
+from manga_watch.sources.base import SourceAdapter
 from manga_watch.sources.comic_action import ComicActionAdapter
 from manga_watch.sources.comic_walker import ComicWalkerAdapter
 from manga_watch.sources.kakuyomu import KakuyomuAdapter
+from manga_watch.sources.registry import DEFAULT_ADAPTERS, REGISTERED_ADAPTER_TYPES
 
 
 class FakeHttpClient:
@@ -13,7 +19,41 @@ class FakeHttpClient:
         return self.pages[url]
 
 
+def discover_adapter_types():
+    discovered = {}
+
+    for module_info in pkgutil.iter_modules(sources_package.__path__):
+        if module_info.name in {"base", "registry", "util"}:
+            continue
+
+        module = importlib.import_module(f"{sources_package.__name__}.{module_info.name}")
+        for _, adapter_type in inspect.getmembers(module, inspect.isclass):
+            if adapter_type is SourceAdapter:
+                continue
+            if not issubclass(adapter_type, SourceAdapter):
+                continue
+            if inspect.isabstract(adapter_type):
+                continue
+            if adapter_type.__module__ != module.__name__:
+                continue
+            if adapter_type.source in discovered:
+                raise AssertionError(f"duplicate adapter source registered in modules: {adapter_type.source}")
+            discovered[adapter_type.source] = adapter_type
+
+    return discovered
+
+
 class SourceAdapterTests(unittest.TestCase):
+    def test_registry_contract_covers_all_source_adapter_modules(self):
+        discovered = discover_adapter_types()
+        registered = {adapter_type.source: adapter_type for adapter_type in REGISTERED_ADAPTER_TYPES}
+
+        self.assertEqual(discovered, registered)
+        self.assertEqual(
+            tuple(registered.keys()),
+            tuple(adapter.source for adapter in DEFAULT_ADAPTERS),
+        )
+
     def test_comic_walker_adapter_fetches_latest_episode_from_fixture(self):
         adapter = ComicWalkerAdapter()
         seed_url = "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456001_E"


### PR DESCRIPTION
## Issue
- Closes #21

## Summary
- define `REGISTERED_ADAPTER_TYPES` as the single source of truth for source adapter registration
- add a discovery-based test that fails when a concrete adapter module exists but is not registered
- document the 2-step source adapter addition contract in README

## Verification
- `.venv/bin/python -m unittest tests.test_sources tests.test_check tests.test_runner`

## Residual Risks
- adapter registration remains intentionally static, so adding a source still requires editing `manga_watch/sources/registry.py`
- the omission test only covers concrete `SourceAdapter` classes under `manga_watch/sources`