### PR TITLE
fix: validate watchlist health policy and preserve Kakuyomu seed URLs

### DIFF
--- a/manga_watch/sources/kakuyomu.py
+++ b/manga_watch/sources/kakuyomu.py
@@ -31,7 +31,7 @@ class KakuyomuAdapter(SourceAdapter):
         return WorkDescriptor(
             source=self.source,
             work_id=work_id,
-            seed_url=seed_url.rstrip("/"),
+            seed_url=seed_url,
             metadata=metadata,
         )
 

--- a/manga_watch/status.py
+++ b/manga_watch/status.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
 
-from manga_watch.storage import load_state, load_watchlist
+from manga_watch.storage import load_state, load_watchlist, normalize_health_policy
 
 DEFAULT_CRAWL_SCHEDULE = "0 19 * * *"
 DEFAULT_STALE_TOLERANCE = 2.0
@@ -95,23 +95,7 @@ def default_expected_interval_seconds(*, now: int, timezone_name: str) -> int:
 
 
 def health_policy_for_entry(entry: Mapping[str, object], work_id: str) -> Dict[str, object]:
-    policy = entry.get("health_policy")
-    if policy is None:
-        return {}
-    if not isinstance(policy, Mapping):
-        raise ValueError(f"watchlist entry {work_id} health_policy must be an object")
-
-    normalized: Dict[str, object] = {}
-    expected_interval = policy.get("expected_interval_seconds")
-    if expected_interval is not None:
-        expected_interval = int(expected_interval)
-        if expected_interval <= 0:
-            raise ValueError(
-                f"watchlist entry {work_id} health_policy.expected_interval_seconds must be > 0"
-            )
-        normalized["expected_interval_seconds"] = expected_interval
-
-    return normalized
+    return normalize_health_policy(entry.get("health_policy"), work_id) or {}
 
 
 def latest_label(latest: Mapping[str, object]) -> str:

--- a/manga_watch/storage.py
+++ b/manga_watch/storage.py
@@ -140,6 +140,7 @@ def normalize_watchlist_entry(entry: Mapping[str, object]) -> Dict[str, object]:
         entry.get("history_retention"),
         field_name=f"watchlist entry {work_id} history_retention",
     )
+    health_policy = normalize_health_policy(entry.get("health_policy"), work_id)
     normalized = {
         "id": work_id,
         "source": source,
@@ -149,6 +150,8 @@ def normalize_watchlist_entry(entry: Mapping[str, object]) -> Dict[str, object]:
     }
     if history_retention is not None:
         normalized["history_retention"] = history_retention
+    if health_policy is not None:
+        normalized["health_policy"] = health_policy
     for key, value in entry.items():
         if key in normalized or value is None:
             continue
@@ -175,6 +178,33 @@ def normalize_notification_policy(policy: object, work_id: str) -> Dict[str, obj
         "mode": mode,
         "allowed_update_types": allowed_update_types,
     }
+
+
+def normalize_health_policy(
+    policy: object,
+    work_id: str,
+) -> Optional[Dict[str, object]]:
+    if policy is None:
+        return None
+    if not isinstance(policy, Mapping):
+        raise ValueError(f"watchlist entry {work_id} health_policy must be an object")
+
+    normalized: Dict[str, object] = dict(policy)
+    expected_interval = policy.get("expected_interval_seconds")
+    if expected_interval is not None:
+        try:
+            expected_interval = int(expected_interval)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"watchlist entry {work_id} health_policy.expected_interval_seconds must be an integer"
+            ) from exc
+        if expected_interval <= 0:
+            raise ValueError(
+                f"watchlist entry {work_id} health_policy.expected_interval_seconds must be > 0"
+            )
+        normalized["expected_interval_seconds"] = expected_interval
+
+    return normalized
 
 
 def normalize_allowed_update_types(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -19,6 +19,8 @@ from manga_watch.storage import (
     evaluate_notification_policy,
     latest_runtime_to_storage,
     latest_storage_to_runtime,
+    load_watchlist,
+    save_watchlist,
     validate_state,
     validate_watchlist,
 )
@@ -58,8 +60,9 @@ def watchlist_entry(
     seed_url="https://example.com/work",
     enabled=True,
     notification_policy=None,
+    health_policy=None,
 ):
-    return {
+    entry = {
         "id": work_id,
         "source": source,
         "seed_url": seed_url,
@@ -70,6 +73,9 @@ def watchlist_entry(
             "allowed_update_types": None,
         },
     }
+    if health_policy is not None:
+        entry["health_policy"] = health_policy
+    return entry
 
 
 def write_watchlist(path: Path, works):
@@ -272,6 +278,12 @@ class CheckTests(unittest.TestCase):
         self.assertEqual("kakuyomu:123", entry["id"])
         self.assertEqual("https://kakuyomu.jp/works/123", entry["seed_url"])
 
+    def test_build_watchlist_entry_preserves_kakuyomu_trailing_slash(self):
+        entry = check.build_watchlist_entry("https://kakuyomu.jp/works/123/")
+
+        self.assertEqual("kakuyomu:123", entry["id"])
+        self.assertEqual("https://kakuyomu.jp/works/123/", entry["seed_url"])
+
     def test_build_watchlist_entry_uses_stable_comic_action_work_id(self):
         fake_client = mock.Mock()
         fake_client.get_text.return_value = (
@@ -327,6 +339,66 @@ class CheckTests(unittest.TestCase):
                     ],
                 }
             )
+
+    def test_validate_watchlist_rejects_non_integer_health_policy_expected_interval_seconds(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "health_policy.expected_interval_seconds must be an integer",
+        ):
+            validate_watchlist(
+                {
+                    "version": 2,
+                    "works": [
+                        watchlist_entry(
+                            notification_policy={
+                                "mode": "all",
+                                "allowed_update_types": None,
+                            },
+                            health_policy={"expected_interval_seconds": "oops"},
+                        )
+                    ],
+                }
+            )
+
+    def test_load_watchlist_rejects_invalid_health_policy_expected_interval_seconds(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(
+                watchlist_path,
+                [
+                    {
+                        **watchlist_entry(),
+                        "health_policy": {"expected_interval_seconds": "oops"},
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "health_policy.expected_interval_seconds must be an integer",
+            ):
+                load_watchlist(str(watchlist_path))
+
+    def test_save_watchlist_rejects_invalid_health_policy_expected_interval_seconds(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "health_policy.expected_interval_seconds must be an integer",
+            ):
+                save_watchlist(
+                    {
+                        "version": 2,
+                        "works": [
+                            {
+                                **watchlist_entry(),
+                                "health_policy": {"expected_interval_seconds": "oops"},
+                            }
+                        ],
+                    },
+                    str(watchlist_path),
+                )
 
     def test_evaluate_notification_policy_rejects_unknown_allowed_update_type(self):
         with self.assertRaisesRegex(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -189,7 +189,7 @@ class SourceAdapterTests(unittest.TestCase):
                 "source": "kakuyomu",
                 "kind": "kakuyomu",
                 "workId": "kakuyomu:123",
-                "seedUrl": "https://kakuyomu.jp/works/123",
+                "seedUrl": "https://kakuyomu.jp/works/123/",
                 "series": "kakuyomu:123",
                 "numericWorkId": "123",
             },


### PR DESCRIPTION
## Issue
- Closes #67
- Parent: #68

## Changes
- validate `health_policy.expected_interval_seconds` during watchlist normalization so load/save reject malformed values before `status.py`
- reuse the same health policy normalization in `status.py` to keep one validation path
- preserve Kakuyomu input URLs as stored `seed_url`, including a trailing slash when the input had one
- add focused regression coverage for malformed health policy and Kakuyomu trailing-slash preservation

## Verification
- `.venv/bin/python -m unittest tests.test_check tests.test_sources tests.test_status tests.test_watchlist`

## Residual Risk
- Verification ran on the available local `python3` runtime because `python3.12` is not installed in this environment
