### PR TITLE
Issue #16: evaluate notification policy per work

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ checker の出力契約は JSON のままです。
       "update_type": "main_story",
       "classification_reason": "episode_title matched main-story numbering",
       "default_notify": true,
+      "notification": {
+        "mode": "important_only",
+        "allowed_update_types": null,
+        "should_notify": true,
+        "applied_via": "mode",
+        "reason": "mode=important_only allows main_story"
+      },
       "from": {"seriesTitle": "...", "episodeTitle": "..."},
       "to": {
         "seriesTitle": "...",
@@ -115,7 +122,16 @@ python3 -m manga_watch.backlog --mark-read KC_003913_S
 - `bonus`: 既定では notifier backend に通知しない
 - `announcement`: 既定では notifier backend に通知しない
 
-`main_story` と suppress 対象が衝突した場合は `unknown` に倒し、`bonus` と `announcement` だけが衝突した場合は suppress 側に残します。checker / state / run report には suppressed update も残ります。
+`main_story` と suppress 対象が衝突した場合は `unknown` に倒し、`bonus` と `announcement` だけが衝突した場合は suppress 側に残します。
+
+watchlist の `notification_policy` は classification default の上に適用されます。
+
+- `allowed_update_types` が `null` でないときは mode より優先する
+- `mode=all`: `default_notify` を無視して全 `update_type` を通知する
+- `mode=important_only`: `main_story` と `unknown` だけを通知する
+- `mode=mute`: どの `update_type` も通知しない
+
+checker / state / run report には suppressed update も残ります。machine-readable な checker 出力では `updates[].notification.should_notify=false` で「更新はあったが通知しない」を区別できます。
 
 ## Notification events
 
@@ -130,6 +146,13 @@ runner が backend に送る update event は次の schema です。
   "series_title": "蜘蛛ですが、なにか？",
   "update_type": "main_story",
   "detected_at": "2026-03-08T08:00:00Z",
+  "notification": {
+    "mode": "important_only",
+    "allowed_update_types": null,
+    "should_notify": true,
+    "applied_via": "mode",
+    "reason": "mode=important_only allows main_story"
+  },
   "from": {
     "latest_key": "KC_0039130008800011_E",
     "series_title": "蜘蛛ですが、なにか？",
@@ -151,6 +174,7 @@ runner が backend に送る update event は次の schema です。
 
 - `event_id` は `work_id + latest_key` を SHA-256 で固定長化した stable id です。consumer はこれで dedupe します。
 - delivery contract は consumer 視点では at-least-once 前提です。duplicate を受け取っても `event_id` で idempotent に処理してください。
+- `notification` は watchlist policy を適用した時点の effective decision です。`default_notify=false` な `bonus` update でも `mode=all` なら `should_notify=true` になります。
 - current runner は persisted outbox を持たず、backend 送信は同期 1 回です。backend failure が state 更新後に起きると manual replay が必要です。
 - `stdout` backend は 1 event = 1 JSON line を標準出力へ flush します。
 - `webhook` backend は 1 event ごとに JSON POST します。HTTP `2xx` だけを success とし、それ以外の status / timeout / transport error は failure として run を失敗扱いにします。

--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -20,6 +20,8 @@ from manga_watch.sources import (
 from manga_watch.sources.base import SourceParseError
 from manga_watch.sources.comic_action import extract_comic_action_series_id
 from manga_watch.storage import (
+    NOTIFICATION_POLICY_MODE_ALL,
+    evaluate_notification_policy,
     history_retention_for_work,
     latest_runtime_to_storage,
     latest_storage_to_runtime,
@@ -36,6 +38,10 @@ DEFAULT_RETRY_COUNT = 2
 DEFAULT_RETRY_BACKOFF = 0.5
 DEFAULT_MAX_WORKERS = 4
 DEFAULT_MAX_WORKERS_PER_HOST = 2
+DEFAULT_NOTIFICATION_POLICY = {
+    "mode": NOTIFICATION_POLICY_MODE_ALL,
+    "allowed_update_types": None,
+}
 
 
 class CheckRunError(RuntimeError):
@@ -125,6 +131,13 @@ def latest_id_for_state(latest: Mapping[str, object]) -> str:
     return str(latest.get("latestKey") or latest.get("episodeCode") or latest.get("url") or "")
 
 
+def update_type_for_latest(latest: Mapping[str, object]) -> str:
+    update_type = latest.get("update_type")
+    if isinstance(update_type, str) and update_type:
+        return update_type
+    return "unknown"
+
+
 def default_notify_for_latest(latest: Mapping[str, object]) -> Optional[bool]:
     if "default_notify" in latest and latest.get("default_notify") is not None:
         return bool(latest.get("default_notify"))
@@ -135,6 +148,20 @@ def default_notify_for_latest(latest: Mapping[str, object]) -> Optional[bool]:
     if update_type in SUPPRESSED_UPDATE_TYPES:
         return False
     return None
+
+
+def notification_metadata(
+    latest: Mapping[str, object],
+    *,
+    notification_policy: Optional[Mapping[str, object]],
+) -> Dict[str, object]:
+    effective_policy = DEFAULT_NOTIFICATION_POLICY if notification_policy is None else notification_policy
+    if not isinstance(effective_policy, Mapping):
+        raise ValueError("notification_policy must be an object")
+    return evaluate_notification_policy(
+        effective_policy,
+        update_type=update_type_for_latest(latest),
+    )
 
 
 def update_event_metadata(latest: Mapping[str, object]) -> Dict[str, object]:
@@ -237,6 +264,7 @@ def apply_item_transition(
     *,
     seen_at: int,
     history_retention: int,
+    notification_policy: Optional[Mapping[str, object]] = None,
 ) -> Tuple[Dict[str, object], Optional[Dict[str, object]]]:
     latest_copy = dict(latest)
     latest_copy.setdefault("workId", item_id)
@@ -266,6 +294,10 @@ def apply_item_transition(
             unread_event_ids.append(latest_id)
         history, unread_event_ids = trim_history(history, unread_event_ids, history_retention)
         update = {"id": item_id, "from": previous_latest, "to": latest_copy}
+        update["notification"] = notification_metadata(
+            latest_copy,
+            notification_policy=notification_policy,
+        )
         update.update(update_event_metadata(latest_copy))
         return (
             {
@@ -531,6 +563,7 @@ def run_check(
             source_result.latest or {},
             seen_at=now,
             history_retention=history_retention,
+            notification_policy=entry.get("notification_policy"),
         )
         works_state[source_result.item_id] = next_entry
         if update is not None:

--- a/manga_watch/notifier.py
+++ b/manga_watch/notifier.py
@@ -75,6 +75,45 @@ def normalize_update_snapshot(snapshot: object) -> Dict[str, object]:
     return normalized
 
 
+def normalize_notification_metadata(notification: object) -> Dict[str, object]:
+    if not isinstance(notification, Mapping):
+        return {}
+
+    normalized: Dict[str, object] = {}
+
+    mode = _coerce_text(notification.get("mode"))
+    if mode:
+        normalized["mode"] = mode
+
+    if "allowed_update_types" in notification:
+        allowed_update_types = notification.get("allowed_update_types")
+        if allowed_update_types is None:
+            normalized["allowed_update_types"] = None
+        elif isinstance(allowed_update_types, list):
+            normalized_allowed_update_types = []
+            seen_update_types = set()
+            for item in allowed_update_types:
+                normalized_update_type = _coerce_text(item)
+                if not normalized_update_type or normalized_update_type in seen_update_types:
+                    continue
+                seen_update_types.add(normalized_update_type)
+                normalized_allowed_update_types.append(normalized_update_type)
+            normalized["allowed_update_types"] = normalized_allowed_update_types
+
+    if "should_notify" in notification and notification.get("should_notify") is not None:
+        normalized["should_notify"] = bool(notification.get("should_notify"))
+
+    applied_via = _coerce_text(notification.get("applied_via"))
+    if applied_via:
+        normalized["applied_via"] = applied_via
+
+    reason = _coerce_text(notification.get("reason"))
+    if reason:
+        normalized["reason"] = reason
+
+    return normalized
+
+
 def derive_event_id(work_id: str, latest_key: str) -> str:
     digest = hashlib.sha256(f"{work_id}\n{latest_key}".encode("utf-8")).hexdigest()
     return f"{work_id}:{digest}"
@@ -94,9 +133,10 @@ class UpdateEvent:
     detected_at: str
     before: Dict[str, object]
     after: Dict[str, object]
+    notification: Dict[str, object]
 
     def as_payload(self) -> Dict[str, object]:
-        return {
+        payload = {
             "schema_version": 1,
             "event_id": self.event_id,
             "work_id": self.work_id,
@@ -107,6 +147,9 @@ class UpdateEvent:
             "from": dict(self.before),
             "to": dict(self.after),
         }
+        if self.notification:
+            payload["notification"] = dict(self.notification)
+        return payload
 
 
 def build_update_event(update: Mapping[str, object], *, detected_at: str) -> UpdateEvent:
@@ -123,6 +166,7 @@ def build_update_event(update: Mapping[str, object], *, detected_at: str) -> Upd
 
     series_title = _coerce_text(after.get("series_title") or before.get("series_title")) or work_id
     update_type = _coerce_text(update.get("update_type") or after.get("update_type")) or "unknown"
+    notification = normalize_notification_metadata(update.get("notification"))
 
     return UpdateEvent(
         event_id=derive_event_id(work_id, latest_key),
@@ -133,6 +177,7 @@ def build_update_event(update: Mapping[str, object], *, detected_at: str) -> Upd
         detected_at=detected_at,
         before=before,
         after=after,
+        notification=notification,
     )
 
 

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -57,13 +57,20 @@ def default_notify_for_event(update: Dict[str, object]) -> bool:
     return update_type_for_event(update) in DEFAULT_NOTIFY_UPDATE_TYPES
 
 
-def partition_updates_by_default_notify(
+def should_notify_for_event(update: Dict[str, object]) -> bool:
+    notification = update.get("notification")
+    if isinstance(notification, dict) and notification.get("should_notify") is not None:
+        return bool(notification.get("should_notify"))
+    return default_notify_for_event(update)
+
+
+def partition_updates_by_notification_policy(
     updates: List[Dict[str, object]],
 ) -> tuple[List[Dict[str, object]], List[Dict[str, object]]]:
     notify = []
     suppressed = []
     for update in updates:
-        if default_notify_for_event(update):
+        if should_notify_for_event(update):
             notify.append(update)
         else:
             suppressed.append(update)
@@ -134,7 +141,7 @@ def format_run_report(
     updates: List[Dict[str, object]],
     errors: Dict[str, List[Dict[str, object]]],
     state: Dict[str, object],
-    default_notify_count: int,
+    notified_update_count: int,
     suppressed_update_count: int,
     update_notification_sent: bool,
 ) -> str:
@@ -142,8 +149,8 @@ def format_run_report(
     lines = [
         f"{'巡回実行に一部失敗がありました' if degraded else '巡回実行しました'} ({timestamp})",
         f"更新検知: {len(updates)}件",
-        f"既定通知対象: {default_notify_count}件",
-        f"既定抑制: {suppressed_update_count}件",
+        f"通知対象: {notified_update_count}件",
+        f"通知抑制: {suppressed_update_count}件",
         f"通知: {'送信した' if update_notification_sent else '送信なし'}",
     ]
     lines.extend(format_checker_error_lines(errors))
@@ -230,6 +237,8 @@ def run_once(
     detected_at = detected_at_for_timestamp(now)
     update_count = 0
     error_count = 0
+    notified_update_count = 0
+    suppressed_update_count = 0
 
     try:
         result = checker(config.watchlist_path)
@@ -239,12 +248,14 @@ def run_once(
         update_count = len(updates)
         errors = normalize_checker_errors(result)
         error_count = checker_error_count(errors)
-        default_notify_updates, suppressed_updates = partition_updates_by_default_notify(updates)
+        notify_updates, suppressed_updates = partition_updates_by_notification_policy(updates)
+        notified_update_count = len(notify_updates)
+        suppressed_update_count = len(suppressed_updates)
 
         state = state_loader()
         update_notification_sent = False
         delivery_errors: List[str] = []
-        for update in default_notify_updates:
+        for update in notify_updates:
             try:
                 notifier.send(build_update_event(update, detected_at=detected_at))
                 update_notification_sent = True
@@ -260,14 +271,16 @@ def run_once(
                 updates=updates,
                 errors=errors,
                 state=state,
-                default_notify_count=len(default_notify_updates),
-                suppressed_update_count=len(suppressed_updates),
+                notified_update_count=notified_update_count,
+                suppressed_update_count=suppressed_update_count,
                 update_notification_sent=update_notification_sent,
             )
         )
         return {
             "ok": error_count == 0,
             "updateCount": update_count,
+            "notifiedUpdateCount": notified_update_count,
+            "suppressedUpdateCount": suppressed_update_count,
             "errorCount": error_count,
             "timestamp": timestamp,
         }
@@ -276,6 +289,8 @@ def run_once(
         return {
             "ok": False,
             "updateCount": update_count,
+            "notifiedUpdateCount": notified_update_count,
+            "suppressedUpdateCount": suppressed_update_count,
             "errorCount": error_count,
             "timestamp": timestamp,
             "error": f"{exc.__class__.__name__}: {exc}",

--- a/manga_watch/storage.py
+++ b/manga_watch/storage.py
@@ -3,12 +3,22 @@ import os
 import re
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
+from manga_watch.update_classification import DEFAULT_NOTIFY_UPDATE_TYPES
+
 DEFAULT_WATCHLIST_PATH = os.path.join(os.path.dirname(__file__), "watchlist.json")
 DEFAULT_STATE_PATH = os.path.join(os.path.dirname(__file__), "state.json")
 
 WATCHLIST_VERSION = 2
 STATE_VERSION = 2
 DEFAULT_HISTORY_RETENTION = 20
+NOTIFICATION_POLICY_MODE_ALL = "all"
+NOTIFICATION_POLICY_MODE_IMPORTANT_ONLY = "important_only"
+NOTIFICATION_POLICY_MODE_MUTE = "mute"
+SUPPORTED_NOTIFICATION_POLICY_MODES = {
+    NOTIFICATION_POLICY_MODE_ALL,
+    NOTIFICATION_POLICY_MODE_IMPORTANT_ONLY,
+    NOTIFICATION_POLICY_MODE_MUTE,
+}
 
 _LATEST_RUNTIME_TO_STORAGE = {
     "workId": "work_id",
@@ -146,16 +156,102 @@ def normalize_notification_policy(policy: object, work_id: str) -> Dict[str, obj
     mode = str(policy.get("mode") or "").strip()
     if not mode:
         raise ValueError(f"watchlist entry {work_id} notification_policy.mode is required")
+    if mode not in SUPPORTED_NOTIFICATION_POLICY_MODES:
+        supported_modes = ", ".join(sorted(SUPPORTED_NOTIFICATION_POLICY_MODES))
+        raise ValueError(
+            f"watchlist entry {work_id} notification_policy.mode must be one of: {supported_modes}"
+        )
     allowed_update_types = policy.get("allowed_update_types")
     if allowed_update_types is not None:
         if not isinstance(allowed_update_types, list):
             raise ValueError(
                 f"watchlist entry {work_id} notification_policy.allowed_update_types must be a list or null"
             )
-        allowed_update_types = [str(item) for item in allowed_update_types]
+        normalized_allowed_update_types: List[str] = []
+        seen_update_types = set()
+        for item in allowed_update_types:
+            normalized_update_type = str(item).strip()
+            if not normalized_update_type or normalized_update_type in seen_update_types:
+                continue
+            seen_update_types.add(normalized_update_type)
+            normalized_allowed_update_types.append(normalized_update_type)
+        allowed_update_types = normalized_allowed_update_types
     return {
         "mode": mode,
         "allowed_update_types": allowed_update_types,
+    }
+
+
+def evaluate_notification_policy(
+    policy: Mapping[str, object],
+    *,
+    update_type: object,
+) -> Dict[str, object]:
+    mode = str(policy.get("mode") or "").strip()
+    if mode not in SUPPORTED_NOTIFICATION_POLICY_MODES:
+        raise ValueError(f"unsupported notification_policy.mode: {mode or '<empty>'}")
+
+    allowed_update_types = policy.get("allowed_update_types")
+    normalized_allowed_update_types: Optional[List[str]]
+    if allowed_update_types is None:
+        normalized_allowed_update_types = None
+    else:
+        if not isinstance(allowed_update_types, list):
+            raise ValueError("notification_policy.allowed_update_types must be a list or null")
+        normalized_allowed_update_types = []
+        seen_update_types = set()
+        for item in allowed_update_types:
+            normalized_update_type = str(item).strip()
+            if not normalized_update_type or normalized_update_type in seen_update_types:
+                continue
+            seen_update_types.add(normalized_update_type)
+            normalized_allowed_update_types.append(normalized_update_type)
+
+    normalized_update_type = str(update_type or "").strip() or "unknown"
+    if normalized_allowed_update_types is not None:
+        should_notify = normalized_update_type in normalized_allowed_update_types
+        reason = (
+            f"allowed_update_types override matched {normalized_update_type}"
+            if should_notify
+            else f"allowed_update_types override did not include {normalized_update_type}"
+        )
+        return {
+            "mode": mode,
+            "allowed_update_types": normalized_allowed_update_types,
+            "should_notify": should_notify,
+            "applied_via": "allowed_update_types",
+            "reason": reason,
+        }
+
+    if mode == NOTIFICATION_POLICY_MODE_ALL:
+        return {
+            "mode": mode,
+            "allowed_update_types": None,
+            "should_notify": True,
+            "applied_via": "mode",
+            "reason": "mode=all notifies every update_type",
+        }
+
+    if mode == NOTIFICATION_POLICY_MODE_MUTE:
+        return {
+            "mode": mode,
+            "allowed_update_types": None,
+            "should_notify": False,
+            "applied_via": "mode",
+            "reason": "mode=mute suppresses every update_type",
+        }
+
+    should_notify = normalized_update_type in DEFAULT_NOTIFY_UPDATE_TYPES
+    return {
+        "mode": mode,
+        "allowed_update_types": None,
+        "should_notify": should_notify,
+        "applied_via": "mode",
+        "reason": (
+            f"mode=important_only allows {normalized_update_type}"
+            if should_notify
+            else f"mode=important_only suppresses {normalized_update_type}"
+        ),
     }
 
 

--- a/spec.md
+++ b/spec.md
@@ -52,8 +52,11 @@
 - `seed_url`: adapter normalize に再投入できる canonical seed
 - `enabled`: `false` のとき checker はその作品を巡回しない
 - `history_retention`: 任意。作品ごとの既読履歴保持件数。未指定時は既定値 `20`
-- `notification_policy.mode`: v2 migration では既定値 `all`
-- `notification_policy.allowed_update_types`: 明示設定が無ければ `null`
+- `notification_policy.mode`: `all` / `important_only` / `mute`。v2 migration では既定値 `all`
+- `notification_policy.allowed_update_types`: 明示設定が無ければ `null`。`null` でないときは mode より優先する
+- `notification_policy.mode=all`: classification default を bypass して全 `update_type` を通知する
+- `notification_policy.mode=important_only`: `main_story` と `unknown` を通知する
+- `notification_policy.mode=mute`: どの `update_type` も通知しない
 - `health_policy.expected_interval_seconds`: stale 判定用の期待巡回間隔。未指定時は `CRAWL_INTERVAL`、無ければ `CRAWL_SCHEDULE`、さらに無ければ既定 cron (`0 19 * * *`) から導出する
 
 ### `watchlist add` CLI
@@ -249,7 +252,8 @@ python3 -m manga_watch.check manga_watch/watchlist.json
 - 同じ `event_id` を再検知しても履歴は重複させない。必要なら event snapshot だけ補完更新する
 - 新規 event が履歴に追加されたときだけ `unread.event_ids` にその id を追加する
 - `latest_key` が同じで `seriesTitle` / `episodeTitle` / `pageTitle` / 補足 metadata だけ改善された場合は silent merge する
-- update event と state.latest には `update_type`, `classification_reason`, `default_notify` を含める
+- state.latest / history.latest には `update_type`, `classification_reason`, `default_notify` を含める
+- checker の `updates[]` には top-level `notification` を含める。`should_notify=false` は「更新あり / backend 通知なし」を意味し、`updates=[]` の「更新なし」と区別できるようにする
 - source ごとの parser/runtime failure は `errors.sources` に積み、成功した作品の state 更新は継続する
 - retry 対象は transport error / timeout / HTTP `429` / `5xx` に限定する
 - HTTP `404`、unsupported URL、parse error は即失敗として `errors.sources` に積む
@@ -357,6 +361,13 @@ python3 -m manga_watch.runner
   "series_title": "蜘蛛ですが、なにか？",
   "update_type": "main_story",
   "detected_at": "2026-03-08T08:00:00Z",
+  "notification": {
+    "mode": "important_only",
+    "allowed_update_types": null,
+    "should_notify": true,
+    "applied_via": "mode",
+    "reason": "mode=important_only allows main_story"
+  },
   "from": {
     "latest_key": "KC_0039130008800011_E",
     "series_title": "蜘蛛ですが、なにか？",
@@ -380,10 +391,11 @@ python3 -m manga_watch.runner
 - `event_id` は `sha256(work_id + "\n" + latest_key)` を `"<work_id>:<digest>"` にした stable id
 - `detected_at` は UTC の RFC 3339 timestamp
 - `from` / `to` は snake_case に正規化した snapshot
-- runner は既定通知対象 (`default_notify=true` or update-type default) の update だけを backend に送る
+- `notification` は watchlist policy を適用した effective decision。`default_notify=false` な update でも `mode=all` や explicit `allowed_update_types` で `should_notify=true` になり得る
+- runner は `notification.should_notify=true` の update だけを backend に送る。`notification` が無い legacy payload だけ `default_notify` / update-type default に fallback する
 - suppressed update は state と run report には残るが backend には送らない
 
-### Default notification behavior
+### Classification defaults and notification policy
 
 - `main_story`: 既定通知対象
 - `unknown`: fail-open で既定通知対象
@@ -391,8 +403,12 @@ python3 -m manga_watch.runner
 - `announcement`: 既定抑制対象
 - `main_story` と suppress 対象が衝突した場合は `unknown` に倒す
 - `bonus` と `announcement` だけが衝突した場合は suppress 側に残す
-- runner は既定通知対象だけを notifier backend に送る
-- suppressed update も state と run report には残し、run report には `既定通知対象件数` と `既定抑制件数` を含める
+- `allowed_update_types` が明示設定されていれば、それをその作品の最終通知判定として使う。空 list も有効で、その場合は全 suppress
+- `allowed_update_types=null` のときだけ `mode` を使う
+- `mode=all`: 全 `update_type` を通知し、classification default を bypass する
+- `mode=important_only`: `main_story` と `unknown` だけを通知する
+- `mode=mute`: 全 suppress
+- suppressed update も state と run report には残し、run report には `通知対象件数` と `通知抑制件数` を含める
 
 ## Reader / Writer compatibility matrix
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -15,7 +15,13 @@ import requests
 from manga_watch import check
 from manga_watch.sources import LatestEpisode, RequestsHttpClient, SourceAdapter, WorkDescriptor
 from manga_watch.sources.base import SourceParseError
-from manga_watch.storage import latest_runtime_to_storage, latest_storage_to_runtime, validate_state
+from manga_watch.storage import (
+    evaluate_notification_policy,
+    latest_runtime_to_storage,
+    latest_storage_to_runtime,
+    validate_state,
+    validate_watchlist,
+)
 
 
 class FakeAdapter(SourceAdapter):
@@ -51,13 +57,15 @@ def watchlist_entry(
     source="fake",
     seed_url="https://example.com/work",
     enabled=True,
+    notification_policy=None,
 ):
     return {
         "id": work_id,
         "source": source,
         "seed_url": seed_url,
         "enabled": enabled,
-        "notification_policy": {
+        "notification_policy": notification_policy
+        or {
             "mode": "all",
             "allowed_update_types": None,
         },
@@ -285,6 +293,78 @@ class CheckTests(unittest.TestCase):
         self.assertEqual("comic-action:13933686331663374228", entry["id"])
         self.assertEqual("comic-action", entry["source"])
 
+    def test_validate_watchlist_rejects_unknown_notification_policy_mode(self):
+        with self.assertRaisesRegex(ValueError, "notification_policy.mode must be one of"):
+            validate_watchlist(
+                {
+                    "version": 2,
+                    "works": [
+                        watchlist_entry(
+                            notification_policy={
+                                "mode": "weekly_digest",
+                                "allowed_update_types": None,
+                            }
+                        )
+                    ],
+                }
+            )
+
+    def test_evaluate_notification_policy_truth_table(self):
+        cases = [
+            (
+                {"mode": "all", "allowed_update_types": None},
+                "bonus",
+                True,
+                "mode",
+                "mode=all notifies every update_type",
+            ),
+            (
+                {"mode": "important_only", "allowed_update_types": None},
+                "main_story",
+                True,
+                "mode",
+                "mode=important_only allows main_story",
+            ),
+            (
+                {"mode": "important_only", "allowed_update_types": None},
+                "announcement",
+                False,
+                "mode",
+                "mode=important_only suppresses announcement",
+            ),
+            (
+                {"mode": "mute", "allowed_update_types": None},
+                "unknown",
+                False,
+                "mode",
+                "mode=mute suppresses every update_type",
+            ),
+            (
+                {"mode": "mute", "allowed_update_types": ["announcement"]},
+                "announcement",
+                True,
+                "allowed_update_types",
+                "allowed_update_types override matched announcement",
+            ),
+            (
+                {"mode": "all", "allowed_update_types": ["main_story"]},
+                "bonus",
+                False,
+                "allowed_update_types",
+                "allowed_update_types override did not include bonus",
+            ),
+        ]
+
+        for policy, update_type, should_notify, applied_via, reason in cases:
+            with self.subTest(policy=policy, update_type=update_type):
+                decision = evaluate_notification_policy(policy, update_type=update_type)
+
+                self.assertEqual(policy["mode"], decision["mode"])
+                self.assertEqual(policy["allowed_update_types"], decision["allowed_update_types"])
+                self.assertEqual(should_notify, decision["should_notify"])
+                self.assertEqual(applied_via, decision["applied_via"])
+                self.assertEqual(reason, decision["reason"])
+
     def test_run_check_initializes_state_without_updates(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"
@@ -382,12 +462,205 @@ class CheckTests(unittest.TestCase):
                 "id": "work-1",
                 "from": latest_storage_to_runtime(previous["latest"]),
                 "to": latest,
+                "notification": {
+                    "mode": "all",
+                    "allowed_update_types": None,
+                    "should_notify": True,
+                    "applied_via": "mode",
+                    "reason": "mode=all notifies every update_type",
+                },
                 "update_type": "main_story",
                 "classification_reason": "episode_title matched main-story numbering",
                 "default_notify": True,
             },
             update,
         )
+
+    def test_apply_item_transition_evaluates_notification_policy_truth_table(self):
+        previous = {
+            "latest": {
+                "source": "fake",
+                "work_id": "work-1",
+                "latest_key": "ep-1",
+                "series_title": "作品A",
+                "episode_title": "第1話",
+                "url": "https://example.com/work/1",
+            },
+            "history": [],
+            "unread": {"event_ids": []},
+            "health": {
+                "last_checked_at": 10,
+                "last_success_at": 10,
+                "consecutive_failures": 0,
+            },
+        }
+        cases = [
+            (
+                "mode=all bypasses suppressed defaults",
+                {"mode": "all", "allowed_update_types": None},
+                "bonus",
+                False,
+                True,
+                "mode",
+                None,
+            ),
+            (
+                "mode=important_only allows main_story",
+                {"mode": "important_only", "allowed_update_types": None},
+                "main_story",
+                True,
+                True,
+                "mode",
+                None,
+            ),
+            (
+                "mode=important_only allows unknown",
+                {"mode": "important_only", "allowed_update_types": None},
+                "unknown",
+                True,
+                True,
+                "mode",
+                None,
+            ),
+            (
+                "mode=important_only suppresses bonus",
+                {"mode": "important_only", "allowed_update_types": None},
+                "bonus",
+                False,
+                False,
+                "mode",
+                None,
+            ),
+            (
+                "mode=mute suppresses everything",
+                {"mode": "mute", "allowed_update_types": None},
+                "main_story",
+                True,
+                False,
+                "mode",
+                None,
+            ),
+            (
+                "allowed_update_types overrides mute",
+                {"mode": "mute", "allowed_update_types": ["bonus"]},
+                "bonus",
+                False,
+                True,
+                "allowed_update_types",
+                ["bonus"],
+            ),
+            (
+                "empty allowed_update_types overrides all",
+                {"mode": "all", "allowed_update_types": []},
+                "main_story",
+                True,
+                False,
+                "allowed_update_types",
+                [],
+            ),
+        ]
+
+        for description, policy, update_type, default_notify, should_notify, applied_via, allowed in cases:
+            latest = {
+                "source": "fake",
+                "workId": "work-1",
+                "latestKey": f"ep-{update_type}",
+                "seriesTitle": "作品A",
+                "episodeTitle": f"{update_type} update",
+                "url": f"https://example.com/{update_type}",
+                "update_type": update_type,
+                "default_notify": default_notify,
+            }
+
+            with self.subTest(description=description):
+                next_entry, update = check.apply_item_transition(
+                    "work-1",
+                    previous,
+                    latest,
+                    seen_at=20,
+                    history_retention=5,
+                    notification_policy=policy,
+                )
+
+                self.assertIsNotNone(update)
+                self.assertEqual(1, len(next_entry["history"]))
+                self.assertEqual(["ep-" + update_type], next_entry["unread"]["event_ids"])
+                self.assertEqual(policy["mode"], update["notification"]["mode"])
+                self.assertEqual(allowed, update["notification"]["allowed_update_types"])
+                self.assertEqual(should_notify, update["notification"]["should_notify"])
+                self.assertEqual(applied_via, update["notification"]["applied_via"])
+
+    def test_run_check_keeps_suppressed_updates_in_state_and_machine_readable_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            state_path = Path(tmpdir) / "state.json"
+            watchlist = [watchlist_entry()]
+            watchlist[0]["notification_policy"] = {
+                "mode": "important_only",
+                "allowed_update_types": None,
+            }
+            write_watchlist(watchlist_path, watchlist)
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "works": {
+                            "work-1": {
+                                "latest": {
+                                    "source": "fake",
+                                    "work_id": "work-1",
+                                    "latest_key": "ep-1",
+                                    "series_title": "作品A",
+                                    "episode_title": "第1話",
+                                    "url": "https://example.com/work/1",
+                                },
+                                "history": [],
+                                "unread": {"event_ids": []},
+                                "health": {
+                                    "last_checked_at": 10,
+                                    "last_success_at": 10,
+                                    "consecutive_failures": 0,
+                                },
+                            }
+                        },
+                        "last_run_at": 10,
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            latest = {
+                "source": "fake",
+                "workId": "work-1",
+                "latestKey": "ep-2",
+                "seriesTitle": "作品A",
+                "episodeTitle": "番外編",
+                "url": "https://example.com/work/2",
+                "update_type": "bonus",
+                "classification_reason": "episode_title matched bonus marker",
+                "default_notify": False,
+            }
+
+            with mock.patch.dict(os.environ, {"MANGA_WATCH_STATE": str(state_path)}, clear=False):
+                with mock.patch(
+                    "manga_watch.check.normalize_item",
+                    return_value={
+                        "source": "fake",
+                        "workId": "work-1",
+                        "seedUrl": "https://example.com/work",
+                    },
+                ):
+                    with mock.patch("manga_watch.check.compute_latest", return_value=latest):
+                        result = check.run_check(str(watchlist_path))
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertEqual({"sources": [], "run": []}, result["errors"])
+        self.assertEqual(1, len(result["updates"]))
+        self.assertFalse(result["updates"][0]["notification"]["should_notify"])
+        self.assertEqual("important_only", result["updates"][0]["notification"]["mode"])
+        self.assertEqual(["ep-2"], state["works"]["work-1"]["unread"]["event_ids"])
+        self.assertEqual(["ep-2"], [event["event_id"] for event in state["works"]["work-1"]["history"]])
 
     def test_apply_item_transition_silently_merges_metadata_when_latest_key_is_stable(self):
         previous = {

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -87,6 +87,23 @@ class RunnerTests(unittest.TestCase):
             notifier_config=NotifierConfig(backends=("stdout",)),
         )
 
+    def make_notification(
+        self,
+        *,
+        mode="important_only",
+        allowed_update_types=None,
+        should_notify=True,
+        applied_via="mode",
+        reason="test notification policy",
+    ):
+        return {
+            "mode": mode,
+            "allowed_update_types": allowed_update_types,
+            "should_notify": should_notify,
+            "applied_via": applied_via,
+            "reason": reason,
+        }
+
     def make_update(
         self,
         *,
@@ -95,6 +112,7 @@ class RunnerTests(unittest.TestCase):
         latest_key="episode-2",
         episode_title="第2話",
         classification_reason=None,
+        notification=None,
     ):
         update = {
             "id": "work-1",
@@ -113,6 +131,12 @@ class RunnerTests(unittest.TestCase):
             },
             "update_type": update_type,
             "default_notify": default_notify,
+            "notification": dict(
+                notification
+                or self.make_notification(
+                    should_notify=default_notify,
+                )
+            ),
         }
         if classification_reason is not None:
             update["classification_reason"] = classification_reason
@@ -167,6 +191,7 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("work-1", payload["work_id"])
         self.assertEqual("episode-2", payload["latest_key"])
         self.assertEqual("作品A", payload["series_title"])
+        self.assertTrue(payload["notification"]["should_notify"])
 
     def test_webhook_notifier_treats_2xx_as_success(self):
         event = build_update_event(
@@ -246,12 +271,14 @@ class RunnerTests(unittest.TestCase):
         )
 
         self.assertTrue(outcome["ok"])
+        self.assertEqual(0, outcome["notifiedUpdateCount"])
+        self.assertEqual(0, outcome["suppressedUpdateCount"])
         self.assertEqual(0, outcome["errorCount"])
         self.assertEqual([], notifier.events)
         self.assertEqual(1, len(reports))
         self.assertIn("通知: 送信なし", reports[0])
-        self.assertIn("既定通知対象: 0件", reports[0])
-        self.assertIn("既定抑制: 0件", reports[0])
+        self.assertIn("通知対象: 0件", reports[0])
+        self.assertIn("通知抑制: 0件", reports[0])
         self.assertIn("エラー: 0件", reports[0])
         self.assertEqual([], errors)
 
@@ -270,6 +297,8 @@ class RunnerTests(unittest.TestCase):
         )
 
         self.assertTrue(outcome["ok"])
+        self.assertEqual(1, outcome["notifiedUpdateCount"])
+        self.assertEqual(0, outcome["suppressedUpdateCount"])
         self.assertEqual(1, len(notifier.events))
         payload = notifier.events[0].as_payload()
         self.assertEqual("work-1", payload["work_id"])
@@ -277,9 +306,10 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("作品A", payload["series_title"])
         self.assertEqual("main_story", payload["update_type"])
         self.assertEqual("2023-11-14T22:13:20Z", payload["detected_at"])
+        self.assertTrue(payload["notification"]["should_notify"])
         self.assertIn("通知: 送信した", reports[0])
-        self.assertIn("既定通知対象: 1件", reports[0])
-        self.assertIn("既定抑制: 0件", reports[0])
+        self.assertIn("通知対象: 1件", reports[0])
+        self.assertIn("通知抑制: 0件", reports[0])
 
     def test_run_once_suppresses_bonus_updates_from_notifier_but_reports_them(self):
         notifier = FakeNotifier()
@@ -305,27 +335,29 @@ class RunnerTests(unittest.TestCase):
         )
 
         self.assertTrue(outcome["ok"])
+        self.assertEqual(0, outcome["notifiedUpdateCount"])
+        self.assertEqual(1, outcome["suppressedUpdateCount"])
         self.assertEqual([], notifier.events)
         self.assertIn("更新検知: 1件", reports[0])
-        self.assertIn("既定通知対象: 0件", reports[0])
-        self.assertIn("既定抑制: 1件", reports[0])
+        self.assertIn("通知対象: 0件", reports[0])
+        self.assertIn("通知抑制: 1件", reports[0])
         self.assertIn("通知: 送信なし", reports[0])
 
     def test_run_once_unknown_updates_fail_open_to_notifier(self):
         notifier = FakeNotifier()
+        update = self.make_update(
+            update_type="unknown",
+            default_notify=True,
+            episode_title="春の特別掲載",
+            classification_reason="matched both story and bonus markers",
+        )
+        update.pop("notification")
 
         outcome = run_once(
             self.make_config(),
             notifier=notifier,
             checker=lambda _: {
-                "updates": [
-                    self.make_update(
-                        update_type="unknown",
-                        default_notify=True,
-                        episode_title="春の特別掲載",
-                        classification_reason="matched both story and bonus markers",
-                    )
-                ]
+                "updates": [update]
             },
             state_loader=self.make_state,
             now_fn=lambda: 1_700_000_000,
@@ -341,6 +373,43 @@ class RunnerTests(unittest.TestCase):
             "matched both story and bonus markers",
             payload["to"]["classification_reason"],
         )
+
+    def test_run_once_mode_all_notifies_bonus_updates_even_when_default_notify_is_false(self):
+        notifier = FakeNotifier()
+
+        outcome = run_once(
+            self.make_config(),
+            notifier=notifier,
+            checker=lambda _: {
+                "updates": [
+                    self.make_update(
+                        update_type="bonus",
+                        default_notify=False,
+                        episode_title="番外編",
+                        classification_reason="episode_title matched bonus marker",
+                        notification=self.make_notification(
+                            mode="all",
+                            should_notify=True,
+                            reason="mode=all notifies every update_type",
+                        ),
+                    )
+                ]
+            },
+            state_loader=self.make_state,
+            now_fn=lambda: 1_700_000_000,
+            report_logger=lambda _: None,
+            error_logger=lambda _: self.fail("unexpected error log"),
+        )
+
+        self.assertTrue(outcome["ok"])
+        self.assertEqual(1, outcome["notifiedUpdateCount"])
+        self.assertEqual(0, outcome["suppressedUpdateCount"])
+        self.assertEqual(1, len(notifier.events))
+        payload = notifier.events[0].as_payload()
+        self.assertEqual("bonus", payload["update_type"])
+        self.assertFalse(payload["to"]["default_notify"])
+        self.assertEqual("all", payload["notification"]["mode"])
+        self.assertTrue(payload["notification"]["should_notify"])
 
     def test_run_once_marks_source_errors_as_degraded_while_still_sending_events(self):
         notifier = FakeNotifier()
@@ -378,10 +447,12 @@ class RunnerTests(unittest.TestCase):
         )
 
         self.assertFalse(outcome["ok"])
+        self.assertEqual(1, outcome["notifiedUpdateCount"])
+        self.assertEqual(0, outcome["suppressedUpdateCount"])
         self.assertEqual(1, outcome["errorCount"])
         self.assertEqual(1, len(notifier.events))
         self.assertIn("巡回実行に一部失敗がありました", reports[0])
-        self.assertIn("既定通知対象: 1件", reports[0])
+        self.assertIn("通知対象: 1件", reports[0])
         self.assertIn("エラー: 1件", reports[0])
         self.assertIn("source/parse [fetch_latest] work-2: parse failed", reports[0])
 
@@ -402,6 +473,8 @@ class RunnerTests(unittest.TestCase):
 
         self.assertFalse(outcome["ok"])
         self.assertEqual(1, outcome["updateCount"])
+        self.assertEqual(1, outcome["notifiedUpdateCount"])
+        self.assertEqual(0, outcome["suppressedUpdateCount"])
         self.assertEqual([], reports)
         self.assertEqual(1, len(errors))
         self.assertIn("巡回実行に失敗しました", errors[0])


### PR DESCRIPTION
## Issue
- Closes #16

## What Changed
- evaluate each work's `notification_policy` during checker updates and attach the effective `notification` decision to machine-readable update payloads
- honor policy precedence in runtime delivery: explicit `allowed_update_types` overrides `mode`, and `mode=all|important_only|mute` now controls notifier fan-out per stable `work_id`
- keep suppressed updates in state/history/run reports while making them distinguishable from "no updates", and document the contract in `spec.md` / `README.md`
- validate supported notification policy modes and cover the truth table with focused tests

## Verification
- `PYTHONPATH=/tmp/comic_crawler_test_deps python3 -m unittest tests.test_sources tests.test_update_classification tests.test_check tests.test_status tests.test_watchlist tests.test_runner tests.test_migrate_v2 tests.test_backlog`

## Residual Risks
- notifier backends still receive only notified updates by design; suppressed updates are machine-readable via checker output and run reports rather than a separate backend payload
- `notification_policy.allowed_update_types` accepts arbitrary strings, so mismatches are suppressed rather than rejected unless a future schema tightens the enum
