### PR TITLE
feat: add merger gate skill

### DIFF
--- a/.agents/skills/gh-issue-maker-chief-engineer-loop/SKILL.md
+++ b/.agents/skills/gh-issue-maker-chief-engineer-loop/SKILL.md
@@ -5,22 +5,23 @@ description: >
   Codex で回す専用ループ。指定 Issue から accepted scope と制約を抽出し、
   独立した作業単位ごとに `maker` エージェントを必要に応じて並列起動して実装し、
   親セッションで統合して PR を作成または更新し、その PR を
-  `$spacex-chief-reviewer` でレビューする。reviewer が NG を返したら指摘を
-  次の maker work packet に落として再実装し、承認されるまで繰り返す。Use when:
+  `$spacex-chief-reviewer` でレビューし、最後に `$merger` で merge まで進める。
+  reviewer または merger が NG を返したら指摘を次の maker work packet に落として
+  再実装し、マージされるまで繰り返す。Use when:
   GitHub Issue URL/番号だけを渡して作業を開始したいとき、Issue に既存の Chief
-  Engineer レビューがあるとき、実装から PR 更新と `$spacex-chief-reviewer`
-  による再レビューまでを標準ループで自動的に進めたいとき。
+  Engineer レビューがあるとき、実装から PR 更新、`$spacex-chief-reviewer`
+  による再レビュー、`$merger` による merge までを標準ループで自動的に進めたいとき。
 ---
 
-# GitHub Issue Maker / Chief Reviewer Loop
+# GitHub Issue Maker / Chief Reviewer / Merger Loop
 
 ## Overview
 
-`codex-mission-control` の派生版として、Issue 起点の実装ループだけに責務を絞る。親セッションが Mission Planner と Mission Control を兼務し、実装は原則 `maker` が担い、PR gate は `$spacex-chief-reviewer` が担う。
+`codex-mission-control` の派生版として、Issue 起点の実装ループだけに責務を絞る。親セッションが Mission Planner と Mission Control を兼務し、実装は原則 `maker` が担い、PR gate は `$spacex-chief-reviewer` と `$merger` が担う。
 
-Issue に既存の Chief Engineer レビューがある前提で始め、`maker` が実装し、親セッションが結果を統合して PR を作成または更新し、その PR を `$spacex-chief-reviewer` が gate として判定する。reviewer が `NG` を返した場合は、その指摘を次 cycle の maker packet に変換して再実装する。
+Issue に既存の Chief Engineer レビューがある前提で始め、`maker` が実装し、親セッションが結果を統合して PR を作成または更新し、その PR を `$spacex-chief-reviewer` が review gate として判定し、`$merger` が merge gate と実マージを担当する。reviewer または merger が `NG` を返した場合は、その指摘を次 cycle の maker packet に変換して再実装または PR 状態の修正を行う。
 
-この loop でいう `APPROVE` / `NG` gate は、**親セッションや maker と別 agent の context で reviewer が判定したときだけ有効**とする。親セッションが reviewer 手順を自己適用して得た結論は、evidence 整理や事前点検には使えても gate 完了には数えない。
+この loop でいう review / merge gate は、**親セッションや maker と別 agent の context で reviewer / merger が判定したときだけ有効**とする。親セッションが reviewer や merger の手順を自己適用して得た結論は、evidence 整理や事前点検には使えても gate 完了には数えない。
 
 この skill は、呼び出し時に進め方を毎回指定しなくてよい。Issue を指定されたら、この標準ループをデフォルト動作として実行する。
 
@@ -50,7 +51,9 @@ Issue に既存の Chief Engineer レビューがある前提で始め、`maker`
 - maker の成果を統合し、必要な verification を走らせる。
 - 統合した変更から PR を作成または既存 PR を更新する。
 - `$spacex-chief-reviewer` を**別 agent**として起動し、PR review packet を渡し、`APPROVE` か `NG` を受け取る。
-- reviewer の `NG` を、次 cycle の maker packet に変換する。
+- reviewer に、chat 上の判定だけでなく PR 上へ `$spacex-chief-reviewer` 署名付きの gate comment を残させる。
+- reviewer `APPROVE` 後に `$merger` を**別 agent**として起動し、merge gate と実マージを委譲する。
+- reviewer または merger の `NG` を、次 cycle の maker packet または PR hygiene 作業に変換する。
 
 `explorer` や `telemetry` は常用しない。対象ファイルが広すぎて file mapping ができない場合だけ `explorer` を補助的に使い、検証が複雑で maker の自己検証だけでは不十分な場合だけ `telemetry` を追加する。
 
@@ -124,8 +127,10 @@ PR の扱いは次を原則とする。
 - reviewer agent には `fork_context=false` を優先し、親セッションの実装 reasoning を丸ごと渡さず、PR URL、統合後の diff, changed files, test evidence, known gaps など review に必要な最小限の packet だけを渡す。
 - reviewer は計画ではなく、PR 上の実装済み差分をレビューする。
 - reviewer は `spacex-chief-reviewer` の標準フローで review を行い、`APPROVE` か `NG` を返す。
+- reviewer には、chat 上の判定に加えて PR 上へ gate comment を残すことを明示的に要求する。comment には literal な `$spacex-chief-reviewer` と、最終行の `APPROVE` または `NG` を含めさせる。
 - 曖昧な「ほぼよい」「条件付きでよい」は `NG` として扱い、再作業項目へ落とす。
 - 親セッションが reviewer skill を自分でなぞっても、それは gate ではなく preflight review に留まる。**別 agent の判定が返るまで cycle は完了しない。**
+- reviewer が chat では `APPROVE` を返しても、PR comment を残していなければ merge gate に進めてはいけない。
 
 reviewer への packet には次を含める。
 
@@ -136,6 +141,7 @@ reviewer への packet には次を含める。
 - 検証結果
 - 既知の未解決事項
 - 今回求める gate 判定
+- PR に残すべき gate comment 形式
 
 別 agent reviewer を起動できない場合:
 
@@ -143,19 +149,47 @@ reviewer への packet には次を含める。
 - ただし `APPROVE` 扱いで完了してはいけない。
 - 状態は `reviewer gate pending` または `degraded: reviewer unavailable` として止める。
 
-### 6. `NG` なら 2 に戻る
+### 6. `APPROVE` 後に `$merger` を実行する
 
-- reviewer の `NG` を論点ごとに分解する。
-- 各論点を、次 cycle の maker packet に落とし込む。
+- 親セッションは reviewer の PR comment を確認したあと、`$merger` を**別 agent / 別 thread**として起動する。
+- merger agent には PR URL と、chief reviewer が残した gate comment が prerequisite であることを渡す。
+- merger は次を確認する。
+  - PR 上に `$spacex-chief-reviewer` の `APPROVE` comment がある
+  - PR の review thread がすべて resolved である
+- merger は条件を満たさない、または確認不能な場合、PR に `Merge NG` コメントを残して `NG` を返す。
+- merger は条件を満たした場合だけ `gh pr merge --merge --delete-branch` で merge する。
+- 親セッションや reviewer が merger の手順を自己適用しても、それは merge gate ではない。
+
+merger への packet には次を含める。
+
+- PR URL
+- chief reviewer comment の期待形式
+- merge に使う strategy (`--merge`)
+- unresolved review thread は blocker であること
+- 今回求める merge gate 判定
+
+別 agent merger を起動できない場合:
+
+- 親セッションは reviewer gate 完了までは進めてよい。
+- ただし merge 完了扱いにしてはいけない。
+- 状態は `merger gate pending` または `degraded: merger unavailable` として止める。
+
+### 7. reviewer または merger が `NG` なら戻る
+
+- reviewer / merger の `NG` を論点ごとに分解する。
+- コード修正が必要な論点は、次 cycle の maker packet に落とし込む。
+- review thread resolve や reviewer comment 追記のような PR hygiene だけが不足している場合は、親セッションがその不足を解消して 5 または 6 に戻ってよい。
 - scope creep を防ぐため、Issue の外に広がった rework は切り離す。
 - PR は閉じず、同じ PR を更新し続けることを基本とする。
 - 同じ理由で 2 cycle 連続 `NG` になったら、packet の切り方か設計前提が悪い可能性が高い。親セッションが loop を止め、Issue Brief を再構成する。
 
-### 7. `APPROVE` で完了する
+### 8. merge 完了で終了する
 
 次をすべて満たしたときだけ完了とする。
 
 - **別 agent として起動された** `$spacex-chief-reviewer` が `APPROVE` を返した。
+- その reviewer が、PR 上へ `$spacex-chief-reviewer` 署名付きの `APPROVE` comment を残している。
+- **別 agent として起動された** `$merger` が merge 条件を確認し、PR を実際にマージした。
 - 対応 PR が作成済みまたは最新状態に更新済みである。
 - Issue の acceptance criteria が evidence 付きで満たされている。
 - main regression risk と test gaps が明示されている。
@@ -171,6 +205,9 @@ gh api repos/<owner>/<repo>/issues/<number>/comments --paginate
 gh pr view <pr>
 gh pr create
 gh pr edit <pr>
+gh pr comment <pr>
+gh pr merge <pr> --merge --delete-branch
+gh api graphql -f query='... reviewThreads ...'
 rg --files
 rg <pattern>
 ```
@@ -182,7 +219,7 @@ rg <pattern>
 - maker が走らせる確認は、broad なフルテストより、packet に紐づく focused check を優先する。
 - PR 操作は親セッションが行う。maker に PR 作成や更新を任せない。
 - `$spacex-chief-reviewer` review 前に、親セッションが最低限の integration check を行う。
-- reviewer gate は親セッションではなく、別 agent 起動で実行する。
+- reviewer gate と merger gate は親セッションではなく、別 agent 起動で実行する。
 
 ## Guardrails
 
@@ -192,6 +229,8 @@ rg <pattern>
 - maker が返した「done」を鵜呑みにせず、親セッションが evidence を確認する。
 - PR は parent-owned artifact として扱い、子エージェントに ownership を分散しない。
 - PR gate は必ず `$spacex-chief-reviewer` を通し、review は実コードと検証結果に対して行い、口頭の説明だけで通さない。
+- reviewer の chat 上の `APPROVE` だけを根拠に merge してはいけない。PR 上の `$spacex-chief-reviewer` comment が必要。
+- merge は必ず `$merger` を通し、unresolved review thread が 1 件でも残っている状態で進めてはいけない。
 - 親セッションの自己レビューや reviewer checklist の自己適用を、`APPROVE` / `NG` gate とみなしてはいけない。
-- reviewer gate は必ず実装 agent と別 context で行い、別 agent を起動できない場合は completion ではなく pending / degraded として止める。
+- reviewer gate と merger gate は必ず実装 agent と別 context で行い、別 agent を起動できない場合は completion ではなく pending / degraded として止める。
 - この skill は「Issue 起点の実装 loop」に特化している。探索が主目的なら `$codex-mission-control` に戻る。

--- a/.agents/skills/merger/SKILL.md
+++ b/.agents/skills/merger/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: merger
+description: >
+  comic_crawler 用の PR merger gate。PR 上に `$spacex-chief-reviewer` の
+  `APPROVE` コメントが残っていることと、全 review thread が resolved であることを
+  確認し、両方を満たせば merge commit で PR をマージする。確認不能または未充足なら
+  `Merge NG` として理由を PR にコメントする。Use when: comic_crawler の PR を
+  最終ゲートで確認し、条件を満たすときだけ安全にマージしたいとき。
+---
+
+# Merger
+
+## Overview
+
+この skill は merge 実行専用の最終 gate であり、「レビュー済みか」ではなく「repo が要求する merge 前提が PR 上で確認できるか」を判定する。
+
+この repo で merge してよいのは、少なくとも次を両方確認できた場合だけとする。
+
+- PR 上に `$spacex-chief-reviewer` の `APPROVE` コメントがある
+- PR の review thread がすべて resolved である
+
+どちらか一方でも未充足、または API 取得失敗などで確認不能なら merge してはいけない。その場合は `Merge NG` として理由を PR にコメントし、そこで止める。
+
+## Invocation Contract
+
+最小入力は PR 指定だけでよい。
+
+- `Use $merger on <owner/repo#number>`
+- `$merger を使って <PR URL> を確認して、条件を満たすならマージして`
+
+この skill は条件確認と merge 実行を内包しているので、追加の手順指定がなくてもこの標準フローで動く。
+
+## Required Evidence
+
+### Chief Reviewer approval comment
+
+Chief Reviewer の承認は、PR 上に残ったコメントとして確認できなければならない。Merger は次を満たす最新の comment / review を approval evidence として扱う。
+
+- body に literal な `$spacex-chief-reviewer` が含まれる
+- body の最終判断として `APPROVE` または `NG` が明示されている
+
+複数ある場合は、時刻順で最も新しい decisive なものを採用する。最新が `NG` なら merge 不可。`APPROVE` が chat 上にしか無い、または PR 上の comment に残っていない場合も merge 不可。
+
+### Resolved review threads
+
+review comment の解決状態は GitHub GraphQL の `reviewThreads` で確認する。1 件でも `isResolved=false` が残っていたら merge 不可。人間・bot を問わず unresolved thread は blocker として扱う。
+
+GraphQL 取得に失敗した場合や、pagination 上限のせいで全件確認できない場合も `確認不能` として merge 不可にする。
+
+## Workflow
+
+### 1. PR を特定して一次情報を集める
+
+- PR URL または `owner/repo#number` を正規化する。
+- `gh pr view` で `state`, `url`, `comments`, `reviews`, `headRefName`, `baseRefName` を取得する。
+- GraphQL で `reviewThreads` を取得する。
+- 必要なら issue comment と review body を追加で読む。
+
+優先するコマンド:
+
+```bash
+gh pr view <pr> --json number,url,state,headRefName,baseRefName,comments,reviews
+gh api graphql -f query='... reviewThreads ...'
+```
+
+### 2. Chief Reviewer approval evidence を判定する
+
+- issue comments と reviews の両方から `$spacex-chief-reviewer` を含む decisive なものを探す。
+- 最新の decisive item が `APPROVE` なら pass。
+- 見つからない、最新が `NG`、コメント形式が曖昧、author や本文から chief reviewer comment と断定できない場合は fail。
+
+### 3. review thread 解決状態を判定する
+
+- `reviewThreads.nodes[*].isResolved` を確認する。
+- 1 件でも unresolved があれば fail。
+- thread 数が多すぎて全件を確認できない場合や API エラー時も fail。
+
+### 4. 条件を満たさない場合は `Merge NG` を PR にコメントする
+
+- `gh pr comment` で理由を PR に残す。
+- コメントには少なくとも次を含める。
+
+```markdown
+## Merge NG
+- Chief Reviewer approval comment: ok | missing | latest decision is NG | unconfirmed
+- Review threads: all resolved | unresolved (<count>) | unconfirmed
+- Reason: ...
+- Next action: ...
+```
+
+- 既存の unresolved thread を勝手に resolve してはならない。
+- 同じ理由で直近に自分の `Merge NG` コメントがある場合は重複投稿を避ける。
+
+### 5. 条件を満たす場合だけマージする
+
+- `gh pr merge --merge --delete-branch` を使う。
+- merge 実行前に PR が `OPEN` であることを確認する。
+- merge コマンドが失敗した場合は、その失敗理由を `Merge NG` として PR にコメントして止める。
+
+この repo では merge commit を使う。
+
+## Result Contract
+
+結果は次のいずれかで返す。
+
+```markdown
+## Merge Result
+- MERGED
+- PR: ...
+- Evidence:
+  - Chief Reviewer comment: ...
+  - Review threads: all resolved
+```
+
+または
+
+```markdown
+## Merge Result
+- NG
+- Reason: ...
+- PR comment posted: yes | no
+```
+
+## Guardrails
+
+- chat 上の reviewer `APPROVE` を、PR comment の代わりに使ってはいけない。
+- `$spacex-chief-reviewer` comment の本文に decisive な `APPROVE` / `NG` が無ければ approval evidence とみなしてはいけない。
+- unresolved review thread を無視して merge してはいけない。
+- merge は必ず `--merge` を使い、`--squash` / `--rebase` を使わない。
+- 前提確認に失敗したのに「たぶん大丈夫」で merge してはいけない。

--- a/.agents/skills/spacex-chief-reviewer/SKILL.md
+++ b/.agents/skills/spacex-chief-reviewer/SKILL.md
@@ -118,7 +118,13 @@ repo 固有の review 観点は [references/repo-review-focus.md](references/rep
 - ...
 ```
 
-GitHub に approve を実際に投稿するのは user が明示的に求めたときだけにする。デフォルトは chat 上での gate judgement に留める。
+GitHub に reviewer 結果を実際に投稿するのは、user または親 workflow が明示的に求めたときだけにする。デフォルトは chat 上での gate judgement に留める。
+
+`$merger` の前提として PR comment が必要な workflow で呼ばれた場合は、chat 応答に加えて `gh pr comment` で同じ判定を PR に残す。その comment には少なくとも次を含める。
+
+- literal な `$spacex-chief-reviewer`
+- skill の標準フォーマット
+- 最終行の `APPROVE` または `NG`
 
 ## Guardrails
 
@@ -129,3 +135,4 @@ GitHub に approve を実際に投稿するのは user が明示的に求めた�
 - unrelated な既存問題を広げすぎない。ただし今回の変更で悪化するなら blocker として扱う。
 - `NG` を出すときは veto として扱い、approve に向かう最短の代替案を返す。
 - 「理屈は通るが、この repo では運用上つらい」「局所的には直ったが全体として無理がある」も reviewer の正当な `NG` になりうる。
+- PR comment posting を求められた場合は、chat 上の判定と PR 上の判定を食い違わせてはいけない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ This repository has Codex project-local skills under `./.agents/skills`. Treat t
 
 ### Available skills
 
-- gh-issue-maker-chief-engineer-loop: GitHub Issue を起点に、accepted scope と制約を抽出し、`maker` 実装、PR 更新、`$spacex-chief-reviewer` による gate までを標準ループで進める。Use when: Issue URL/番号だけで作業を開始したいとき、Issue に既存の Chief Engineer レビューがあるとき。 (file: ./.agents/skills/gh-issue-maker-chief-engineer-loop/SKILL.md)
+- gh-issue-maker-chief-engineer-loop: GitHub Issue を起点に、accepted scope と制約を抽出し、`maker` 実装、PR 更新、`$spacex-chief-reviewer` による gate、`$merger` による merge gate までを標準ループで進める。Use when: Issue URL/番号だけで作業を開始したいとき、Issue に既存の Chief Engineer レビューがあるとき。 (file: ./.agents/skills/gh-issue-maker-chief-engineer-loop/SKILL.md)
 - gh-pr-spacex-chief-engineer-review: GitHub の指定 PR を Chief Engineer 観点でレビューし、Description と実装の整合、過去指摘の解消状況まで確認する。Use when: PR URL/番号を渡してマージ前レビューをしたいとき。 (file: ./.agents/skills/gh-pr-spacex-chief-engineer-review/SKILL.md)
+- merger: comic_crawler 用の最終 merge gate。`$spacex-chief-reviewer` の `APPROVE` コメントと全 review thread resolved を確認し、満たすときだけ merge する。Use when: comic_crawler の PR を条件付きで自動マージしたいとき。 (file: ./.agents/skills/merger/SKILL.md)
 - spacex-chief-reviewer: comic_crawler 専用の reviewer gate。repo の規模と既存構造に対して変更が merge-ready かを `APPROVE` / `NG` で判定する。Use when: comic_crawler の PR を repo 固有の観点でレビューしたいとき。 (file: ./.agents/skills/spacex-chief-reviewer/SKILL.md)
 
 ### How to use skills


### PR DESCRIPTION
## Summary
- update the repo-local `$merger` skill so merge now requires three conditions: a `$spacex-chief-reviewer` `APPROVE` comment, all review threads resolved, and every PR `Residual Risks` item issueized and linked to the parent issue as a sub-issue
- update `$gh-issue-maker-chief-engineer-loop` so the standard workflow requires residual risks to be turned into follow-up issues, reflected in the PR body, and passed into the merger gate as merge blockers
- refresh `AGENTS.md` discovery text to match the stronger merger gate

## Verification
- Not run (skill / workflow documentation changes only)
