### PR TITLE
docs(spec): define Discord latest and runner contracts

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,5 +1,21 @@
 # comic_crawler / spec
 
+## Table of contents
+
+- [Runtime baseline](#runtime-baseline)
+- [Glossary](#glossary)
+- [Purpose](#purpose)
+- [Runtime Inputs](#runtime-inputs)
+- [State](#state)
+- [Core behavior](#core-behavior)
+- [Reply Discord `latest` query](#reply-discord-latest-query)
+- [Checker](#checker)
+- [Runner](#runner)
+- [Reader / Writer compatibility matrix](#reader--writer-compatibility-matrix)
+- [One-time migration](#one-time-migration)
+- [Verification gate for migrated data](#verification-gate-for-migrated-data)
+- [Non-goals](#non-goals)
+
 ## Runtime baseline
 
 - ローカル実行 / Docker / 将来の CI は Python `3.12` を単一の runtime baseline とする
@@ -12,12 +28,16 @@
 - **state v2**: `manga_watch/state.json`
 - **checker**: `python3 -m manga_watch.check <watchlist.json>`
 - **runner**: `python3 -m manga_watch.runner`
+- **latest query**: 保存済み state から最新話一覧を返す read-only 問い合わせ
+- **fetch trigger**: Discord から runner を手動起動する write path の問い合わせ
+- **daily notification**: 更新があったとき Discord main channel に送る通知
+- **run report**: 毎回 Discord run-report channel に送る実行結果
 - **work_id**: 作品単位で不変な識別子
 - **latest_key**: 更新検知と通知重複排除の基準キー
 
 ## Purpose
 
-複数の漫画サイトを作品単位で監視し、新しいエピソードが公開されたら通知する。Issue #7 の cutover 以降、runtime が正として扱う永続データは watchlist/state v2 のみで、v1 (`urls.txt`, `state.json` v1) は migration 入力と rollback 用 backup に限定する。
+複数の漫画サイトを作品単位で監視し、新しいエピソードが公開されたら通知し、保存済みの最新話一覧を問い合わせできるようにする。Issue #7 の cutover 以降、runtime が正として扱う永続データは watchlist/state v2 のみで、v1 (`urls.txt`, `state.json` v1) は migration 入力と rollback 用 backup に限定する。
 
 ## Runtime Inputs
 
@@ -248,7 +268,115 @@ status CLI と後続の通知設計では、state v2 に保存された `health`
 
 ## Core behavior
 
-### Checker execution
+### Reply Discord `latest` query
+
+保存済みの watchlist/state v2 を読み取り、Discord 上の `latest` 問い合わせに対して現在の最新話一覧を返す read-only 機能。
+
+#### Input contract
+
+- Discord の inbound surface は read-only な `latest` query をサポートする
+- canonical input は trim 後に本文がちょうど `latest` であるメッセージとする
+- `latest` query は live crawl を走らせず、保存済み watchlist/state v2 だけを読む
+- `latest` query は watchlist/state を変更しない
+- 応答生成失敗時も checker や runner の定期実行には影響を与えない
+
+#### Source of truth and ordering
+
+- query の source of truth は `watchlist v2 + state v2`
+- 一覧順は watchlist の入力順を正とする
+- `enabled=false` の作品は既定では一覧に含めない
+- watchlist に無い orphaned state entry は `latest` 応答に含めない
+- 各行の内容は `state.works[work_id].latest` と `state.works[work_id].health` から生成する
+- `state.last_run_at` は一覧全体の `最終巡回` として使う
+
+#### Response contract
+
+正常系の本文は次の形を正とする。
+
+```text
+保存済みの最新話一覧です
+最終巡回: 2026-03-07 17:03:09 JST
+現在のリスト:
+[第71話](<https://example.com/episodes/71>)　作品A
+[第8話](<https://example.com/episodes/8>)　作品B
+```
+
+- 1 行目は固定で `保存済みの最新話一覧です`
+- `最終巡回` は `state.last_run_at` を `TZ` で `YYYY-MM-DD HH:MM:SS ZZZ` に整形する
+- `state.last_run_at` が `null` または未設定なら `最終巡回: まだ実行されていません` とする
+- 3 行目は固定で `現在のリスト:`
+- 各作品は 1 行で返し、少なくとも `最新話ラベル + URL + 作品名` を含める
+- URL があるときは Discord Markdown link 形式 `[label](<url>)` を使う
+- URL が無いときは plain text で `label　作品名` とする
+- `latest` が空オブジェクトの作品は `（未取得）　作品名` とする
+
+#### Label fallback rules
+
+- 作品名は `latest.series_title`, `latest.series`, `work_id` の順で選ぶ
+- 最新話ラベルは `latest.episode_title`, `latest.episode_code`, `latest.url`, `未取得` の順で選ぶ
+- `latest.url` があり、`episode_title` が無い場合でも link label には `episode_code` を優先し、両方無いときだけ URL 自体を label とする
+
+#### Episode label truncation rules
+
+- `latest` query の一覧は縦に見比べやすいことを優先し、長い最新話ラベルは省略してよい
+- 省略対象は「話数ヘッダの後ろに続く自由文 subtitle」とし、話数ヘッダ自体はできるだけ保持する
+- 話数ヘッダの例:
+  - `第71話`
+  - `第78話その1`
+  - `第55話後編`
+  - `第62話②`
+  - `Episode 12`
+  - `Ep.8`
+  - `#8`
+- 話数ヘッダの直後に空白または区切り記号があり、その後ろに subtitle が続く場合は `header + separator + subtitle` に分けて扱う
+- truncate は subtitle にだけ適用し、`header` と `separator` はそのまま残す
+- 文字数は Unicode grapheme cluster 単位で数える
+- subtitle の最大長は `…` を含めて 8 文字とする
+- subtitle が 8 文字を超える場合は、先頭 7 文字を残して `…` を付ける
+- 省略記号は常に `…` とする
+- 全角/半角の違いは文字数計算に使わない
+- mixed width の subtitle も同じ文字数ルールで切る
+- subtitle を分離できない場合は、最新話ラベル全体に fallback truncate を適用する
+- fallback truncate の上限は `…` を含めて 20 文字とする
+- 最新話ラベル全体が 20 文字を超える場合は、先頭 19 文字を残して `…` を付ける
+- fallback truncate は subtitle 分離に失敗した場合だけ使う。分離できる場合は subtitle-only truncate を優先する
+
+例:
+
+- `第71話 abcdefghijk` -> `第71話 abcdefg…`
+- `第71話 あいうえおかきくけ` -> `第71話 あいうえおかき…`
+- `第71話 abあいうcdef` -> `第71話 abあいうcd…`
+- `abcdefghijklmnopqrstu` -> `abcdefghijklmnopqrs…`
+- `第55話後編` -> `第55話後編`
+
+#### Empty / stale / partial-failure semantics
+
+- 一覧対象作品が 0 件、または全作品が未取得なら次を返す
+
+```text
+保存済みの最新話一覧です
+最終巡回: まだ実行されていません
+現在のリスト:
+- まだ保存済みの監視結果がありません
+```
+
+- `latest` query は `更新なし` を意味しない。あくまで「保存済み state の参照」である
+- 直近 run で 1 件以上 `health.consecutive_failures > 0` の作品がある場合、本文末尾に warning summary を追加する
+- warning summary は少なくとも「一部作品は直近巡回で失敗しており、表示内容は保存済みデータである」ことを伝える
+- `last_run_at` が大きく古い場合の stale 判定閾値は query surface 側で別途持ってよいが、stale warning を出しても live crawl を自動実行してはならない
+- source failure と run-level failure は `更新なし` と混同しない文言で返す
+
+#### Verification gate
+
+- command routing は `latest` を read-only query として解釈できること
+- response generation は watchlist 順、timestamp formatting、empty state、partial failure warning を自動テストで担保する
+- `latest` query 実行時に source fetch が呼ばれないことをテストで担保する
+
+### Checker
+
+watchlist を巡回して各作品の最新話を取得し、更新検知・エラー収集・state v2 更新を行うコア処理。
+
+#### Execution contract
 
 ```bash
 python3 -m manga_watch.check manga_watch/watchlist.json
@@ -274,7 +402,7 @@ python3 -m manga_watch.check manga_watch/watchlist.json
 - 失敗した作品も `health.last_checked_at` と `health.consecutive_failures` は更新する
 - watchlist/state の読み込みや state 保存のような run-level failure は `errors.run` に記録し、`CheckRunError` として返す
 
-### Status CLI
+#### Status CLI
 
 ```bash
 python3 -m manga_watch.check --status
@@ -286,7 +414,7 @@ python3 -m manga_watch.check --status --format json
 - JSON 出力は同じ情報を `summary` と `works[]` に分けて返す
 - `works[].health` には `state`, `last_checked_at`, `last_success_at`, `consecutive_failures`, `expected_interval_seconds`, `stale_after_seconds` を含む
 
-## Backlog CLI
+#### Backlog CLI
 
 ```bash
 python3 -m manga_watch.backlog --unread-only
@@ -299,13 +427,13 @@ python3 -m manga_watch.backlog --mark-read KC_003913_S
 - `--json`: 機械可読な履歴 / unread summary を出す。event に `gap` があればそのまま含める
 - `--mark-read <work_id>`: その作品の `unread.event_ids` を空にして保存し、保持ルールに従って既読履歴を trim する
 
-### Multi-update gap capability
+#### Multi-update gap capability
 
 - ComicWalker / Kakuyomu: `episodeTitle` / `pageTitle` に比較可能な番号が含まれるときは推定話数を出せる
 - comic-action: `latest_key` は episode URL で、adapter contract だけでは series 内の差分件数を導けない。title から番号が取れない場合は `previous_latest_only` fallback になる
 - どの source でも exact な全話遡及取得はしない。`gap.from_latest` と optional な推定件数を downstream 入力として使う
 
-### Checker error schema
+#### Error schema
 
 ```json
 {
@@ -332,11 +460,13 @@ python3 -m manga_watch.backlog --mark-read KC_003913_S
 }
 ```
 
-### Atomic state writes
+#### Atomic state writes
 
 state 保存は `temp file -> json dump -> flush -> fsync(file) -> replace -> fsync(directory)` を必須とする。v2 cutover で durability を落とさない。
 
-## Runner
+### Runner
+
+Checker を定期実行または手動実行し、daily notification と run report を Discord に送る運用オーケストレーション機能。
 
 ```bash
 python3 -m manga_watch.runner
@@ -347,6 +477,9 @@ python3 -m manga_watch.runner
 - `MANGA_WATCH_NOTIFIER_BACKENDS`
 - `MANGA_WATCH_WEBHOOK_URL` (`webhook` backend を使うとき)
 - `MANGA_WATCH_WEBHOOK_TIMEOUT`
+- `DISCORD_BOT_TOKEN` (Discord inbound / outbound surface を使うとき)
+- `DISCORD_MAIN_CHANNEL_ID` (daily notification を Discord main channel へ送るとき)
+- `DISCORD_RUN_REPORT_CHANNEL_ID` (run report を Discord run-report channel へ送るとき)
 - `TZ`。既定値は `Asia/Tokyo`
 - `CRAWL_SCHEDULE` または `CRAWL_INTERVAL`
 - `RUN_ON_STARTUP`
@@ -358,7 +491,17 @@ python3 -m manga_watch.runner
 - `MANGA_WATCH_HTTP_WORKERS`
 - `MANGA_WATCH_HTTP_WORKERS_PER_HOST`
 
-### Notification backends
+#### Scheduled scan contract
+
+- runner は watchlist 全体を定期スキャンする
+- スキャンの目的は各作品の最新話を再取得し、保存済み `latest_key` と比較して更新を検知すること
+- 本番既定値は日次スキャンであり、既定スケジュールは `CRAWL_SCHEDULE=0 19 * * *` とする
+- `CRAWL_INTERVAL` を使う構成では日次以外の頻度も許容するが、contract 上の最小要件は「定期スキャンされること」である
+- `RUN_ON_STARTUP=true` のときは定期スキャンに加えて起動直後に 1 回スキャンする
+- 1 回の定期スキャンの結果は、更新検知・state 更新・run report・失敗可視化に一貫して反映される
+- `latest` query は read-only 参照であり、定期スキャンの代替ではない
+
+#### Notification backends
 
 - `MANGA_WATCH_NOTIFIER_BACKENDS` は required。comma-separated で `stdout`, `webhook` を並べる
 - runner は同じ update event を指定順に全 backend へ fan-out する
@@ -371,8 +514,9 @@ python3 -m manga_watch.runner
 - `notification_outbox` entry は少なくとも `event`, `pending_backends`, `attempt_count`, `last_attempted_at`, `last_error` を持つ
 - delivery failure 時は failed backend だけ `pending_backends` に残し、次の `runner` run または `python3 -m manga_watch.replay_outbox` で replay する
 - `notification_outbox` が空になるまで delivery は at-least-once で続く。consumer は `event_id` で idempotent に処理する
+- Discord `latest` / `fetch` / daily notification / run report はこの backend fan-out とは別の surface であり、契約は後続節を正とする
 
-### Update event schema
+#### Update event schema
 
 ```json
 {
@@ -417,7 +561,7 @@ python3 -m manga_watch.runner
 - runner は `notification.should_notify=true` の update だけを backend に送る。`notification` が無い legacy payload だけ `default_notify` / update-type default に fallback する
 - suppressed update は state と run report には残るが backend には送らない
 
-### Classification defaults and notification policy
+#### Classification defaults and notification policy
 
 - `main_story`: 既定通知対象
 - `unknown`: fail-open で既定通知対象
@@ -433,6 +577,83 @@ python3 -m manga_watch.runner
 - `mode=important_only`: `main_story` と `unknown` だけを通知する
 - `mode=mute`: 全 suppress
 - suppressed update も state と run report には残し、run report には `通知対象件数` と `通知抑制件数` を含める
+
+#### Discord `fetch` trigger
+
+- Discord の inbound surfaceは write path の `fetch` trigger をサポートする
+- canonical input は trim 後に本文がちょうど `fetch` であるメッセージとする
+- `fetch` trigger は「その時点で 1 回 runner を実行する」手動トリガーであり、日次 19 時の定期実行と同じ実行経路を通る
+- `fetch` trigger で開始された run は、checker 実行、state 更新、daily notification、run report、failure handling を定期実行と同じ contract で処理する
+- `fetch` trigger は read-only ではなく、成功時には state を更新しうる
+- 実行中の runner が無い場合は trigger を受け付け、command を受けた Discord 上に受理メッセージを返してよい
+- 受理メッセージは少なくとも「手動 fetch を受け付けた」ことと「結果は daily notification / run report を確認すべき」ことを伝える
+- すでに scheduled run, startup run, または別の `fetch` run が進行中なら、新しい `fetch` run は開始しない
+- 進行中に拒否した場合は「現在巡回実行中であるため新しい fetch は開始しない」ことを返す
+- `fetch` run と scheduled run の違いは trigger source だけであり、更新検知・通知重複防止・失敗時挙動は同一である
+
+#### Daily notification contract
+
+- daily notification の送信先は `DISCORD_MAIN_CHANNEL_ID` とする
+- runner は checker の `updates` を入力として daily notification を生成する
+- 1 run で 1 件以上更新があった場合、その run の更新を 1 通の集約メッセージとして通知してよい
+- 更新 0 件の run では daily notification を送らない
+- 通知対象は「今回 run で `latest_key` が変わった作品」だけとする
+- 同じ `work_id` と `latest_key` の組み合わせに対する daily notification は 1 回だけ送る
+- 更新を検知した直後の成功 run で 1 回通知したあとは、後続 run で `latest_key` が変わらない限り再通知しない
+- 翌日など更新が無い run では daily notification を送らず、run report だけを送る
+- `fetch` run でも同じ重複防止 contract を適用し、すでに通知済みの `work_id + latest_key` は再通知しない
+- metadata refresh のような silent merge は daily notification の対象にしない
+- 通知の並び順は `updates` の順、すなわち watchlist 順を正とする
+
+#### Daily notification response contract
+
+更新通知本文は次の形を正とする。
+
+```text
+新着エピソードを検知しました（2026-03-02）
+[蜘蛛ですが、なにか？：第78話その1](<https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130009000011_E?episodeType=latest>)←第77話その2
+[航宙軍士官、冒険者になる：第62話①](<https://comic-walker.com/detail/KC_001405_S/episodes/KC_0014050006800011_E?episodeType=latest>)←第61話
+```
+
+- 1 行目は固定で `新着エピソードを検知しました（YYYY-MM-DD）` とする
+- 日付は通知生成時刻ではなく、その run が属する local date を `TZ` 基準で整形して使う
+- 2 行目以降は 1 更新につき 1 行とする
+- 各行は `[作品名：新しい最新話](<URL>)←前回話` の形式を正とする
+- URL は更新後 `to.url` を使う
+- 作品名は `to.series_title`, `to.seriesTitle`, `to.series`, `id` の順で選ぶ
+- 新しい最新話は `to.episode_title`, `to.episodeTitle`, `to.episode_code`, `to.episodeCode`, `to.url` の順で選ぶ
+- 前回話は `from.episode_title`, `from.episodeTitle`, `from.episode_code`, `from.episodeCode`, `from.url`, `未取得` の順で選ぶ
+- 作品名と新しい最新話の区切りは全角コロン `：` を使う
+- 新旧比較の区切りは ASCII の left arrow ではなく、固定で `←` を使う
+- URL が無い場合は `[label](<url>)` ではなく plain text の `作品名：新しい最新話←前回話` に degrade してよい
+
+#### Notification label normalization
+
+- 更新通知内の `新しい最新話` には `latest` query と同じ episode label truncation rules を適用してよい
+- `前回話` にも同じ truncate rules を適用してよい
+- 作品名は原則として truncate しない。極端に長い場合の truncation は別 contract として扱う
+
+#### Run report contract
+
+- run report の送信先は `DISCORD_RUN_REPORT_CHANNEL_ID` とする
+- runner は更新有無にかかわらず、1 run ごとに 1 通の run report を送る
+- run report は少なくとも次を含む
+  - 実行時刻
+  - trigger source (`scheduled`, `startup`, `discord_fetch` のいずれか)
+  - 更新検知件数
+  - daily notification を送信したか
+  - source failure / run-level failure の要約
+  - 現在のリスト、または最新状態の要約
+- run report の目的は「更新がなかった」ことと「run が失敗した」ことを区別可能にすることである
+- 更新 0 件でも run report は送る
+- 更新があって daily notification 送信にも成功した run でも、別途 run report は送る
+
+#### Notification failure semantics
+
+- 更新通知の送信失敗は `更新なし` と混同してはならない
+- 更新通知送信に失敗した run でも、run report または別の failure surface から「更新検知はあったが通知 delivery は失敗した」ことが分かる必要がある
+- run report 自体の送信失敗も、更新なしとして扱ってはならない
+- delivery の durable replay を行う場合、その contract は outbox/replay 側の仕様を正とする
 
 ## Reader / Writer compatibility matrix
 


### PR DESCRIPTION
## Summary
- add a table of contents and glossary entries for `latest query`, `fetch trigger`, `daily notification`, and `run report`
- restructure Core behavior into `Reply Discord latest query`, `Checker`, and `Runner`
- define the Discord `latest` response contract, daily scan/update notification contract, run report contract, and manual Discord `fetch` trigger contract

## Testing
- Not run (docs/spec only)

## Notes
- `SPEC0.md` and `SPEC0-1diff.md` were left out of this PR; this PR contains only the finalized `spec.md` changes
- Refs #52
