### PR TITLE
feat: add single-flight Discord fetch coordinator

### DIFF
--- a/manga_watch/discord_fetch.py
+++ b/manga_watch/discord_fetch.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from manga_watch.runner import RunCoordinator, start_fetch_run
+
+FETCH_COMMAND = "fetch"
+
+
+def handle_fetch_trigger(
+    message_content: object,
+    *,
+    coordinator: RunCoordinator,
+) -> Optional[Dict[str, object]]:
+    normalized = str(message_content or "").strip()
+    if normalized != FETCH_COMMAND:
+        return None
+    return start_fetch_run(coordinator)

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -607,7 +607,7 @@ class RunCoordinator:
         }
 
 
-def handle_fetch_trigger(coordinator: RunCoordinator) -> Dict[str, object]:
+def start_fetch_run(coordinator: RunCoordinator) -> Dict[str, object]:
     outcome = coordinator.start_background(TRIGGER_SOURCE_DISCORD_FETCH)
     if outcome.get("rejected"):
         outcome["message"] = FETCH_REJECTED_MESSAGE

--- a/tests/test_discord_fetch.py
+++ b/tests/test_discord_fetch.py
@@ -1,0 +1,57 @@
+import unittest
+
+from manga_watch.discord_fetch import handle_fetch_trigger
+from manga_watch.runner import (
+    FETCH_ACCEPTED_MESSAGE,
+    TRIGGER_SOURCE_DISCORD_FETCH,
+)
+
+
+class RecordingCoordinator:
+    def __init__(self, outcome):
+        self.outcome = dict(outcome)
+        self.calls = []
+
+    def start_background(self, trigger_source):
+        self.calls.append(trigger_source)
+        return dict(self.outcome)
+
+
+class DiscordFetchTests(unittest.TestCase):
+    def test_handle_fetch_trigger_routes_only_trimmed_exact_fetch(self):
+        coordinator = RecordingCoordinator(
+            {
+                "ok": True,
+                "accepted": True,
+                "background": True,
+                "timestamp": "2026-03-08 00:00:00 JST",
+                "triggerSource": TRIGGER_SOURCE_DISCORD_FETCH,
+            }
+        )
+
+        response = handle_fetch_trigger("fetch", coordinator=coordinator)
+
+        self.assertEqual([TRIGGER_SOURCE_DISCORD_FETCH], coordinator.calls)
+        self.assertIsNotNone(response)
+        self.assertTrue(response["accepted"])
+        self.assertEqual(FETCH_ACCEPTED_MESSAGE, response["message"])
+        self.assertEqual(TRIGGER_SOURCE_DISCORD_FETCH, response["triggerSource"])
+        self.assertIsNone(handle_fetch_trigger("fetch now", coordinator=coordinator))
+        self.assertEqual([TRIGGER_SOURCE_DISCORD_FETCH], coordinator.calls)
+
+    def test_handle_fetch_trigger_accepts_whitespace_trimmed_fetch(self):
+        coordinator = RecordingCoordinator(
+            {
+                "ok": True,
+                "accepted": True,
+                "background": True,
+                "timestamp": "2026-03-08 00:00:00 JST",
+                "triggerSource": TRIGGER_SOURCE_DISCORD_FETCH,
+            }
+        )
+
+        response = handle_fetch_trigger("  fetch  ", coordinator=coordinator)
+
+        self.assertEqual([TRIGGER_SOURCE_DISCORD_FETCH], coordinator.calls)
+        self.assertIsNotNone(response)
+        self.assertEqual(FETCH_ACCEPTED_MESSAGE, response["message"])

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -27,9 +27,9 @@ from manga_watch.runner import (
     TRIGGER_SOURCE_STARTUP,
     RunCoordinator,
     RunnerConfig,
-    handle_fetch_trigger,
     replay_outbox_once,
     run_once,
+    start_fetch_run,
 )
 from manga_watch.storage import load_state, save_state
 
@@ -641,7 +641,7 @@ class RunnerTests(unittest.TestCase):
             error_logger=lambda _: self.fail("unexpected error log"),
         )
 
-        outcome = handle_fetch_trigger(coordinator)
+        outcome = start_fetch_run(coordinator)
 
         self.assertTrue(outcome["ok"])
         self.assertTrue(outcome["accepted"])
@@ -676,7 +676,7 @@ class RunnerTests(unittest.TestCase):
             error_logger=lambda _: self.fail("unexpected error log"),
         )
 
-        fetch_outcome = handle_fetch_trigger(coordinator)
+        fetch_outcome = start_fetch_run(coordinator)
         self.assertTrue(fetch_outcome["accepted"])
         self.assertTrue(checker_started.wait(0.5))
 
@@ -710,7 +710,7 @@ class RunnerTests(unittest.TestCase):
             error_logger=lambda _: self.fail("unexpected error log"),
         )
 
-        fetch_outcome = handle_fetch_trigger(coordinator)
+        fetch_outcome = start_fetch_run(coordinator)
         self.assertTrue(fetch_outcome["accepted"])
         self.assertTrue(checker_started.wait(0.5))
 
@@ -746,11 +746,11 @@ class RunnerTests(unittest.TestCase):
             error_logger=errors.append,
         )
 
-        first_outcome = handle_fetch_trigger(coordinator)
+        first_outcome = start_fetch_run(coordinator)
         self.assertTrue(first_outcome["accepted"])
         self.wait_until(lambda: not coordinator.is_running())
 
-        second_outcome = handle_fetch_trigger(coordinator)
+        second_outcome = start_fetch_run(coordinator)
         self.assertTrue(second_outcome["accepted"])
         self.wait_until(lambda: not coordinator.is_running())
 
@@ -790,11 +790,11 @@ class RunnerTests(unittest.TestCase):
             error_logger=lambda _: self.fail("unexpected error log"),
         )
 
-        accepted_outcome = handle_fetch_trigger(coordinator)
+        accepted_outcome = start_fetch_run(coordinator)
         self.assertTrue(accepted_outcome["accepted"])
         self.assertTrue(checker_started.wait(0.5))
 
-        rejected_outcome = handle_fetch_trigger(coordinator)
+        rejected_outcome = start_fetch_run(coordinator)
 
         self.assertFalse(rejected_outcome["ok"])
         self.assertTrue(rejected_outcome["rejected"])


### PR DESCRIPTION
## Issue
- closes #70
- parent #68

## What Changed
- add a shared `RunCoordinator` so startup, scheduled, and Discord `fetch` all pass through the same single-flight contract
- propagate `trigger_source` through the success and failure reporting paths
- add `manga_watch.discord_fetch.handle_fetch_trigger()` as the exact-match Discord `fetch` routing adapter and keep coordinator execution behind `start_fetch_run()`
- add focused tests for exact-match routing, whitespace-trimmed `fetch`, idle accept, startup reject, scheduled reject, re-accept after failure, and reject-without-side-effects

## Verification
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_fetch tests.test_runner`

## Residual Risks
- this lane keeps the Phase 1 in-process trigger model and does not introduce multi-process coordination or durable queuing
