### PR TITLE
feat: preserve multi-update gap metadata in backlog history

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ checker は watchlist を並列に処理しますが、`updates` / `errors.sourc
 
 各作品は `latest`, `history`, `unread`, `health` を持ちます。
 
-- `history`: `event_id` と `seen_at` を持つ更新イベント列
+- `history`: `event_id`, `seen_at`, `latest` を持つ更新イベント列。`latest_key` が進んだ event には任意で `gap` を持てる
+- `history[].gap.from_latest`: 直前 run で見えていた latest snapshot。複数話進行を exact に取れない source でも最低限この差分は残す
+- `history[].gap.estimated_new_episode_count`: `episodeTitle` / `pageTitle` から話数を比較できたときだけ入る推定件数
 - `unread.event_ids`: 未読イベントの source of truth
 - `health`: `last_checked_at`, `last_success_at`, `consecutive_failures`
 
@@ -109,7 +111,10 @@ python3 -m manga_watch.backlog --mark-read KC_003913_S
 ```
 
 - `--json`: unread 数と履歴イベントを JSON で出力
+- `--json` 出力の event には任意で `gap` が入り、`from_latest` と推定話数から multi-update gap を downstream に渡せる
 - `--mark-read <work_id>`: その作品の現在未読を既読化し、保持ルールに従って履歴を trim
+
+複数話進行の推定は source 固有 id ではなく title から行います。`第N話` / `Episode N` / `Ep.N` / `#N` のような番号が両端で取れるときだけ `estimated_new_episode_count` を出し、取れない source や title では `from_latest` だけを残す fallback にします。
 
 ### legacy v1 input
 

--- a/manga_watch/backlog.py
+++ b/manga_watch/backlog.py
@@ -52,6 +52,45 @@ def series_label(work_id: str, latest: Mapping[str, object]) -> str:
     return str(latest.get("series_title") or latest.get("series") or work_id)
 
 
+def serialize_gap(gap: object) -> Optional[Dict[str, object]]:
+    if not isinstance(gap, Mapping):
+        return None
+    from_latest = gap.get("from_latest", {})
+    if not isinstance(from_latest, Mapping):
+        from_latest = {}
+
+    serialized: Dict[str, object] = {
+        "from_episode_label": latest_label(from_latest, "不明"),
+        "from_url": from_latest.get("url"),
+        "multiple_updates": gap.get("multiple_updates")
+        if isinstance(gap.get("multiple_updates"), bool)
+        else None,
+        "estimation_basis": str(gap.get("estimation_basis") or "").strip() or None,
+    }
+
+    estimated_count = gap.get("estimated_new_episode_count")
+    if isinstance(estimated_count, int):
+        serialized["estimated_new_episode_count"] = estimated_count
+    if from_latest:
+        serialized["from_latest"] = dict(from_latest)
+
+    return {key: value for key, value in serialized.items() if value is not None}
+
+
+def format_gap_suffix(event: Mapping[str, object]) -> str:
+    gap = event.get("gap")
+    if not isinstance(gap, Mapping):
+        return ""
+
+    from_label = str(gap.get("from_episode_label") or "不明")
+    estimated_count = gap.get("estimated_new_episode_count")
+    if gap.get("multiple_updates") is True and isinstance(estimated_count, int):
+        return f" gap from {from_label} (+{estimated_count} estimated)"
+    if gap.get("multiple_updates") is None:
+        return f" gap from {from_label} (count unavailable)"
+    return ""
+
+
 def collect_backlog(
     state: Mapping[str, object],
     *,
@@ -109,6 +148,7 @@ def collect_backlog(
                 "episode_label": latest_label(event_latest, "不明"),
                 "url": event_latest.get("url"),
                 "unread": event_id in unread_set,
+                "gap": serialize_gap(event.get("gap")),
             }
             all_events.append(serialized)
             if serialized["unread"]:
@@ -267,6 +307,7 @@ def format_backlog_text(payload: Mapping[str, object]) -> str:
             lines.append("Unread events:")
             for event in unread_events:
                 suffix = f" {event['url']}" if event.get("url") else ""
+                suffix += format_gap_suffix(event)
                 lines.append(
                     f"- {event['seen_at_label']} {event['episode_label']} ({event['event_id']}){suffix}"
                 )
@@ -277,6 +318,7 @@ def format_backlog_text(payload: Mapping[str, object]) -> str:
             lines.append("Recent history:")
             for event in recent_history:
                 suffix = f" {event['url']}" if event.get("url") else ""
+                suffix += format_gap_suffix(event)
                 lines.append(
                     f"- {event['seen_at_label']} {event['episode_label']} ({event['event_id']}){suffix}"
                 )

--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -4,6 +4,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 import json
 import os
+import re
 import sys
 import time
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
@@ -42,6 +43,12 @@ DEFAULT_NOTIFICATION_POLICY = {
     "mode": NOTIFICATION_POLICY_MODE_ALL,
     "allowed_update_types": None,
 }
+EPISODE_NUMBER_PATTERNS = (
+    re.compile(r"第\s*(\d+)\s*話"),
+    re.compile(r"\bEpisode\s+(\d+)\b", re.IGNORECASE),
+    re.compile(r"\bEp\.?\s*(\d+)\b", re.IGNORECASE),
+    re.compile(r"#\s*(\d+)"),
+)
 
 
 class CheckRunError(RuntimeError):
@@ -219,12 +226,58 @@ def unread_state_for_entry(previous_entry: Optional[Mapping[str, object]]) -> Di
     return unread
 
 
+def episode_label_candidates(latest: Mapping[str, object]) -> List[str]:
+    candidates: List[str] = []
+    for key in ("episodeTitle", "pageTitle", "episode_title", "page_title"):
+        value = latest.get(key)
+        if not isinstance(value, str):
+            continue
+        label = value.strip()
+        if label and label not in candidates:
+            candidates.append(label)
+    return candidates
+
+
+def episode_number_for_latest(latest: Mapping[str, object]) -> Optional[int]:
+    for label in episode_label_candidates(latest):
+        for pattern in EPISODE_NUMBER_PATTERNS:
+            match = pattern.search(label)
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def build_history_gap(
+    previous_latest: Mapping[str, object],
+    latest: Mapping[str, object],
+) -> Dict[str, object]:
+    gap: Dict[str, object] = {
+        "from_latest": latest_runtime_to_storage(previous_latest),
+        "multiple_updates": None,
+        "estimation_basis": "previous_latest_only",
+    }
+
+    previous_episode_number = episode_number_for_latest(previous_latest)
+    latest_episode_number = episode_number_for_latest(latest)
+    if previous_episode_number is None or latest_episode_number is None:
+        return gap
+    if latest_episode_number <= previous_episode_number:
+        return gap
+
+    estimated_new_episode_count = latest_episode_number - previous_episode_number
+    gap["estimated_new_episode_count"] = estimated_new_episode_count
+    gap["multiple_updates"] = estimated_new_episode_count > 1
+    gap["estimation_basis"] = "episode_title_number"
+    return gap
+
+
 def sync_history_event(
     history,
     latest: Mapping[str, object],
     *,
     seen_at: int,
     insert_if_missing: bool,
+    new_event: Optional[Mapping[str, object]] = None,
 ):
     event_id = latest_id_for_state(latest)
     if not event_id:
@@ -248,11 +301,14 @@ def sync_history_event(
         return updated_history, False
 
     updated_history.append(
-        {
+        dict(
+            new_event
+            or {
             "event_id": event_id,
             "seen_at": seen_at,
             "latest": latest_runtime_to_storage(latest),
-        }
+            }
+        )
     )
     return updated_history, True
 
@@ -284,11 +340,18 @@ def apply_item_transition(
     previous_latest_id = latest_id_for_state(previous_latest)
     latest_id = latest_id_for_state(latest_copy)
     if previous_latest_id != latest_id:
+        next_event = {
+            "event_id": latest_id,
+            "seen_at": seen_at,
+            "latest": latest_runtime_to_storage(latest_copy),
+            "gap": build_history_gap(previous_latest, latest_copy),
+        }
         history, inserted = sync_history_event(
             history,
             latest_copy,
             seen_at=seen_at,
             insert_if_missing=True,
+            new_event=next_event,
         )
         if inserted and latest_id not in unread_event_ids:
             unread_event_ids.append(latest_id)

--- a/spec.md
+++ b/spec.md
@@ -199,10 +199,14 @@ Phase 1 はこの matrix を source of truth とし、未記載の URL 種別は
 ### State field rules
 
 - `latest`: 現在の最新話 snapshot。未成功作品では `{}` を許容する
-- `history`: 更新イベント列。各 event は `event_id`, `seen_at`, `latest` を持つ
+- `history`: 更新イベント列。各 event は `event_id`, `seen_at`, `latest` を持ち、必要に応じて `gap` を持てる
 - `history[].event_id`: `latest_key` をそのまま使う。作品ごとに一意で、履歴追加の idempotency key でもある
 - `history[].seen_at`: その更新 event を checker が検知した UNIX timestamp
 - `history[].latest`: event 時点の latest snapshot
+- `history[].gap.from_latest`: 直前 run で見えていた latest snapshot。multi-update gap を exact に取れない場合でも最低限ここは埋める
+- `history[].gap.estimated_new_episode_count`: `episodeTitle` / `pageTitle` の両端から話数を抽出できたときだけ入る推定件数
+- `history[].gap.multiple_updates`: 推定件数が 2 以上なら `true`、1 件なら `false`、話数推定不能なら `null` 相当で保持する
+- `history[].gap.estimation_basis`: `episode_title_number` または `previous_latest_only`
 - `unread.event_ids`: 未読 event id の source of truth。`unread_count` は永続化しない
 - `health.last_checked_at`: 直近でその作品を巡回した UNIX timestamp
 - `health.last_success_at`: 直近で成功した UNIX timestamp
@@ -249,6 +253,9 @@ python3 -m manga_watch.check manga_watch/watchlist.json
 - source fetch は `MANGA_WATCH_HTTP_WORKERS` 本で並列実行できるが、state 更新順・`updates`・`errors.sources` は watchlist 入力順で deterministic に固定する
 - `latest_key` が変わったときだけ `updates` に積む
 - `latest_key` が変わったとき、未登録の `event_id=latest_key` を `history` に 1 回だけ追加する
+- 新規 `history` event には `gap.from_latest=直前 latest` を保存する。これが backlog / unread で「latest 1 件以上」の入力になる
+- `episodeTitle` / `pageTitle` の両端から `第N話` / `Episode N` / `Ep.N` / `#N` を比較できる場合だけ `gap.estimated_new_episode_count` を埋める
+- 話数推定不能な source や title では `gap.estimation_basis=previous_latest_only` の fallback にし、exact count は出さない
 - 同じ `event_id` を再検知しても履歴は重複させない。必要なら event snapshot だけ補完更新する
 - 新規 event が履歴に追加されたときだけ `unread.event_ids` にその id を追加する
 - `latest_key` が同じで `seriesTitle` / `episodeTitle` / `pageTitle` / 補足 metadata だけ改善された場合は silent merge する
@@ -283,8 +290,14 @@ python3 -m manga_watch.backlog --mark-read KC_003913_S
 
 - `--unread-only`: 未読がある作品だけ表示する
 - `--work-id`: 対象作品を 1 つに絞る
-- `--json`: 機械可読な履歴 / unread summary を出す
+- `--json`: 機械可読な履歴 / unread summary を出す。event に `gap` があればそのまま含める
 - `--mark-read <work_id>`: その作品の `unread.event_ids` を空にして保存し、保持ルールに従って既読履歴を trim する
+
+### Multi-update gap capability
+
+- ComicWalker / Kakuyomu: `episodeTitle` / `pageTitle` に比較可能な番号が含まれるときは推定話数を出せる
+- comic-action: `latest_key` は episode URL で、adapter contract だけでは series 内の差分件数を導けない。title から番号が取れない場合は `previous_latest_only` fallback になる
+- どの source でも exact な全話遡及取得はしない。`gap.from_latest` と optional な推定件数を downstream 入力として使う
 
 ### Checker error schema
 

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -107,6 +107,69 @@ class BacklogTests(unittest.TestCase):
         self.assertEqual("第3話", payload["works"][0]["latest_label"])
         self.assertEqual("ep-3", payload["works"][0]["unread_events"][0]["event_id"])
 
+    def test_backlog_module_reports_multi_update_gap_in_json_and_text(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            write_state(
+                state_path,
+                {
+                    "version": 2,
+                    "works": {
+                        "work-1": {
+                            "latest": {
+                                "series_title": "作品A",
+                                "episode_title": "第4話",
+                                "latest_key": "ep-4",
+                            },
+                            "history": [
+                                {
+                                    "event_id": "ep-4",
+                                    "seen_at": 1700000100,
+                                    "latest": {
+                                        "series_title": "作品A",
+                                        "episode_title": "第4話",
+                                        "latest_key": "ep-4",
+                                        "url": "https://example.com/ep-4",
+                                    },
+                                    "gap": {
+                                        "from_latest": {
+                                            "series_title": "作品A",
+                                            "episode_title": "第1話",
+                                            "latest_key": "ep-1",
+                                            "url": "https://example.com/ep-1",
+                                        },
+                                        "multiple_updates": True,
+                                        "estimated_new_episode_count": 3,
+                                        "estimation_basis": "episode_title_number",
+                                    },
+                                }
+                            ],
+                            "unread": {"event_ids": ["ep-4"]},
+                            "health": {
+                                "last_checked_at": 1700000100,
+                                "last_success_at": 1700000100,
+                                "consecutive_failures": 0,
+                            },
+                        }
+                    },
+                    "last_run_at": 1700000100,
+                },
+            )
+
+            json_result = self.run_backlog_module("--state", str(state_path), "--json")
+            text_result = self.run_backlog_module("--state", str(state_path))
+
+        self.assertEqual(0, json_result.returncode, msg=json_result.stderr)
+        self.assertEqual(0, text_result.returncode, msg=text_result.stderr)
+
+        payload = json.loads(json_result.stdout)
+        gap = payload["works"][0]["unread_events"][0]["gap"]
+        self.assertEqual("第1話", gap["from_episode_label"])
+        self.assertEqual(3, gap["estimated_new_episode_count"])
+        self.assertTrue(gap["multiple_updates"])
+        self.assertEqual("episode_title_number", gap["estimation_basis"])
+        self.assertIn("gap from 第1話 (+3 estimated)", text_result.stdout)
+
     def test_backlog_module_mark_read_all_clears_unread_state(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             state_path = Path(tmpdir) / "state.json"

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -476,6 +476,59 @@ class CheckTests(unittest.TestCase):
             update,
         )
 
+    def test_apply_item_transition_records_multi_update_gap_metadata(self):
+        previous = {
+            "latest": {
+                "source": "fake",
+                "work_id": "work-1",
+                "latest_key": "ep-1",
+                "series_title": "作品A",
+                "episode_title": "第1話",
+                "url": "https://example.com/work/1",
+            },
+            "history": [],
+            "unread": {"event_ids": []},
+            "health": {
+                "last_checked_at": 10,
+                "last_success_at": 10,
+                "consecutive_failures": 0,
+            },
+        }
+        latest = {
+            "source": "fake",
+            "workId": "work-1",
+            "latestKey": "ep-4",
+            "seriesTitle": "作品A",
+            "episodeTitle": "第4話",
+            "url": "https://example.com/work/4",
+        }
+
+        next_entry, update = check.apply_item_transition(
+            "work-1",
+            previous,
+            latest,
+            seen_at=20,
+            history_retention=5,
+        )
+
+        self.assertEqual("ep-4", next_entry["history"][0]["event_id"])
+        self.assertEqual(
+            {
+                "from_latest": latest_storage_to_runtime(previous["latest"]),
+                "multiple_updates": True,
+                "estimated_new_episode_count": 3,
+                "estimation_basis": "episode_title_number",
+            },
+            {
+                "from_latest": latest_storage_to_runtime(next_entry["history"][0]["gap"]["from_latest"]),
+                "multiple_updates": next_entry["history"][0]["gap"]["multiple_updates"],
+                "estimated_new_episode_count": next_entry["history"][0]["gap"]["estimated_new_episode_count"],
+                "estimation_basis": next_entry["history"][0]["gap"]["estimation_basis"],
+            },
+        )
+        self.assertEqual(latest_storage_to_runtime(previous["latest"]), update["from"])
+        self.assertEqual(latest, update["to"])
+
     def test_apply_item_transition_evaluates_notification_policy_truth_table(self):
         previous = {
             "latest": {


### PR DESCRIPTION
## Summary
- store optional multi-update `gap` metadata on history events when `latest_key` advances
- expose gap details in backlog JSON/text so unread and recent history show more than the current latest snapshot
- document title-based estimation and fallback behavior by source, and cover the multi-update scenario with tests

## Issue
- closes #43
- parent: #6

## Verification
- `.venv/bin/python -m unittest tests.test_check tests.test_backlog`
- `.venv/bin/python -m py_compile manga_watch/check.py manga_watch/backlog.py`

## Residual risk
- exact episode counts still depend on comparable numbering in `episodeTitle` / `pageTitle`; otherwise the fallback is `from_latest` only