### PR TITLE
feat: add read-only Discord latest query surface

### DIFF
--- a/manga_watch/discord_latest.py
+++ b/manga_watch/discord_latest.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Callable, Dict, List, Mapping, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from manga_watch.discord_text import format_discord_link
+from manga_watch.storage import load_state, load_watchlist
+
+DEFAULT_TIMEZONE = "Asia/Tokyo"
+LATEST_COMMAND = "latest"
+HEADER_LINE = "保存済みの最新話一覧です"
+LIST_HEADER_LINE = "現在のリスト:"
+EMPTY_LINE = "- まだ保存済みの監視結果がありません"
+PARTIAL_FAILURE_WARNING = "注意: 一部作品は直近巡回で失敗しており、表示内容は保存済みデータです"
+
+
+def validated_timezone_name(timezone_name: str) -> str:
+    try:
+        ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown TZ value: {timezone_name}") from exc
+    return timezone_name
+
+
+def format_last_run(last_run_at: object, timezone_name: str) -> str:
+    if last_run_at is None:
+        return "まだ実行されていません"
+    timezone_name = validated_timezone_name(timezone_name)
+    return datetime.fromtimestamp(int(last_run_at), tz=ZoneInfo(timezone_name)).strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def series_label(work_id: str, latest: Mapping[str, object]) -> str:
+    return str(latest.get("series_title") or latest.get("series") or work_id)
+
+
+def latest_label(latest: Mapping[str, object]) -> str:
+    return str(latest.get("episode_title") or latest.get("episode_code") or latest.get("url") or "未取得")
+
+
+def render_work_line(work_id: str, latest: Mapping[str, object]) -> str:
+    series = series_label(work_id, latest)
+    if not latest:
+        return f"（未取得）　{series}"
+    return f"{format_discord_link(latest_label(latest), latest.get('url'))}　{series}"
+
+
+def build_latest_query_lines(
+    watchlist: Mapping[str, object],
+    state: Mapping[str, object],
+    *,
+    timezone_name: Optional[str] = None,
+) -> List[str]:
+    works = watchlist.get("works", [])
+    if not isinstance(works, list):
+        raise ValueError("watchlist.works must be a list")
+
+    state_works = state.get("works", {})
+    if not isinstance(state_works, Mapping):
+        raise ValueError("state.works must be an object")
+
+    timezone_name = validated_timezone_name(timezone_name or os.environ.get("TZ", DEFAULT_TIMEZONE))
+    lines = [
+        HEADER_LINE,
+        f"最終巡回: {format_last_run(state.get('last_run_at'), timezone_name)}",
+        LIST_HEADER_LINE,
+    ]
+
+    rendered_works: List[str] = []
+    partial_failure = False
+
+    for raw_entry in works:
+        if not isinstance(raw_entry, Mapping):
+            raise ValueError("watchlist entry must be an object")
+        if not bool(raw_entry.get("enabled")):
+            continue
+
+        work_id = str(raw_entry.get("id") or "").strip()
+        if not work_id:
+            raise ValueError("watchlist entry missing id")
+
+        raw_state_entry = state_works.get(work_id, {})
+        if not isinstance(raw_state_entry, Mapping):
+            raise ValueError(f"state entry {work_id} must be an object")
+
+        latest = raw_state_entry.get("latest", {})
+        if latest is None:
+            latest = {}
+        if not isinstance(latest, Mapping):
+            raise ValueError(f"state entry {work_id}.latest must be an object")
+
+        health = raw_state_entry.get("health", {})
+        if health is None:
+            health = {}
+        if not isinstance(health, Mapping):
+            raise ValueError(f"state entry {work_id}.health must be an object")
+
+        partial_failure = partial_failure or int(health.get("consecutive_failures") or 0) > 0
+        rendered_works.append(render_work_line(work_id, latest))
+
+    if not rendered_works or all(line.startswith("（未取得）") for line in rendered_works):
+        lines.append(EMPTY_LINE)
+    else:
+        lines.extend(rendered_works)
+
+    if partial_failure:
+        lines.extend(["", PARTIAL_FAILURE_WARNING])
+    return lines
+
+
+def build_latest_query_response(
+    watchlist: Mapping[str, object],
+    state: Mapping[str, object],
+    *,
+    timezone_name: Optional[str] = None,
+) -> str:
+    return "\n".join(build_latest_query_lines(watchlist, state, timezone_name=timezone_name))
+
+
+def handle_latest_query(
+    message_content: object,
+    *,
+    watchlist_path: Optional[str] = None,
+    state_path: Optional[str] = None,
+    timezone_name: Optional[str] = None,
+    watchlist_loader: Callable[[Optional[str]], Dict[str, object]] = load_watchlist,
+    state_loader: Callable[[Optional[str]], Dict[str, object]] = load_state,
+) -> Optional[str]:
+    normalized = str(message_content or "").strip()
+    if normalized != LATEST_COMMAND:
+        return None
+    watchlist = watchlist_loader(watchlist_path)
+    state = state_loader(state_path)
+    return build_latest_query_response(
+        watchlist,
+        state,
+        timezone_name=timezone_name,
+    )

--- a/manga_watch/discord_text.py
+++ b/manga_watch/discord_text.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+ELLIPSIS = "…"
+SUBTITLE_LIMIT = 8
+FALLBACK_LABEL_LIMIT = 20
+
+_HEADER_WITH_SUBTITLE_RE = re.compile(
+    r"^(?P<header>(?:"
+    r"第[0-9０-９一二三四五六七八九十百千万〇零]+話(?:その[0-9０-９一二三四五六七八九十百千万〇零]+|[前中後]編|[①②③④⑤⑥⑦⑧⑨⑩])?"
+    r"|Episode\s*\d+"
+    r"|Ep\.\s*\d+"
+    r"|#\d+"
+    r"))(?P<separator>[ \t　:：/\-‐‑‒–—―|｜]+)(?P<subtitle>.+)$"
+)
+
+
+def _is_variation_selector(char: str) -> bool:
+    codepoint = ord(char)
+    return 0xFE00 <= codepoint <= 0xFE0F or 0xE0100 <= codepoint <= 0xE01EF
+
+
+def _is_emoji_modifier(char: str) -> bool:
+    codepoint = ord(char)
+    return 0x1F3FB <= codepoint <= 0x1F3FF
+
+
+def _is_grapheme_extend(char: str) -> bool:
+    return (
+        unicodedata.combining(char) != 0
+        or _is_variation_selector(char)
+        or _is_emoji_modifier(char)
+    )
+
+
+def split_graphemes(text: str) -> list[str]:
+    clusters: list[str] = []
+    current = ""
+    join_next = False
+
+    for char in text:
+        if not current:
+            current = char
+            join_next = char == "\u200d"
+            continue
+
+        if join_next or current.endswith("\u200d") or _is_grapheme_extend(char):
+            current += char
+        else:
+            clusters.append(current)
+            current = char
+        join_next = char == "\u200d"
+
+    if current:
+        clusters.append(current)
+    return clusters
+
+
+def truncate_graphemes(text: str, limit: int) -> str:
+    clusters = split_graphemes(text)
+    if len(clusters) <= limit:
+        return text
+    if limit <= 1:
+        return ELLIPSIS
+    return "".join(clusters[: limit - 1]) + ELLIPSIS
+
+
+def truncate_episode_label(label: object) -> str:
+    normalized = str(label or "")
+    match = _HEADER_WITH_SUBTITLE_RE.match(normalized)
+    if match:
+        header = match.group("header")
+        separator = match.group("separator")
+        subtitle = match.group("subtitle")
+        return f"{header}{separator}{truncate_graphemes(subtitle, SUBTITLE_LIMIT)}"
+    return truncate_graphemes(normalized, FALLBACK_LABEL_LIMIT)
+
+
+def format_discord_link(label: object, url: object) -> str:
+    rendered_label = truncate_episode_label(label)
+    rendered_url = str(url or "").strip()
+    if not rendered_url:
+        return rendered_label
+    return f"[{rendered_label}](<{rendered_url}>)"

--- a/tests/test_discord_latest.py
+++ b/tests/test_discord_latest.py
@@ -1,0 +1,286 @@
+import json
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from manga_watch.discord_latest import (
+    EMPTY_LINE,
+    PARTIAL_FAILURE_WARNING,
+    build_latest_query_response,
+    handle_latest_query,
+)
+from manga_watch.discord_text import format_discord_link, truncate_episode_label
+
+
+class DiscordLatestTests(unittest.TestCase):
+    def make_watchlist(self, works):
+        return {"version": 2, "works": works}
+
+    def make_state(self, works, *, last_run_at=None):
+        return {
+            "version": 2,
+            "works": works,
+            "last_run_at": last_run_at,
+            "notification_outbox": [],
+        }
+
+    def write_payloads(self, watchlist, state):
+        tempdir = tempfile.TemporaryDirectory()
+        root = Path(tempdir.name)
+        watchlist_path = root / "watchlist.json"
+        state_path = root / "state.json"
+        watchlist_path.write_text(json.dumps(watchlist, ensure_ascii=False), encoding="utf-8")
+        state_path.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+        return tempdir, watchlist_path, state_path
+
+    def test_handle_latest_query_routes_only_trimmed_exact_latest(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-1",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-1",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                }
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-1": {
+                    "latest": {
+                        "series_title": "作品A",
+                        "episode_title": "第2話",
+                        "url": "https://example.com/2",
+                    },
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                }
+            },
+            last_run_at=1_700_000_000,
+        )
+        tempdir, watchlist_path, state_path = self.write_payloads(watchlist, state)
+        self.addCleanup(tempdir.cleanup)
+
+        response = handle_latest_query(
+            "  latest  ",
+            watchlist_path=str(watchlist_path),
+            state_path=str(state_path),
+            timezone_name="Asia/Tokyo",
+        )
+
+        self.assertIsNotNone(response)
+        self.assertIn("保存済みの最新話一覧です", response)
+        self.assertIsNone(
+            handle_latest_query(
+                "latest please",
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+                timezone_name="Asia/Tokyo",
+            )
+        )
+
+    def test_build_latest_query_response_uses_watchlist_order_and_ignores_disabled_and_orphans(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-b",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-b",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+                {
+                    "id": "work-a",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-a",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+                {
+                    "id": "work-disabled",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-disabled",
+                    "enabled": False,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-a": {
+                    "latest": {"series_title": "作品A", "episode_title": "第1話", "url": "https://example.com/a"},
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                },
+                "work-b": {
+                    "latest": {"series_title": "作品B", "episode_title": "第8話", "url": "https://example.com/b"},
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                },
+                "work-disabled": {
+                    "latest": {"series_title": "作品C", "episode_title": "第9話", "url": "https://example.com/c"},
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                },
+                "orphan": {
+                    "latest": {"series_title": "孤児", "episode_title": "第99話", "url": "https://example.com/orphan"},
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                },
+            },
+            last_run_at=1_700_000_000,
+        )
+
+        response = build_latest_query_response(watchlist, state, timezone_name="Asia/Tokyo")
+        lines = response.splitlines()
+
+        self.assertEqual("現在のリスト:", lines[2])
+        self.assertEqual("[第8話](<https://example.com/b>)　作品B", lines[3])
+        self.assertEqual("[第1話](<https://example.com/a>)　作品A", lines[4])
+        self.assertNotIn("作品C", response)
+        self.assertNotIn("孤児", response)
+
+    def test_build_latest_query_response_returns_empty_message_when_all_works_are_unfetched(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-1",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-1",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+                {
+                    "id": "work-2",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-2",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-1": {"latest": {}, "history": [], "health": {"consecutive_failures": 0}},
+                "work-2": {"latest": {}, "history": [], "health": {"consecutive_failures": 0}},
+            }
+        )
+
+        response = build_latest_query_response(watchlist, state, timezone_name="Asia/Tokyo")
+
+        self.assertIn("最終巡回: まだ実行されていません", response)
+        self.assertTrue(response.endswith(EMPTY_LINE))
+        self.assertNotIn("（未取得）", response)
+
+    def test_build_latest_query_response_includes_unfetched_rows_when_mixed_with_saved_results(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-1",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-1",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+                {
+                    "id": "work-2",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-2",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-1": {
+                    "latest": {
+                        "series_title": "作品A",
+                        "episode_title": "第71話 abcdefghijk",
+                        "url": "https://example.com/71",
+                    },
+                    "history": [],
+                    "health": {"consecutive_failures": 1},
+                },
+                "work-2": {"latest": {}, "history": [], "health": {"consecutive_failures": 0}},
+            }
+        )
+
+        response = build_latest_query_response(watchlist, state, timezone_name="Asia/Tokyo")
+
+        self.assertIn("[第71話 abcdefg…](<https://example.com/71>)　作品A", response)
+        self.assertIn("（未取得）　work-2", response)
+        self.assertTrue(response.endswith(PARTIAL_FAILURE_WARNING))
+
+    def test_episode_label_truncation_matches_spec_examples(self):
+        self.assertEqual("第71話 abcdefg…", truncate_episode_label("第71話 abcdefghijk"))
+        self.assertEqual("第71話 あいうえおかき…", truncate_episode_label("第71話 あいうえおかきくけ"))
+        self.assertEqual("第71話 abあいうcd…", truncate_episode_label("第71話 abあいうcdef"))
+        self.assertEqual("abcdefghijklmnopqrs…", truncate_episode_label("abcdefghijklmnopqrstu"))
+        self.assertEqual("第55話後編", truncate_episode_label("第55話後編"))
+        self.assertEqual("[第71話 abcdefg…](<https://example.com/71>)", format_discord_link("第71話 abcdefghijk", "https://example.com/71"))
+
+    def test_handle_latest_query_is_read_only_and_uses_only_injected_loaders(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-1",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-1",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                }
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-1": {
+                    "latest": {
+                        "series_title": "作品A",
+                        "episode_code": "ep-2",
+                        "url": "https://example.com/2",
+                    },
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                }
+            },
+            last_run_at=1_700_000_000,
+        )
+        tempdir, watchlist_path, state_path = self.write_payloads(watchlist, state)
+        self.addCleanup(tempdir.cleanup)
+        before_watchlist = watchlist_path.read_text(encoding="utf-8")
+        before_state = state_path.read_text(encoding="utf-8")
+        expected_timestamp = datetime.fromtimestamp(1_700_000_000, tz=ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%d %H:%M:%S %Z")
+        calls = {"watchlist": 0, "state": 0}
+
+        def watchlist_loader(path):
+            calls["watchlist"] += 1
+            self.assertEqual(str(watchlist_path), path)
+            return json.loads(before_watchlist)
+
+        def state_loader(path):
+            calls["state"] += 1
+            self.assertEqual(str(state_path), path)
+            return json.loads(before_state)
+
+        response = handle_latest_query(
+            "latest",
+            watchlist_path=str(watchlist_path),
+            state_path=str(state_path),
+            timezone_name="Asia/Tokyo",
+            watchlist_loader=watchlist_loader,
+            state_loader=state_loader,
+        )
+
+        self.assertEqual(before_watchlist, watchlist_path.read_text(encoding="utf-8"))
+        self.assertEqual(before_state, state_path.read_text(encoding="utf-8"))
+        self.assertEqual({"watchlist": 1, "state": 1}, calls)
+        self.assertIn(f"最終巡回: {expected_timestamp}", response)
+        self.assertIn("[ep-2](<https://example.com/2>)　作品A", response)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue
- closes #69
- parent #68

## What Changed
- add `manga_watch.discord_latest` as a pure read-only latest-query builder/renderer plus thin `latest` command adapter
- add `manga_watch.discord_text` for Discord-safe episode label truncation and link rendering
- add focused tests for routing, watchlist ordering, disabled/orphan exclusion, empty/unfetched behavior, partial-failure warning, and read-only loader usage

## Verification
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_latest`
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_latest tests.test_runner tests.test_status`

## Residual Risks
- this lane adds the read-only latest-query surface and its routing function, but does not add a concrete Discord transport process
