### PR TITLE
feat: classify update types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,18 @@ checker の出力契約は JSON のままです。
   "updates": [
     {
       "id": "KC_003913_S",
+      "update_type": "main_story",
+      "classification_reason": "episode_title matched main-story numbering",
+      "default_notify": true,
       "from": {"seriesTitle": "...", "episodeTitle": "..."},
-      "to": {"seriesTitle": "...", "episodeTitle": "...", "url": "..."}
+      "to": {
+        "seriesTitle": "...",
+        "episodeTitle": "...",
+        "url": "...",
+        "update_type": "main_story",
+        "classification_reason": "episode_title matched main-story numbering",
+        "default_notify": true
+      }
     }
   ],
   "errors": {
@@ -75,6 +85,15 @@ checker は watchlist を並列に処理しますが、`updates` / `errors.sourc
 ### legacy v1 input
 
 `manga_watch/urls.txt` は migration 入力と rollback 用の参考データです。runtime はこのファイルを読みません。
+
+更新分類の既定値は次の通りです。
+
+- `main_story`: 既定で通知する
+- `unknown`: fail-open で既定通知する
+- `bonus`: 既定では main channel に通知しない
+- `announcement`: 既定では main channel に通知しない
+
+`main_story` と suppress 対象が衝突した場合は `unknown` に倒し、`bonus` と `announcement` だけが衝突した場合は suppress 側に残します。checker / state / run report には suppressed update も残ります。
 
 ## Supported sources
 
@@ -134,7 +153,7 @@ source .venv/bin/activate
 pip install -U pip
 pip install -r requirements.txt
 python3 -m manga_watch.check manga_watch/watchlist.json
-python3 -m unittest tests.test_sources tests.test_check tests.test_runner tests.test_migrate_v2
+python3 -m unittest tests.test_sources tests.test_update_classification tests.test_check tests.test_runner tests.test_migrate_v2
 ```
 
 runner をローカル起動する場合は Discord 環境変数を入れてから実行します。
@@ -166,14 +185,17 @@ python3 -m manga_watch.migrate_v2 \
 - `manga_watch/migrate_v2.py`: v1 から v2 への one-time migration CLI
 - `manga_watch/storage.py`: watchlist/state v2 validation と atomic write
 - `manga_watch/runner.py`: スケジューラ + Discord 通知
+- `manga_watch/update_classification.py`: 更新種別と既定通知対象の分類ロジック
 - `manga_watch/watchlist.json`: watchlist v2 sample
 - `manga_watch/state.json`: state v2 sample
 - `manga_watch/urls.txt`: legacy v1 migration input sample
 - `tests/fixtures/<source>/<case>/`: raw response bundle + `manifest.json`
 
+分類テストでは source ごとの代表例に加えて、main/bonus の曖昧ケースと bonus/announcement の suppress 維持ケースを確認します。
+
 ## Maintenance tips
 
 - サイトの HTML が変わって検知が止まったら `python3 -m manga_watch.check manga_watch/watchlist.json` を実行して例外を確認する
-- migration や state contract を更新したら `python3 -m unittest tests.test_sources tests.test_check tests.test_runner tests.test_migrate_v2` を回す
-- run/retry 設定を変えたときは `.venv/bin/python -m unittest tests.test_sources tests.test_check tests.test_runner tests.test_migrate_v2` で runner まで確認する
+- migration や state contract を更新したら `python3 -m unittest tests.test_sources tests.test_update_classification tests.test_check tests.test_runner tests.test_migrate_v2` を回す
+- run/retry 設定を変えたときは `.venv/bin/python -m unittest tests.test_sources tests.test_update_classification tests.test_check tests.test_runner tests.test_migrate_v2` で runner まで確認する
 - 新しい source を足すときは `manga_watch/sources/` に adapter を追加し、`registry.py` に登録する

--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -25,6 +25,7 @@ from manga_watch.storage import (
     load_watchlist,
     save_state,
 )
+from manga_watch.update_classification import DEFAULT_NOTIFY_UPDATE_TYPES, SUPPRESSED_UPDATE_TYPES
 
 DEFAULT_REQUEST_TIMEOUT = 25
 DEFAULT_RETRY_COUNT = 2
@@ -120,6 +121,35 @@ def latest_id_for_state(latest: Mapping[str, object]) -> str:
     return str(latest.get("latestKey") or latest.get("episodeCode") or latest.get("url") or "")
 
 
+def default_notify_for_latest(latest: Mapping[str, object]) -> Optional[bool]:
+    if "default_notify" in latest and latest.get("default_notify") is not None:
+        return bool(latest.get("default_notify"))
+
+    update_type = latest.get("update_type")
+    if update_type in DEFAULT_NOTIFY_UPDATE_TYPES:
+        return True
+    if update_type in SUPPRESSED_UPDATE_TYPES:
+        return False
+    return None
+
+
+def update_event_metadata(latest: Mapping[str, object]) -> Dict[str, object]:
+    metadata: Dict[str, object] = {}
+    update_type = latest.get("update_type")
+    if update_type:
+        metadata["update_type"] = str(update_type)
+
+    classification_reason = latest.get("classification_reason")
+    if classification_reason:
+        metadata["classification_reason"] = str(classification_reason)
+
+    default_notify = default_notify_for_latest(latest)
+    if default_notify is not None:
+        metadata["default_notify"] = default_notify
+
+    return metadata
+
+
 def merge_latest_metadata(
     previous_latest: Mapping[str, object],
     latest: Mapping[str, object],
@@ -128,9 +158,13 @@ def merge_latest_metadata(
     for key, value in latest.items():
         if value is None:
             continue
-        if key in ("seriesTitle", "episodeTitle", "pageTitle"):
+        if key in ("seriesTitle", "episodeTitle", "pageTitle", "update_type", "classification_reason"):
             if value and value != merged.get(key):
                 merged[key] = value
+            continue
+        if key == "default_notify":
+            if value != merged.get(key):
+                merged[key] = bool(value)
             continue
         if not merged.get(key):
             merged[key] = value
@@ -165,13 +199,15 @@ def apply_item_transition(
     previous_latest_id = latest_id_for_state(previous_latest)
     latest_id = latest_id_for_state(latest_copy)
     if previous_latest_id != latest_id:
+        update = {"id": item_id, "from": previous_latest, "to": latest_copy}
+        update.update(update_event_metadata(latest_copy))
         return (
             {
                 "latest": latest_runtime_to_storage(latest_copy),
                 "history": history,
                 "health": success_health(previous_entry, seen_at=seen_at),
             },
-            {"id": item_id, "from": previous_latest, "to": latest_copy},
+            update,
         )
 
     return (

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -11,6 +11,7 @@ import requests
 
 from manga_watch.check import run_check
 from manga_watch.storage import DEFAULT_WATCHLIST_PATH, load_state
+from manga_watch.update_classification import DEFAULT_NOTIFY_UPDATE_TYPES
 
 DEFAULT_CRAWL_SCHEDULE = "0 19 * * *"
 
@@ -72,6 +73,58 @@ def current_series_label(item_id: str, latest: Dict[str, str]) -> str:
     )
 
 
+def update_type_for_event(update: Dict[str, object]) -> str:
+    update_type = update.get("update_type")
+    if isinstance(update_type, str) and update_type:
+        return update_type
+
+    latest = update.get("to", {}) or {}
+    if isinstance(latest, dict):
+        latest_type = latest.get("update_type")
+        if isinstance(latest_type, str) and latest_type:
+            return latest_type
+
+    return "unknown"
+
+
+def classification_reason_for_event(update: Dict[str, object]) -> Optional[str]:
+    reason = update.get("classification_reason")
+    if isinstance(reason, str) and reason:
+        return reason
+
+    latest = update.get("to", {}) or {}
+    if isinstance(latest, dict):
+        latest_reason = latest.get("classification_reason")
+        if isinstance(latest_reason, str) and latest_reason:
+            return latest_reason
+
+    return None
+
+
+def default_notify_for_event(update: Dict[str, object]) -> bool:
+    if "default_notify" in update and update.get("default_notify") is not None:
+        return bool(update.get("default_notify"))
+
+    latest = update.get("to", {}) or {}
+    if isinstance(latest, dict) and "default_notify" in latest and latest.get("default_notify") is not None:
+        return bool(latest.get("default_notify"))
+
+    return update_type_for_event(update) in DEFAULT_NOTIFY_UPDATE_TYPES
+
+
+def partition_updates_by_default_notify(
+    updates: List[Dict[str, object]],
+) -> tuple[List[Dict[str, object]], List[Dict[str, object]]]:
+    notify = []
+    suppressed = []
+    for update in updates:
+        if default_notify_for_event(update):
+            notify.append(update)
+        else:
+            suppressed.append(update)
+    return notify, suppressed
+
+
 def format_update_message(updates: List[Dict[str, object]]) -> str:
     lines = ["新着エピソードを検知しました"]
     for update in updates:
@@ -81,7 +134,13 @@ def format_update_message(updates: List[Dict[str, object]]) -> str:
         series = current_series_label(item_id, latest) or current_series_label(item_id, previous)
         before = latest_label(previous, "未取得")
         after = latest_label(latest, "不明")
-        lines.append(f"- {series}：{before} → {after}")
+        update_type = update_type_for_event(update)
+        suffix = "" if update_type == "main_story" else f" [{update_type}]"
+        lines.append(f"- {series}：{before} → {after}{suffix}")
+        if update_type == "unknown":
+            classification_reason = classification_reason_for_event(update)
+            if classification_reason:
+                lines.append(f"  判定理由: {classification_reason}")
         url = latest.get("url")
         if url:
             lines.append(f"  {url}")
@@ -152,12 +211,16 @@ def format_run_report(
     updates: List[Dict[str, object]],
     errors: Dict[str, List[Dict[str, object]]],
     state: Dict[str, object],
+    default_notify_count: int,
+    suppressed_update_count: int,
     update_notification_sent: bool,
 ) -> str:
     degraded = checker_error_count(errors) > 0
     lines = [
         f"{'巡回実行に一部失敗がありました' if degraded else '巡回実行しました'} ({timestamp})",
         f"更新検知: {len(updates)}件",
+        f"既定通知対象: {default_notify_count}件",
+        f"既定抑制: {suppressed_update_count}件",
         f"通知: {'送信した' if update_notification_sent else '送信なし'}",
     ]
     lines.extend(format_checker_error_lines(errors))
@@ -281,13 +344,14 @@ def run_once(
         if not isinstance(updates, list):
             raise RuntimeError("checker returned invalid updates payload")
         errors = normalize_checker_errors(result)
+        default_notify_updates, suppressed_updates = partition_updates_by_default_notify(updates)
 
         state = state_loader()
         update_notification_sent = False
-        if updates:
+        if default_notify_updates:
             messenger.send_message(
                 config.discord_main_channel_id,
-                format_update_message(updates),
+                format_update_message(default_notify_updates),
             )
             update_notification_sent = True
 
@@ -298,6 +362,8 @@ def run_once(
                 updates=updates,
                 errors=errors,
                 state=state,
+                default_notify_count=len(default_notify_updates),
+                suppressed_update_count=len(suppressed_updates),
                 update_notification_sent=update_notification_sent,
             ),
         )

--- a/manga_watch/sources/base.py
+++ b/manga_watch/sources/base.py
@@ -10,6 +10,8 @@ from urllib.parse import urlparse
 
 import requests
 
+from manga_watch.update_classification import classify_update
+
 UA = os.environ.get(
     "MANGA_WATCH_UA",
     "Mozilla/5.0 (X11; Linux) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
@@ -197,9 +199,24 @@ class LatestEpisode:
     episode_code: Optional[str] = None
     episode_title: Optional[str] = None
     page_title: Optional[str] = None
+    update_type: Optional[str] = None
+    classification_reason: Optional[str] = None
+    default_notify: Optional[bool] = None
     extra: Mapping[str, str] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, str]:
+    def __post_init__(self) -> None:
+        decision = classify_update(
+            episode_title=self.episode_title,
+            page_title=self.page_title,
+        )
+        if not self.update_type:
+            object.__setattr__(self, "update_type", decision.update_type)
+        if not self.classification_reason:
+            object.__setattr__(self, "classification_reason", decision.classification_reason)
+        if self.default_notify is None:
+            object.__setattr__(self, "default_notify", decision.default_notify)
+
+    def to_dict(self) -> Dict[str, object]:
         data = {
             "source": self.source,
             "workId": self.work_id,
@@ -216,6 +233,12 @@ class LatestEpisode:
             data["episodeTitle"] = self.episode_title
         if self.page_title:
             data["pageTitle"] = self.page_title
+        if self.update_type:
+            data["update_type"] = self.update_type
+        if self.classification_reason:
+            data["classification_reason"] = self.classification_reason
+        if self.default_notify is not None:
+            data["default_notify"] = self.default_notify
         for key, value in self.extra.items():
             if value is None:
                 continue

--- a/manga_watch/storage.py
+++ b/manga_watch/storage.py
@@ -16,6 +16,9 @@ _LATEST_RUNTIME_TO_STORAGE = {
     "episodeCode": "episode_code",
     "episodeTitle": "episode_title",
     "pageTitle": "page_title",
+    "update_type": "update_type",
+    "classification_reason": "classification_reason",
+    "default_notify": "default_notify",
 }
 _LATEST_STORAGE_TO_RUNTIME = {value: key for key, value in _LATEST_RUNTIME_TO_STORAGE.items()}
 

--- a/manga_watch/update_classification.py
+++ b/manga_watch/update_classification.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+MAIN_STORY = "main_story"
+BONUS = "bonus"
+ANNOUNCEMENT = "announcement"
+UNKNOWN = "unknown"
+
+DEFAULT_NOTIFY_UPDATE_TYPES = {MAIN_STORY, UNKNOWN}
+SUPPRESSED_UPDATE_TYPES = {BONUS, ANNOUNCEMENT}
+
+MAIN_STORY_PATTERNS: Sequence[re.Pattern[str]] = (
+    re.compile(r"第\s*\d+\s*(?:話|回|限目|章|幕)"),
+    re.compile(r"\b(?:episode|ep\.?)\s*\d+\b", re.IGNORECASE),
+    re.compile(r"#\s*\d+\b"),
+)
+BONUS_PATTERNS: Sequence[re.Pattern[str]] = (
+    re.compile(r"番外編"),
+    re.compile(r"おまけ"),
+    re.compile(r"特別編"),
+    re.compile(r"\bextra\b", re.IGNORECASE),
+    re.compile(r"幕間"),
+    re.compile(r"ショート"),
+    re.compile(r"4コマ"),
+)
+ANNOUNCEMENT_PATTERNS: Sequence[re.Pattern[str]] = (
+    re.compile(r"お知らせ"),
+    re.compile(r"告知"),
+    re.compile(r"休載"),
+    re.compile(r"更新延期"),
+    re.compile(r"次回更新"),
+    re.compile(r"キャンペーン"),
+    re.compile(r"メンテナンス"),
+    re.compile(r"単行本"),
+    re.compile(r"コミックス"),
+)
+
+
+@dataclass(frozen=True)
+class UpdateClassification:
+    update_type: str
+    classification_reason: str
+    default_notify: bool
+
+
+def default_notify_for_update_type(update_type: str) -> bool:
+    return update_type in DEFAULT_NOTIFY_UPDATE_TYPES
+
+
+def classify_update(
+    *,
+    episode_title: Optional[str] = None,
+    page_title: Optional[str] = None,
+) -> UpdateClassification:
+    field_matches = []
+    for field_name, text in (("episode_title", episode_title), ("page_title", page_title)):
+        matches = _matched_update_types(text)
+        if matches:
+            field_matches.append((field_name, matches))
+
+    all_matches = {match for _, matches in field_matches for match in matches}
+    if len(all_matches) > 1:
+        if all_matches.issubset(SUPPRESSED_UPDATE_TYPES):
+            suppressed_type = _suppressed_conflict_update_type(all_matches)
+            return UpdateClassification(
+                update_type=suppressed_type,
+                classification_reason=_suppressed_conflict_reason(field_matches, suppressed_type),
+                default_notify=False,
+            )
+        return UpdateClassification(
+            update_type=UNKNOWN,
+            classification_reason=_conflict_reason(field_matches),
+            default_notify=True,
+        )
+
+    if len(all_matches) == 1:
+        update_type = next(iter(all_matches))
+        field_name = next(field_name for field_name, matches in field_matches if update_type in matches)
+        return UpdateClassification(
+            update_type=update_type,
+            classification_reason=_single_match_reason(field_name, update_type),
+            default_notify=default_notify_for_update_type(update_type),
+        )
+
+    return UpdateClassification(
+        update_type=UNKNOWN,
+        classification_reason="no classification markers matched",
+        default_notify=True,
+    )
+
+
+def _matched_update_types(text: Optional[str]) -> set[str]:
+    if not text:
+        return set()
+
+    normalized = _normalize_text(text)
+    matches = set()
+    if any(pattern.search(normalized) for pattern in MAIN_STORY_PATTERNS):
+        matches.add(MAIN_STORY)
+    if any(pattern.search(normalized) for pattern in BONUS_PATTERNS):
+        matches.add(BONUS)
+    if any(pattern.search(normalized) for pattern in ANNOUNCEMENT_PATTERNS):
+        matches.add(ANNOUNCEMENT)
+    return matches
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
+def _single_match_reason(field_name: str, update_type: str) -> str:
+    if update_type == MAIN_STORY:
+        return f"{field_name} matched main-story numbering"
+    if update_type == BONUS:
+        return f"{field_name} matched bonus marker"
+    if update_type == ANNOUNCEMENT:
+        return f"{field_name} matched announcement marker"
+    return f"{field_name} matched unknown marker"
+
+
+def _conflict_reason(field_matches: Sequence[tuple[str, set[str]]]) -> str:
+    for field_name, matches in field_matches:
+        if len(matches) > 1:
+            joined = " and ".join(_reason_label(match) for match in sorted(matches))
+            return f"{field_name} matched both {joined}"
+
+    joined = " and ".join(
+        _reason_label(match) for match in sorted({match for _, matches in field_matches for match in matches})
+    )
+    return f"conflicting classification markers across fields: {joined}"
+
+
+def _suppressed_conflict_update_type(matches: set[str]) -> str:
+    if ANNOUNCEMENT in matches:
+        return ANNOUNCEMENT
+    return BONUS
+
+
+def _suppressed_conflict_reason(
+    field_matches: Sequence[tuple[str, set[str]]],
+    update_type: str,
+) -> str:
+    return f"{_conflict_reason(field_matches)}; kept suppressed as {update_type}"
+
+
+def _reason_label(update_type: str) -> str:
+    if update_type == MAIN_STORY:
+        return "main-story markers"
+    if update_type == BONUS:
+        return "bonus markers"
+    if update_type == ANNOUNCEMENT:
+        return "announcement markers"
+    return "unknown markers"

--- a/spec.md
+++ b/spec.md
@@ -82,7 +82,10 @@
         "series": "KC_003913_S",
         "series_title": "蜘蛛ですが、なにか？",
         "episode_code": "KC_0039130008900011_E",
-        "episode_title": "第77話その2"
+        "episode_title": "第77話その2",
+        "update_type": "main_story",
+        "classification_reason": "episode_title matched main-story numbering",
+        "default_notify": true
       },
       "history": [],
       "health": {
@@ -126,6 +129,7 @@ python3 -m manga_watch.check manga_watch/watchlist.json
 - source fetch は `MANGA_WATCH_HTTP_WORKERS` 本で並列実行できるが、state 更新順・`updates`・`errors.sources` は watchlist 入力順で deterministic に固定する
 - `latest_key` が変わったときだけ `updates` に積む
 - `latest_key` が同じで `seriesTitle` / `episodeTitle` / `pageTitle` / 補足 metadata だけ改善された場合は silent merge する
+- update event と state.latest には `update_type`, `classification_reason`, `default_notify` を含める
 - source ごとの parser/runtime failure は `errors.sources` に積み、成功した作品の state 更新は継続する
 - retry 対象は transport error / timeout / HTTP `429` / `5xx` に限定する
 - HTTP `404`、unsupported URL、parse error は即失敗として `errors.sources` に積む
@@ -185,6 +189,17 @@ python3 -m manga_watch.runner
 - `MANGA_WATCH_HTTP_RETRY_BACKOFF`
 - `MANGA_WATCH_HTTP_WORKERS`
 - `MANGA_WATCH_HTTP_WORKERS_PER_HOST`
+
+### Default notification behavior
+
+- `main_story`: 既定通知対象
+- `unknown`: fail-open で既定通知対象
+- `bonus`: 既定抑制対象
+- `announcement`: 既定抑制対象
+- `main_story` と suppress 対象が衝突した場合は `unknown` に倒す
+- `bonus` と `announcement` だけが衝突した場合は suppress 側に残す
+- runner の main channel 通知は既定通知対象だけを送る
+- suppressed update も state と run report には残し、run report には `既定通知対象件数` と `既定抑制件数` を含める
 
 ## Reader / Writer compatibility matrix
 
@@ -258,7 +273,7 @@ python3 -m manga_watch.migrate_v2 \
 migrated sample data に対して最低限これを通す:
 
 ```bash
-python3 -m unittest tests.test_sources tests.test_check tests.test_runner tests.test_migrate_v2
+python3 -m unittest tests.test_sources tests.test_update_classification tests.test_check tests.test_runner tests.test_migrate_v2
 ```
 
 この suite で次を確認できることを cutover 条件にする。

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -352,6 +352,9 @@ class CheckTests(unittest.TestCase):
             "seriesTitle": "作品A",
             "episodeTitle": "第2話",
             "url": "https://example.com/work/2",
+            "update_type": "main_story",
+            "classification_reason": "episode_title matched main-story numbering",
+            "default_notify": True,
         }
 
         next_entry, update = check.apply_item_transition(
@@ -368,6 +371,9 @@ class CheckTests(unittest.TestCase):
                 "id": "work-1",
                 "from": latest_storage_to_runtime(previous["latest"]),
                 "to": latest,
+                "update_type": "main_story",
+                "classification_reason": "episode_title matched main-story numbering",
+                "default_notify": True,
             },
             update,
         )
@@ -383,6 +389,9 @@ class CheckTests(unittest.TestCase):
                 "page_title": "",
                 "url": "https://example.com/work/1",
                 "summary": "",
+                "update_type": "unknown",
+                "classification_reason": "missing episode title",
+                "default_notify": True,
             },
             "history": [],
             "health": {
@@ -400,6 +409,9 @@ class CheckTests(unittest.TestCase):
             "pageTitle": "作品A 第1話",
             "url": "https://example.com/work/1?ref=canonical",
             "summary": "補足",
+            "update_type": "main_story",
+            "classification_reason": "episode_title matched main-story numbering",
+            "default_notify": True,
         }
 
         next_entry, update = check.apply_item_transition(
@@ -416,6 +428,12 @@ class CheckTests(unittest.TestCase):
         self.assertEqual("作品A 第1話", runtime_latest["pageTitle"])
         self.assertEqual("補足", runtime_latest["summary"])
         self.assertEqual("https://example.com/work/1", runtime_latest["url"])
+        self.assertEqual("main_story", runtime_latest["update_type"])
+        self.assertEqual(
+            "episode_title matched main-story numbering",
+            runtime_latest["classification_reason"],
+        )
+        self.assertTrue(runtime_latest["default_notify"])
         self.assertEqual(20, next_entry["health"]["last_checked_at"])
 
     def test_error_records_distinguish_source_parse_and_run_failures(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -76,6 +76,8 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(1, len(messenger.messages))
         self.assertEqual("report", messenger.messages[0][0])
         self.assertIn("通知: 送信なし", messenger.messages[0][1])
+        self.assertIn("既定通知対象: 0件", messenger.messages[0][1])
+        self.assertIn("既定抑制: 0件", messenger.messages[0][1])
         self.assertIn("エラー: 0件", messenger.messages[0][1])
         self.assertIn("作品A：第1話", messenger.messages[0][1])
 
@@ -89,6 +91,9 @@ class RunnerTests(unittest.TestCase):
                     "series_title": "作品A",
                     "episode_title": "第2話",
                     "url": "https://example.com/2",
+                    "update_type": "main_story",
+                    "classification_reason": "episode_title matched main-story numbering",
+                    "default_notify": True,
                 },
             }
         ]
@@ -119,8 +124,119 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("main", messenger.messages[0][0])
         self.assertIn("作品A：第1話 → 第2話", messenger.messages[0][1])
         self.assertEqual("report", messenger.messages[1][0])
+        self.assertIn("既定通知対象: 1件", messenger.messages[1][1])
+        self.assertIn("既定抑制: 0件", messenger.messages[1][1])
         self.assertIn("通知: 送信した", messenger.messages[1][1])
         self.assertIn("エラー: 0件", messenger.messages[1][1])
+
+    def test_run_once_suppresses_bonus_updates_from_main_channel_but_reports_them(self):
+        messenger = FakeMessenger()
+        updates = [
+            {
+                "id": "work-1",
+                "from": {
+                    "seriesTitle": "作品A",
+                    "episodeTitle": "第1話",
+                    "update_type": "main_story",
+                },
+                "to": {
+                    "seriesTitle": "作品A",
+                    "episodeTitle": "番外編",
+                    "url": "https://example.com/bonus",
+                    "update_type": "bonus",
+                    "classification_reason": "episode_title matched bonus marker",
+                    "default_notify": False,
+                },
+                "update_type": "bonus",
+                "classification_reason": "episode_title matched bonus marker",
+                "default_notify": False,
+            }
+        ]
+        state = {
+            "works": {
+                "work-1": {
+                    "latest": {
+                        "series_title": "作品A",
+                        "episode_title": "番外編",
+                        "update_type": "bonus",
+                    },
+                    "history": [],
+                    "health": {
+                        "last_checked_at": 1_700_000_000,
+                        "last_success_at": 1_700_000_000,
+                        "consecutive_failures": 0,
+                    },
+                }
+            }
+        }
+
+        outcome = run_once(
+            self.make_config(),
+            messenger=messenger,
+            checker=lambda _: {"updates": updates},
+            state_loader=lambda: state,
+            now_fn=lambda: 1_700_000_000,
+        )
+
+        self.assertTrue(outcome["ok"])
+        self.assertEqual(0, outcome["errorCount"])
+        self.assertEqual(1, len(messenger.messages))
+        self.assertEqual("report", messenger.messages[0][0])
+        self.assertIn("更新検知: 1件", messenger.messages[0][1])
+        self.assertIn("既定通知対象: 0件", messenger.messages[0][1])
+        self.assertIn("既定抑制: 1件", messenger.messages[0][1])
+        self.assertIn("通知: 送信なし", messenger.messages[0][1])
+
+    def test_run_once_unknown_updates_fail_open_to_main_channel(self):
+        messenger = FakeMessenger()
+        updates = [
+            {
+                "id": "work-1",
+                "from": {"seriesTitle": "作品A", "episodeTitle": "第1話"},
+                "to": {
+                    "seriesTitle": "作品A",
+                    "episodeTitle": "春の特別掲載",
+                    "url": "https://example.com/unknown",
+                    "update_type": "unknown",
+                    "classification_reason": "matched both story and bonus markers",
+                    "default_notify": True,
+                },
+                "update_type": "unknown",
+                "classification_reason": "matched both story and bonus markers",
+                "default_notify": True,
+            }
+        ]
+        state = {
+            "works": {
+                "work-1": {
+                    "latest": {
+                        "series_title": "作品A",
+                        "episode_title": "春の特別掲載",
+                        "update_type": "unknown",
+                    },
+                    "history": [],
+                    "health": {
+                        "last_checked_at": 1_700_000_000,
+                        "last_success_at": 1_700_000_000,
+                        "consecutive_failures": 0,
+                    },
+                }
+            }
+        }
+
+        outcome = run_once(
+            self.make_config(),
+            messenger=messenger,
+            checker=lambda _: {"updates": updates},
+            state_loader=lambda: state,
+            now_fn=lambda: 1_700_000_000,
+        )
+
+        self.assertTrue(outcome["ok"])
+        self.assertEqual("main", messenger.messages[0][0])
+        self.assertIn("[unknown]", messenger.messages[0][1])
+        self.assertIn("判定理由: matched both story and bonus markers", messenger.messages[0][1])
+        self.assertEqual("report", messenger.messages[1][0])
 
     def test_run_once_marks_source_errors_as_degraded_while_still_sending_updates(self):
         messenger = FakeMessenger()
@@ -183,6 +299,8 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("main", messenger.messages[0][0])
         self.assertEqual("report", messenger.messages[1][0])
         self.assertIn("巡回実行に一部失敗がありました", messenger.messages[1][1])
+        self.assertIn("既定通知対象: 1件", messenger.messages[1][1])
+        self.assertIn("既定抑制: 0件", messenger.messages[1][1])
         self.assertIn("エラー: 1件", messenger.messages[1][1])
         self.assertIn("source/parse [fetch_latest] work-2: parse failed", messenger.messages[1][1])
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -39,6 +39,25 @@ ERROR_TYPES = {
     "SourceParseError": SourceParseError,
     "RuntimeError": RuntimeError,
 }
+EXPECTED_LATEST_CLASSIFICATIONS = {
+    "comic-walker": {
+        "normal": "main_story",
+        "title_variation_or_bonus": "bonus",
+        "same_episode_refresh": "main_story",
+    },
+    "kakuyomu": {
+        "normal": "main_story",
+        "title_variation_or_bonus": "bonus",
+        "same_episode_refresh": "main_story",
+    },
+    "comic-action": {
+        "normal": "main_story",
+        "title_variation": "bonus",
+        "escaped_next_uri": "main_story",
+        "broken_missing_next": "main_story",
+        "broken_loop": "main_story",
+    },
+}
 
 
 class FixtureHttpClient:
@@ -112,7 +131,21 @@ class SourceAdapterTests(unittest.TestCase):
                         adapter.fetch_latest(work, client)
                 else:
                     latest = adapter.fetch_latest(work, client)
-                    self.assertEqual(manifest["expectedLatest"], latest.to_dict())
+                    latest_dict = latest.to_dict()
+                    expected_latest = manifest["expectedLatest"]
+                    self.assertEqual(
+                        expected_latest,
+                        {key: latest_dict[key] for key in expected_latest},
+                    )
+                    self.assertEqual(
+                        EXPECTED_LATEST_CLASSIFICATIONS[source][case_name],
+                        latest_dict["update_type"],
+                    )
+                    self.assertTrue(latest_dict["classification_reason"])
+                    self.assertEqual(
+                        latest_dict["update_type"] in {"main_story", "unknown"},
+                        latest_dict["default_notify"],
+                    )
 
                 client.assert_consumed()
 

--- a/tests/test_update_classification.py
+++ b/tests/test_update_classification.py
@@ -1,0 +1,94 @@
+import unittest
+
+from manga_watch.sources.base import LatestEpisode
+from manga_watch.update_classification import (
+    ANNOUNCEMENT,
+    BONUS,
+    UNKNOWN,
+    classify_update,
+)
+
+
+class UpdateClassificationTests(unittest.TestCase):
+    def test_source_specific_announcement_examples(self):
+        cases = (
+            (
+                "comic-walker",
+                "更新のお知らせ",
+                "【更新のお知らせ】作品A｜カドコミ (コミックウォーカー)",
+            ),
+            (
+                "comic-action",
+                "休載のお知らせ",
+                "休載のお知らせ / 作品B - webアクション | comic-action",
+            ),
+            (
+                "kakuyomu",
+                "次回更新のお知らせ",
+                "次回更新のお知らせ - 作品C - カクヨム",
+            ),
+        )
+        for source, episode_title, page_title in cases:
+            with self.subTest(source=source):
+                decision = classify_update(
+                    episode_title=episode_title,
+                    page_title=page_title,
+                )
+                self.assertEqual(ANNOUNCEMENT, decision.update_type)
+                self.assertIn("announcement", decision.classification_reason)
+                self.assertFalse(decision.default_notify)
+
+    def test_conflicting_main_story_and_bonus_signals_fail_open(self):
+        decision = classify_update(
+            episode_title="第12話 番外編",
+            page_title="第12話 番外編 - 作品C - カクヨム",
+        )
+
+        self.assertEqual(UNKNOWN, decision.update_type)
+        self.assertIn("main-story markers", decision.classification_reason)
+        self.assertIn("bonus markers", decision.classification_reason)
+        self.assertTrue(decision.default_notify)
+
+    def test_bonus_and_announcement_conflicts_stay_suppressed(self):
+        decision = classify_update(
+            episode_title="番外編のお知らせ",
+            page_title="番外編のお知らせ - 作品C - カクヨム",
+        )
+
+        self.assertEqual(ANNOUNCEMENT, decision.update_type)
+        self.assertIn("bonus markers", decision.classification_reason)
+        self.assertIn("announcement markers", decision.classification_reason)
+        self.assertIn("kept suppressed as announcement", decision.classification_reason)
+        self.assertFalse(decision.default_notify)
+
+    def test_latest_episode_to_dict_includes_classification_fields(self):
+        latest = LatestEpisode(
+            source="comic-action",
+            work_id="https://comic-action.com/episode/333",
+            latest_key="https://comic-action.com/episode/333",
+            url="https://comic-action.com/episode/333",
+            series_title="作品B",
+            episode_title="番外編",
+            page_title="番外編 / 作品B - 著者名 | comic-action",
+        )
+
+        payload = latest.to_dict()
+
+        self.assertEqual(BONUS, payload["update_type"])
+        self.assertIn("classification_reason", payload)
+        self.assertTrue(payload["classification_reason"])
+        self.assertFalse(payload["default_notify"])
+
+    def test_unknown_without_strong_signal(self):
+        decision = classify_update(
+            episode_title="最新エピソード",
+            page_title="最新エピソード｜作品A",
+        )
+
+        self.assertEqual(UNKNOWN, decision.update_type)
+        self.assertEqual("no classification markers matched", decision.classification_reason)
+        self.assertTrue(decision.default_notify)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue
- Closes #12

## What Changed
- added shared update classification logic that emits `update_type`, `classification_reason`, and `default_notify` on latest payloads
- propagated classification metadata into checker update events and silent state merges
- changed runner default notification behavior to notify only `main_story` and `unknown`, while keeping suppressed updates visible in run reports
- added source-specific classification tests, ambiguous fail-open coverage, and docs for the new output contract

## Verification
- `.venv/bin/python -m unittest discover -s tests`

## Residual Risks
- classification is still title-heuristic based, so uncommon labels will fall back to `unknown` until more representative fixtures are added