### PR TITLE
feat: implement Discord outbound daily notification and run report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # comic_crawler
 
-Docker コンテナ 1 つで定期クロールし、`stdout` と generic webhook に新着通知 event を送れる漫画更新監視アプリです。run report は毎回標準出力に出します。Issue #7 の cutover 以降、runtime は `watchlist/state v2` のみを読み書きし、Issue #17 以降は state v2 に更新履歴と未読イベントも保持します。
+Docker コンテナ 1 つで定期クロールし、generic notifier backend (`stdout` / webhook) に update event を送れる漫画更新監視アプリです。Discord surface は別契約で、daily notification を main channel、run report を run-report channel へ送ります。stdout/stderr はローカル運用ログとして引き続き使います。Issue #7 の cutover 以降、runtime は `watchlist/state v2` のみを読み書きし、Issue #17 以降は state v2 に更新履歴と未読イベントも保持します。
 
 ## Python 3.12 baseline
 
@@ -14,7 +14,8 @@ Docker / ローカル開発 / 将来の CI はすべて Python `3.12` を単一�
 3. source adapter が最新エピソードを取得する
 4. `manga_watch/state.json` の state v2 と比較する
 5. 更新があれば configured notifier backend(s) に update event を fan-out する
-6. 毎回 run report を標準出力に出す
+6. Discord main channel に daily notification を送り、Discord run-report channel に run report を送る
+7. 同じ内容を必要に応じて標準出力 / 標準エラーにも残す
 
 checker の出力契約は JSON のままです。
 
@@ -102,6 +103,7 @@ checker は watchlist を並列に処理しますが、`updates` / `errors.sourc
 - `history[].gap.estimated_new_episode_count`: `episodeTitle` / `pageTitle` から話数を比較できたときだけ入る推定件数
 - `unread.event_ids`: 未読イベントの source of truth
 - `health`: `last_checked_at`, `last_success_at`, `consecutive_failures`
+- root `discord_delivery.daily_notification`: Discord main channel 向け daily notification の durable dedupe / pending state
 
 履歴保持は作品ごとの `history_retention` で上書きでき、未指定時は既定値 20 件です。trim するときは「未読は全件保持 + 既読は最新 N 件のみ保持」を守ります。必要なら watchlist 側で `health_policy.expected_interval_seconds` を指定し、stale 判定の期待巡回間隔を作品単位で上書きできます。詳細な schema と migration contract は [spec.md](spec.md) を source of truth とします。
 
@@ -274,6 +276,9 @@ compose は `manga_watch/watchlist.json` を read-only mount し、state v2 は 
 - `MANGA_WATCH_NOTIFIER_BACKENDS`: required。comma-separated backend list。現在値は `stdout`, `webhook`
 - `MANGA_WATCH_WEBHOOK_URL`: `webhook` backend を使うときの POST 先 URL
 - `MANGA_WATCH_WEBHOOK_TIMEOUT`: webhook timeout 秒。既定値は `10`
+- `DISCORD_BOT_TOKEN`: Discord main/run-report channel に送る bot token
+- `DISCORD_MAIN_CHANNEL_ID`: daily notification の送信先 channel id
+- `DISCORD_RUN_REPORT_CHANNEL_ID`: run report の送信先 channel id
 - `TZ`: スケジュール計算の timezone。既定値は `Asia/Tokyo`
 - `CRAWL_SCHEDULE`: cron 形式。既定値は `0 19 * * *`
 - `CRAWL_INTERVAL`: 秒単位の固定間隔。`CRAWL_SCHEDULE` と同時指定は不可
@@ -303,10 +308,13 @@ python3.12 -m venv .venv
 .venv/bin/python -m unittest tests.test_source_drift tests.test_sources tests.test_update_classification tests.test_check tests.test_status tests.test_watchlist tests.test_runner tests.test_migrate_v2 tests.test_backlog
 ```
 
-runner をローカル起動する場合は notifier 環境変数を入れてから実行します。
+runner をローカル起動する場合は notifier 環境変数と Discord outbound 環境変数を入れてから実行します。
 
 ```bash
 export MANGA_WATCH_NOTIFIER_BACKENDS=stdout
+export DISCORD_BOT_TOKEN=...
+export DISCORD_MAIN_CHANNEL_ID=...
+export DISCORD_RUN_REPORT_CHANNEL_ID=...
 .venv/bin/python -m manga_watch.runner
 .venv/bin/python -m manga_watch.replay_outbox
 ```
@@ -410,9 +418,11 @@ Post-rollback smoke checks:
 - `manga_watch/source_drift.py`: live source drift canary と fixture refresh 導線
 - `manga_watch/status.py`: status CLI 向けの health 集約と text / JSON 表示
 - `manga_watch/storage.py`: watchlist/state v2 validation と atomic write
+- `manga_watch/discord_text.py`: Discord 表示向け label fallback / truncate helper
+- `manga_watch/discord_outbound.py`: Discord daily notification / run report formatter と sender
 - `manga_watch/notifier.py`: update event schema + stdout/webhook backend
 - `manga_watch/watchlist.py`: `watchlist add <url>` CLI
-- `manga_watch/runner.py`: スケジューラ + notifier fan-out + run report logging
+- `manga_watch/runner.py`: スケジューラ + notifier fan-out + Discord outbound orchestration
 - `manga_watch/update_classification.py`: 更新種別と既定通知対象の分類ロジック
 - `manga_watch/watchlist.json`: watchlist v2 sample
 - `manga_watch/state.json`: state v2 sample

--- a/manga_watch/discord_latest.py
+++ b/manga_watch/discord_latest.py
@@ -5,7 +5,11 @@ from datetime import datetime
 from typing import Callable, Dict, List, Mapping, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from manga_watch.discord_text import format_discord_link
+from manga_watch.discord_text import (
+    episode_label_for_snapshot,
+    format_discord_link,
+    series_label_for_snapshot,
+)
 from manga_watch.storage import load_state, load_watchlist
 
 DEFAULT_TIMEZONE = "Asia/Tokyo"
@@ -32,11 +36,11 @@ def format_last_run(last_run_at: object, timezone_name: str) -> str:
 
 
 def series_label(work_id: str, latest: Mapping[str, object]) -> str:
-    return str(latest.get("series_title") or latest.get("series") or work_id)
+    return series_label_for_snapshot(work_id, latest)
 
 
 def latest_label(latest: Mapping[str, object]) -> str:
-    return str(latest.get("episode_title") or latest.get("episode_code") or latest.get("url") or "未取得")
+    return episode_label_for_snapshot(latest)
 
 
 def render_work_line(work_id: str, latest: Mapping[str, object]) -> str:

--- a/manga_watch/discord_outbound.py
+++ b/manga_watch/discord_outbound.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import requests
+
+from manga_watch.discord_text import (
+    episode_label_for_snapshot,
+    series_label_for_snapshot,
+    truncate_episode_label,
+)
+
+DEFAULT_DISCORD_API_BASE_URL = "https://discord.com/api/v10"
+DEFAULT_DISCORD_TIMEOUT = 10
+DEFAULT_TIMEZONE = "Asia/Tokyo"
+DISCORD_DELIVERY_STATE_KEY = "discord_delivery"
+DAILY_NOTIFICATION_STATE_KEY = "daily_notification"
+RUN_REPORT_FAILURE_HEADLINE = "run report 自体の送信に失敗しました"
+
+
+def _coerce_text(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def validated_timezone_name(timezone_name: str) -> str:
+    try:
+        ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown TZ value: {timezone_name}") from exc
+    return timezone_name
+
+
+class DiscordTransport(Protocol):
+    def send_message(self, channel_id: str, content: str) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class DiscordOutboundConfig:
+    bot_token: str
+    main_channel_id: str
+    run_report_channel_id: str
+    api_base_url: str = DEFAULT_DISCORD_API_BASE_URL
+    timeout: int = DEFAULT_DISCORD_TIMEOUT
+
+    @classmethod
+    def from_env(cls) -> "DiscordOutboundConfig":
+        bot_token = _coerce_text(os.environ.get("DISCORD_BOT_TOKEN"))
+        if not bot_token:
+            raise ValueError("DISCORD_BOT_TOKEN is required")
+
+        main_channel_id = _coerce_text(os.environ.get("DISCORD_MAIN_CHANNEL_ID"))
+        if not main_channel_id:
+            raise ValueError("DISCORD_MAIN_CHANNEL_ID is required")
+
+        run_report_channel_id = _coerce_text(os.environ.get("DISCORD_RUN_REPORT_CHANNEL_ID"))
+        if not run_report_channel_id:
+            raise ValueError("DISCORD_RUN_REPORT_CHANNEL_ID is required")
+
+        return cls(
+            bot_token=bot_token,
+            main_channel_id=main_channel_id,
+            run_report_channel_id=run_report_channel_id,
+        )
+
+
+class DiscordChannelClient:
+    def __init__(
+        self,
+        config: DiscordOutboundConfig,
+        *,
+        session: Optional[requests.Session] = None,
+    ):
+        self.config = config
+        self.session = session or requests.Session()
+
+    def send_message(self, channel_id: str, content: str) -> None:
+        normalized_channel_id = _coerce_text(channel_id)
+        if not normalized_channel_id:
+            raise RuntimeError("Discord channel_id is required")
+
+        try:
+            response = self.session.post(
+                f"{self.config.api_base_url}/channels/{normalized_channel_id}/messages",
+                json={
+                    "content": str(content),
+                    "allowed_mentions": {"parse": []},
+                },
+                headers={
+                    "Authorization": f"Bot {self.config.bot_token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=self.config.timeout,
+                allow_redirects=False,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Discord delivery failed: {exc}") from exc
+
+        if 200 <= response.status_code < 300:
+            return
+
+        detail = response.text.strip().replace("\n", " ")
+        raise RuntimeError(f"Discord returned HTTP {response.status_code}: {detail[:300]}")
+
+
+def _daily_notification_state(state: Dict[str, object]) -> Dict[str, object]:
+    discord_delivery = state.setdefault(DISCORD_DELIVERY_STATE_KEY, {})
+    if not isinstance(discord_delivery, dict):
+        discord_delivery = {}
+        state[DISCORD_DELIVERY_STATE_KEY] = discord_delivery
+
+    daily_notification = discord_delivery.setdefault(
+        DAILY_NOTIFICATION_STATE_KEY,
+        {
+            "delivered_latest_keys": {},
+            "pending_messages": [],
+        },
+    )
+    if not isinstance(daily_notification, dict):
+        daily_notification = {
+            "delivered_latest_keys": {},
+            "pending_messages": [],
+        }
+        discord_delivery[DAILY_NOTIFICATION_STATE_KEY] = daily_notification
+    return daily_notification
+
+
+def daily_notification_key(update: Mapping[str, object]) -> Optional[Tuple[str, str]]:
+    work_id = _coerce_text(update.get("id") or update.get("work_id"))
+    latest = update.get("to", {}) or {}
+    if not isinstance(latest, Mapping):
+        latest = {}
+    latest_key = _coerce_text(
+        latest.get("latest_key")
+        or latest.get("latestKey")
+        or latest.get("episode_code")
+        or latest.get("episodeCode")
+        or latest.get("url")
+    )
+    if not work_id or not latest_key:
+        return None
+    return work_id, latest_key
+
+
+def _pending_daily_notification_keys(state: Mapping[str, object]) -> set[Tuple[str, str]]:
+    discord_delivery = state.get(DISCORD_DELIVERY_STATE_KEY, {})
+    if not isinstance(discord_delivery, Mapping):
+        return set()
+    daily_notification = discord_delivery.get(DAILY_NOTIFICATION_STATE_KEY, {})
+    if not isinstance(daily_notification, Mapping):
+        return set()
+    pending_messages = daily_notification.get("pending_messages", [])
+    if not isinstance(pending_messages, list):
+        return set()
+
+    keys: set[Tuple[str, str]] = set()
+    for entry in pending_messages:
+        if not isinstance(entry, Mapping):
+            continue
+        message_keys = entry.get("message_keys", [])
+        if not isinstance(message_keys, list):
+            continue
+        for message_key in message_keys:
+            if not isinstance(message_key, Mapping):
+                continue
+            work_id = _coerce_text(message_key.get("work_id"))
+            latest_key = _coerce_text(message_key.get("latest_key"))
+            if work_id and latest_key:
+                keys.add((work_id, latest_key))
+    return keys
+
+
+def pending_daily_notification_count(state: Mapping[str, object]) -> int:
+    discord_delivery = state.get(DISCORD_DELIVERY_STATE_KEY, {})
+    if not isinstance(discord_delivery, Mapping):
+        return 0
+    daily_notification = discord_delivery.get(DAILY_NOTIFICATION_STATE_KEY, {})
+    if not isinstance(daily_notification, Mapping):
+        return 0
+    pending_messages = daily_notification.get("pending_messages", [])
+    return len(pending_messages) if isinstance(pending_messages, list) else 0
+
+
+def _delivered_latest_keys(state: Mapping[str, object]) -> Dict[str, str]:
+    discord_delivery = state.get(DISCORD_DELIVERY_STATE_KEY, {})
+    if not isinstance(discord_delivery, Mapping):
+        return {}
+    daily_notification = discord_delivery.get(DAILY_NOTIFICATION_STATE_KEY, {})
+    if not isinstance(daily_notification, Mapping):
+        return {}
+    delivered = daily_notification.get("delivered_latest_keys", {})
+    if not isinstance(delivered, Mapping):
+        return {}
+
+    normalized: Dict[str, str] = {}
+    for work_id, entry in delivered.items():
+        latest_key = None
+        if isinstance(entry, Mapping):
+            latest_key = _coerce_text(entry.get("latest_key"))
+        else:
+            latest_key = _coerce_text(entry)
+        if latest_key:
+            normalized[str(work_id)] = latest_key
+    return normalized
+
+
+def format_daily_notification_line(update: Mapping[str, object]) -> str:
+    work_id = str(update.get("id") or update.get("work_id") or "")
+    before = update.get("from", {}) or {}
+    if not isinstance(before, Mapping):
+        before = {}
+    after = update.get("to", {}) or {}
+    if not isinstance(after, Mapping):
+        after = {}
+
+    series = series_label_for_snapshot(work_id, after)
+    latest_label = truncate_episode_label(episode_label_for_snapshot(after, fallback="未取得"))
+    previous_label = truncate_episode_label(episode_label_for_snapshot(before, fallback="未取得"))
+    rendered_url = _coerce_text(after.get("url"))
+    text = f"{series}：{latest_label}"
+    if rendered_url:
+        text = f"[{text}](<{rendered_url}>)"
+    return f"{text}←{previous_label}"
+
+
+def build_daily_notification_message(
+    updates: Sequence[Mapping[str, object]],
+    *,
+    now_ts: float,
+    timezone_name: str,
+) -> str:
+    local_date = datetime.fromtimestamp(
+        now_ts,
+        tz=ZoneInfo(validated_timezone_name(timezone_name or DEFAULT_TIMEZONE)),
+    ).strftime("%Y-%m-%d")
+    lines = [f"新着エピソードを検知しました（{local_date}）"]
+    lines.extend(format_daily_notification_line(update) for update in updates)
+    return "\n".join(lines)
+
+
+def enqueue_daily_notification(
+    state: Dict[str, object],
+    *,
+    updates: Sequence[Mapping[str, object]],
+    channel_id: str,
+    now_ts: float,
+    timezone_name: str,
+    created_at: str,
+) -> Dict[str, object]:
+    delivered = _delivered_latest_keys(state)
+    pending_keys = _pending_daily_notification_keys(state)
+    queued_updates: List[Mapping[str, object]] = []
+    message_keys: List[Dict[str, str]] = []
+
+    for update in updates:
+        message_key = daily_notification_key(update)
+        if message_key is None:
+            continue
+        work_id, latest_key = message_key
+        if delivered.get(work_id) == latest_key or message_key in pending_keys:
+            continue
+        queued_updates.append(update)
+        message_keys.append({"work_id": work_id, "latest_key": latest_key})
+
+    if not queued_updates:
+        return {
+            "queued": False,
+            "candidateUpdateCount": 0,
+        }
+
+    daily_notification = _daily_notification_state(state)
+    pending_messages = daily_notification.setdefault("pending_messages", [])
+    if not isinstance(pending_messages, list):
+        pending_messages = []
+        daily_notification["pending_messages"] = pending_messages
+    pending_messages.append(
+        {
+            "channel_id": channel_id,
+            "content": build_daily_notification_message(
+                queued_updates,
+                now_ts=now_ts,
+                timezone_name=timezone_name,
+            ),
+            "message_keys": message_keys,
+            "created_at": created_at,
+            "attempt_count": 0,
+            "last_attempted_at": None,
+            "last_error": None,
+        }
+    )
+    return {
+        "queued": True,
+        "candidateUpdateCount": len(queued_updates),
+    }
+
+
+def deliver_daily_notifications(
+    state: Dict[str, object],
+    *,
+    client: DiscordTransport,
+    attempted_at: str,
+) -> Dict[str, object]:
+    daily_notification = _daily_notification_state(state)
+    pending_messages = list(daily_notification.get("pending_messages", []) or [])
+    delivered_latest_keys = daily_notification.setdefault("delivered_latest_keys", {})
+    if not isinstance(delivered_latest_keys, dict):
+        delivered_latest_keys = {}
+        daily_notification["delivered_latest_keys"] = delivered_latest_keys
+
+    delivered_count = 0
+    errors: List[str] = []
+    remaining_messages: List[Dict[str, object]] = []
+    blocked = False
+
+    for raw_entry in pending_messages:
+        entry = dict(raw_entry)
+        if blocked:
+            remaining_messages.append(entry)
+            continue
+        try:
+            client.send_message(str(entry.get("channel_id") or ""), str(entry.get("content") or ""))
+            delivered_count += 1
+            for message_key in entry.get("message_keys", []):
+                if not isinstance(message_key, Mapping):
+                    continue
+                work_id = _coerce_text(message_key.get("work_id"))
+                latest_key = _coerce_text(message_key.get("latest_key"))
+                if work_id and latest_key:
+                    delivered_latest_keys[work_id] = {
+                        "latest_key": latest_key,
+                        "delivered_at": attempted_at,
+                    }
+        except Exception as exc:
+            blocked = True
+            entry["attempt_count"] = int(entry.get("attempt_count", 0) or 0) + 1
+            entry["last_attempted_at"] = attempted_at
+            entry["last_error"] = str(exc)
+            remaining_messages.append(entry)
+            errors.append(f"daily_notification: {exc}")
+
+    daily_notification["pending_messages"] = remaining_messages
+    return {
+        "attemptedCount": len(pending_messages),
+        "deliveredCount": delivered_count,
+        "remainingCount": len(remaining_messages),
+        "errors": errors,
+    }
+
+
+def _format_checker_error_lines(errors: Mapping[str, Sequence[Mapping[str, object]]]) -> List[str]:
+    lines: List[str] = []
+
+    for error in errors.get("sources", []):
+        item = str(error.get("id") or error.get("url") or "unknown")
+        phase = str(error.get("phase") or "unknown")
+        kind = str(error.get("kind") or "runtime")
+        message = str(error.get("message") or "unknown error")
+        lines.append(f"- source/{kind} [{phase}] {item}: {message}")
+
+    for error in errors.get("run", []):
+        stage = str(error.get("stage") or "unknown")
+        kind = str(error.get("kind") or "runtime")
+        message = str(error.get("message") or "unknown error")
+        lines.append(f"- run/{kind} [{stage}]: {message}")
+
+    return lines
+
+
+def build_run_report_message(
+    *,
+    timestamp: str,
+    trigger_source: str,
+    update_count: int,
+    notified_update_count: int,
+    suppressed_update_count: int,
+    outbox_pending_count: int,
+    daily_notification_sent: bool,
+    daily_notification_pending_count: int,
+    errors: Mapping[str, Sequence[Mapping[str, object]]],
+    delivery_failures: Sequence[str],
+    state_lines: Sequence[str],
+) -> str:
+    source_failures = len(errors.get("sources", []))
+    run_failures = len(errors.get("run", []))
+    delivery_failure_count = len(delivery_failures)
+    if run_failures > 0 or delivery_failure_count > 0:
+        headline = "巡回実行に失敗しました"
+    elif source_failures > 0:
+        headline = "巡回実行に一部失敗がありました"
+    else:
+        headline = "巡回実行しました"
+
+    lines = [
+        f"{headline} ({timestamp})",
+        f"トリガー: {trigger_source}",
+        f"更新検知: {update_count}件",
+        f"通知対象: {notified_update_count}件",
+        f"通知抑制: {suppressed_update_count}件",
+        f"daily notification: {'送信した' if daily_notification_sent else '送信なし'}",
+        f"generic notifier outbox残件: {outbox_pending_count}件",
+        f"Discord daily pending: {daily_notification_pending_count}件",
+        f"source failure: {source_failures}件",
+        f"run-level failure: {run_failures}件",
+        f"delivery failure: {delivery_failure_count}件",
+    ]
+    checker_error_lines = _format_checker_error_lines(errors)
+    if checker_error_lines:
+        lines.append("failure details:")
+        lines.extend(checker_error_lines)
+    if delivery_failures:
+        if not checker_error_lines:
+            lines.append("failure details:")
+        lines.extend(f"- delivery: {failure}" for failure in delivery_failures)
+    lines.append("現在のリスト:")
+    lines.extend(state_lines)
+    return "\n".join(lines)
+
+
+def format_run_report_delivery_failure(
+    *,
+    timestamp: str,
+    trigger_source: str,
+    exc: Exception,
+) -> str:
+    return "\n".join(
+        [
+            f"{RUN_REPORT_FAILURE_HEADLINE} ({timestamp})",
+            f"トリガー: {trigger_source}",
+            f"エラー: {exc.__class__.__name__}: {exc}",
+        ]
+    )

--- a/manga_watch/discord_text.py
+++ b/manga_watch/discord_text.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from typing import Mapping
 
 ELLIPSIS = "…"
 SUBTITLE_LIMIT = 8
@@ -76,6 +77,30 @@ def truncate_episode_label(label: object) -> str:
         subtitle = match.group("subtitle")
         return f"{header}{separator}{truncate_graphemes(subtitle, SUBTITLE_LIMIT)}"
     return truncate_graphemes(normalized, FALLBACK_LABEL_LIMIT)
+
+
+def series_label_for_snapshot(work_id: object, snapshot: Mapping[str, object]) -> str:
+    return str(
+        snapshot.get("series_title")
+        or snapshot.get("seriesTitle")
+        or snapshot.get("series")
+        or work_id
+    )
+
+
+def episode_label_for_snapshot(
+    snapshot: Mapping[str, object],
+    *,
+    fallback: str = "未取得",
+) -> str:
+    return str(
+        snapshot.get("episode_title")
+        or snapshot.get("episodeTitle")
+        or snapshot.get("episode_code")
+        or snapshot.get("episodeCode")
+        or snapshot.get("url")
+        or fallback
+    )
 
 
 def format_discord_link(label: object, url: object) -> str:

--- a/manga_watch/replay_outbox.py
+++ b/manga_watch/replay_outbox.py
@@ -6,7 +6,7 @@ from manga_watch.runner import RunnerConfig, replay_outbox_once
 
 def main() -> int:
     try:
-        config = RunnerConfig.from_env()
+        config = RunnerConfig.from_env(require_discord=False)
     except Exception as exc:
         print(f"[replay_outbox] configuration error: {exc}", file=sys.stderr)
         return 2

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -8,7 +8,18 @@ from datetime import datetime, timedelta
 from typing import Callable, Dict, List, Mapping, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from manga_watch.check import run_check
+from manga_watch.check import CheckRunError, run_check
+from manga_watch.discord_outbound import (
+    DiscordChannelClient,
+    DiscordOutboundConfig,
+    DiscordTransport,
+    build_run_report_message,
+    deliver_daily_notifications,
+    enqueue_daily_notification,
+    format_run_report_delivery_failure,
+    pending_daily_notification_count,
+)
+from manga_watch.discord_text import episode_label_for_snapshot, series_label_for_snapshot
 from manga_watch.notifier import (
     Notifier,
     NotifierConfig,
@@ -88,19 +99,20 @@ def partition_updates_by_notification_policy(
 
 
 def format_state_lines(state: Dict[str, object]) -> List[str]:
+    if not isinstance(state, Mapping):
+        return ["- 最新状態を取得できませんでした"]
+
     works = state.get("works", {})
-    if not isinstance(works, dict) or not works:
+    if not isinstance(works, Mapping) or not works:
         return ["- まだ監視結果なし"]
 
     lines: List[str] = []
     for item_id in works.keys():
         latest = (works[item_id] or {}).get("latest", {})
-        if not isinstance(latest, dict):
+        if not isinstance(latest, Mapping):
             latest = {}
-        series = (
-            str(latest.get("series_title") or latest.get("series") or item_id)
-        )
-        episode = str(latest.get("episode_title") or latest.get("episode_code") or latest.get("url") or "不明")
+        series = series_label_for_snapshot(item_id, latest)
+        episode = episode_label_for_snapshot(latest, fallback="不明")
         lines.append(f"- {series}：{episode}")
     return lines
 
@@ -271,61 +283,6 @@ def checker_error_count(errors: Dict[str, List[Dict[str, object]]]) -> int:
     return len(errors["sources"]) + len(errors["run"])
 
 
-def format_checker_error_lines(errors: Dict[str, List[Dict[str, object]]]) -> List[str]:
-    total = checker_error_count(errors)
-    lines = [f"エラー: {total}件"]
-    if total == 0:
-        return lines
-
-    lines.append("エラー詳細:")
-    for error in errors["sources"]:
-        item = str(error.get("id") or error.get("url") or "unknown")
-        phase = str(error.get("phase") or "unknown")
-        kind = str(error.get("kind") or "runtime")
-        message = str(error.get("message") or "unknown error")
-        lines.append(f"- source/{kind} [{phase}] {item}: {message}")
-
-    for error in errors["run"]:
-        stage = str(error.get("stage") or "unknown")
-        kind = str(error.get("kind") or "runtime")
-        message = str(error.get("message") or "unknown error")
-        lines.append(f"- run/{kind} [{stage}]: {message}")
-
-    return lines
-
-
-def format_run_report(
-    *,
-    timestamp: str,
-    trigger_source: str,
-    updates: List[Dict[str, object]],
-    errors: Dict[str, List[Dict[str, object]]],
-    state: Dict[str, object],
-    notified_update_count: int,
-    suppressed_update_count: int,
-    outbox_pending_count: int,
-    update_notification_sent: bool,
-) -> str:
-    degraded = checker_error_count(errors) > 0
-    lines = [
-        f"{'巡回実行に一部失敗がありました' if degraded else '巡回実行しました'} ({timestamp})",
-        f"トリガー: {trigger_source}",
-        f"更新検知: {len(updates)}件",
-        f"通知対象: {notified_update_count}件",
-        f"通知抑制: {suppressed_update_count}件",
-        f"通知outbox残件: {outbox_pending_count}件",
-        f"通知: {'送信した' if update_notification_sent else '送信なし'}",
-    ]
-    lines.extend(format_checker_error_lines(errors))
-    lines.extend(
-        [
-        "現在のリスト:",
-        ]
-    )
-    lines.extend(format_state_lines(state))
-    return "\n".join(lines)
-
-
 def format_failure_report(timestamp: str, trigger_source: str, exc: Exception) -> str:
     return "\n".join(
         [
@@ -362,6 +319,15 @@ def format_replay_failure_report(timestamp: str, exc: Exception) -> str:
     )
 
 
+def runner_error_record(stage: str, exc: Exception) -> Dict[str, str]:
+    return {
+        "stage": stage,
+        "kind": "runtime",
+        "errorType": exc.__class__.__name__,
+        "message": str(exc),
+    }
+
+
 @dataclass(frozen=True)
 class RunnerConfig:
     timezone_name: str
@@ -370,9 +336,10 @@ class RunnerConfig:
     crawl_interval: Optional[int]
     run_on_startup: bool
     notifier_config: NotifierConfig
+    discord_outbound_config: Optional[DiscordOutboundConfig] = None
 
     @classmethod
-    def from_env(cls) -> "RunnerConfig":
+    def from_env(cls, *, require_discord: bool = True) -> "RunnerConfig":
         crawl_schedule = os.environ.get("CRAWL_SCHEDULE")
         crawl_interval_raw = os.environ.get("CRAWL_INTERVAL")
         if crawl_schedule and crawl_interval_raw:
@@ -400,6 +367,11 @@ class RunnerConfig:
             crawl_interval=crawl_interval,
             run_on_startup=parse_bool(os.environ.get("RUN_ON_STARTUP"), default=True),
             notifier_config=NotifierConfig.from_env(),
+            discord_outbound_config=(
+                DiscordOutboundConfig.from_env()
+                if require_discord
+                else None
+            ),
         )
 
 
@@ -432,6 +404,7 @@ def run_once(
     *,
     notifier: Optional[Notifier] = None,
     named_notifiers: Optional[Mapping[str, Notifier]] = None,
+    discord_client: Optional[DiscordTransport] = None,
     checker: Callable[[str], Dict[str, object]] = run_check,
     state_loader: Callable[[], Dict[str, object]] = load_state,
     state_saver: Callable[[Dict[str, object]], None] = save_state,
@@ -445,96 +418,188 @@ def run_once(
         notifier=notifier,
         named_notifiers=named_notifiers,
     )
+    resolved_discord_client = discord_client
+    if resolved_discord_client is None and config.discord_outbound_config is not None:
+        resolved_discord_client = DiscordChannelClient(config.discord_outbound_config)
     now = now_fn()
     timestamp = format_timestamp(now, config.timezone_name)
     detected_at = detected_at_for_timestamp(now)
+    updates: List[Dict[str, object]] = []
+    errors: Dict[str, List[Dict[str, object]]] = {"sources": [], "run": []}
+    delivery_failures: List[str] = []
+    state: Optional[Dict[str, object]] = None
+    primary_failure: Optional[Exception] = None
+    run_report_delivery_error: Optional[Exception] = None
     update_count = 0
-    error_count = 0
     notified_update_count = 0
     suppressed_update_count = 0
     outbox_pending_count = 0
+    daily_notification_sent = False
 
     try:
         result = checker(config.watchlist_path)
         updates = result.get("updates", [])
         if not isinstance(updates, list):
             raise RuntimeError("checker returned invalid updates payload")
-        update_count = len(updates)
         errors = normalize_checker_errors(result)
-        error_count = checker_error_count(errors)
-        notify_updates, suppressed_updates = partition_updates_by_notification_policy(updates)
-        notified_update_count = len(notify_updates)
-        suppressed_update_count = len(suppressed_updates)
-
-        state = state_loader()
-        pending_events = []
-        event_build_errors: List[str] = []
-        for update in notify_updates:
-            try:
-                pending_events.append(build_update_event(update, detected_at=detected_at))
-            except Exception as exc:
-                work_id = str(update.get("work_id") or update.get("id") or "<unknown>")
-                event_build_errors.append(f"{work_id}: {exc}")
-        had_existing_outbox = bool(load_notification_outbox(state))
-        enqueued_count = enqueue_notification_events(
-            state,
-            events=pending_events,
-            backend_names=list(named_notifiers.keys()),
-        )
-        if enqueued_count > 0:
-            state_saver(state)
-
-        delivery = deliver_notification_outbox(
-            state,
-            named_notifiers=named_notifiers,
-            attempted_at=detected_at,
-        )
-        outbox_pending_count = int(delivery["remainingCount"])
-        update_notification_sent = int(delivery["deliveredCount"]) > 0
-        if had_existing_outbox or enqueued_count > 0 or outbox_pending_count > 0:
-            state_saver(state)
-        failure_messages = list(event_build_errors)
-        if delivery["errors"]:
-            failure_messages.extend(delivery["errors"])
-        if failure_messages:
-            raise RuntimeError("notification delivery failed: " + "; ".join(failure_messages))
-
-        report_logger(
-            format_run_report(
-                timestamp=timestamp,
-                trigger_source=trigger_source,
-                updates=updates,
-                errors=errors,
-                state=state,
-                notified_update_count=notified_update_count,
-                suppressed_update_count=suppressed_update_count,
-                outbox_pending_count=outbox_pending_count,
-                update_notification_sent=update_notification_sent,
-            )
-        )
-        return {
-            "ok": error_count == 0,
-            "updateCount": update_count,
-            "notifiedUpdateCount": notified_update_count,
-            "suppressedUpdateCount": suppressed_update_count,
-            "errorCount": error_count,
-            "outboxPendingCount": outbox_pending_count,
-            "timestamp": timestamp,
-            "triggerSource": trigger_source,
-        }
+    except CheckRunError as exc:
+        primary_failure = exc.original_error
+        result = exc.result
+        raw_updates = result.get("updates", [])
+        if isinstance(raw_updates, list):
+            updates = raw_updates
+        try:
+            errors = normalize_checker_errors(result)
+        except Exception as normalize_exc:
+            errors = {"sources": [], "run": [runner_error_record("normalize_checker_errors", normalize_exc)]}
     except Exception as exc:
-        error_logger(format_failure_report(timestamp, trigger_source, exc))
-        return {
-            "ok": False,
-            "updateCount": update_count,
-            "notifiedUpdateCount": notified_update_count,
-            "suppressedUpdateCount": suppressed_update_count,
-            "errorCount": error_count,
-            "outboxPendingCount": outbox_pending_count,
-            "timestamp": timestamp,
-            "triggerSource": trigger_source,
-            "error": f"{exc.__class__.__name__}: {exc}",
-        }
+        primary_failure = exc
+        errors["run"].append(runner_error_record("checker", exc))
+
+    update_count = len(updates)
+    notify_updates, suppressed_updates = partition_updates_by_notification_policy(updates)
+    notified_update_count = len(notify_updates)
+    suppressed_update_count = len(suppressed_updates)
+    checker_completed = primary_failure is None
+
+    try:
+        state = state_loader()
+    except Exception as exc:
+        errors["run"].append(runner_error_record("load_runner_state", exc))
+        if primary_failure is None:
+            primary_failure = exc
+
+    if state is None:
+        state = {}
+
+    if checker_completed and isinstance(state, dict):
+        try:
+            pending_events = []
+            for update in notify_updates:
+                try:
+                    pending_events.append(build_update_event(update, detected_at=detected_at))
+                except Exception as exc:
+                    work_id = str(update.get("work_id") or update.get("id") or "<unknown>")
+                    errors["run"].append(
+                        runner_error_record(
+                            "build_update_event",
+                            RuntimeError(f"{work_id}: {exc}"),
+                        )
+                    )
+
+            had_existing_outbox = bool(load_notification_outbox(state))
+            enqueued_count = enqueue_notification_events(
+                state,
+                events=pending_events,
+                backend_names=list(named_notifiers.keys()),
+            )
+            if enqueued_count > 0:
+                state_saver(state)
+
+            delivery = deliver_notification_outbox(
+                state,
+                named_notifiers=named_notifiers,
+                attempted_at=detected_at,
+            )
+            outbox_pending_count = int(delivery["remainingCount"])
+            if had_existing_outbox or enqueued_count > 0 or outbox_pending_count > 0:
+                state_saver(state)
+            if delivery["errors"]:
+                delivery_failures.extend(delivery["errors"])
+        except Exception as exc:
+            errors["run"].append(runner_error_record("generic_notification", exc))
+            if primary_failure is None:
+                primary_failure = exc
+
+        if resolved_discord_client is not None and config.discord_outbound_config is not None:
+            try:
+                enqueue_result = enqueue_daily_notification(
+                    state,
+                    updates=notify_updates,
+                    channel_id=config.discord_outbound_config.main_channel_id,
+                    now_ts=now,
+                    timezone_name=config.timezone_name,
+                    created_at=detected_at,
+                )
+                if enqueue_result["queued"]:
+                    state_saver(state)
+
+                daily_delivery = deliver_daily_notifications(
+                    state,
+                    client=resolved_discord_client,
+                    attempted_at=detected_at,
+                )
+                daily_notification_sent = int(daily_delivery["deliveredCount"]) > 0
+                if enqueue_result["queued"] or int(daily_delivery["attemptedCount"]) > 0:
+                    state_saver(state)
+                if daily_delivery["errors"]:
+                    delivery_failures.extend(daily_delivery["errors"])
+            except Exception as exc:
+                errors["run"].append(runner_error_record("discord_daily_notification", exc))
+                if primary_failure is None:
+                    primary_failure = exc
+
+    error_count = checker_error_count(errors)
+    daily_notification_pending_count = pending_daily_notification_count(state)
+    run_report = build_run_report_message(
+        timestamp=timestamp,
+        trigger_source=trigger_source,
+        update_count=update_count,
+        notified_update_count=notified_update_count,
+        suppressed_update_count=suppressed_update_count,
+        outbox_pending_count=outbox_pending_count,
+        daily_notification_sent=daily_notification_sent,
+        daily_notification_pending_count=daily_notification_pending_count,
+        errors=errors,
+        delivery_failures=delivery_failures,
+        state_lines=format_state_lines(state),
+    )
+
+    if resolved_discord_client is not None and config.discord_outbound_config is not None:
+        try:
+            resolved_discord_client.send_message(
+                config.discord_outbound_config.run_report_channel_id,
+                run_report,
+            )
+        except Exception as exc:
+            run_report_delivery_error = exc
+            error_logger(
+                format_run_report_delivery_failure(
+                    timestamp=timestamp,
+                    trigger_source=trigger_source,
+                    exc=exc,
+                )
+            )
+
+    if not errors["run"] and not delivery_failures and run_report_delivery_error is None:
+        report_logger(run_report)
+
+    if primary_failure is None and delivery_failures:
+        primary_failure = RuntimeError("notification delivery failed: " + "; ".join(delivery_failures))
+    if primary_failure is None and errors["run"]:
+        first_run_error = errors["run"][0]
+        primary_failure = RuntimeError(
+            f"{first_run_error.get('stage')}: {first_run_error.get('message')}"
+        )
+    if primary_failure is not None:
+        error_logger(format_failure_report(timestamp, trigger_source, primary_failure))
+
+    outcome = {
+        "ok": error_count == 0 and not delivery_failures and run_report_delivery_error is None,
+        "updateCount": update_count,
+        "notifiedUpdateCount": notified_update_count,
+        "suppressedUpdateCount": suppressed_update_count,
+        "errorCount": error_count,
+        "outboxPendingCount": outbox_pending_count,
+        "timestamp": timestamp,
+        "triggerSource": trigger_source,
+        "dailyNotificationSent": daily_notification_sent,
+    }
+    if primary_failure is not None:
+        outcome["error"] = f"{primary_failure.__class__.__name__}: {primary_failure}"
+    elif run_report_delivery_error is not None:
+        outcome["error"] = f"{run_report_delivery_error.__class__.__name__}: {run_report_delivery_error}"
+    return outcome
 
 
 @dataclass
@@ -542,6 +607,7 @@ class RunCoordinator:
     config: RunnerConfig
     notifier: Optional[Notifier] = None
     named_notifiers: Optional[Mapping[str, Notifier]] = None
+    discord_client: Optional[DiscordTransport] = None
     checker: Callable[[str], Dict[str, object]] = run_check
     state_loader: Callable[[], Dict[str, object]] = load_state
     state_saver: Callable[[Dict[str, object]], None] = save_state
@@ -562,6 +628,7 @@ class RunCoordinator:
             self.config,
             notifier=self.notifier,
             named_notifiers=self.named_notifiers,
+            discord_client=self.discord_client,
             checker=self.checker,
             state_loader=self.state_loader,
             state_saver=self.state_saver,
@@ -704,6 +771,11 @@ def main() -> int:
     coordinator = RunCoordinator(
         config,
         named_notifiers=named_notifiers,
+        discord_client=(
+            DiscordChannelClient(config.discord_outbound_config)
+            if config.discord_outbound_config is not None
+            else None
+        ),
     )
 
     if config.run_on_startup:

--- a/manga_watch/storage.py
+++ b/manga_watch/storage.py
@@ -56,6 +56,12 @@ def default_state() -> Dict[str, object]:
         "works": {},
         "last_run_at": None,
         "notification_outbox": [],
+        "discord_delivery": {
+            "daily_notification": {
+                "delivered_latest_keys": {},
+                "pending_messages": [],
+            }
+        },
     }
 
 
@@ -313,6 +319,9 @@ def validate_state(payload: Mapping[str, object]) -> Dict[str, object]:
         "works": normalized_works,
         "last_run_at": normalize_optional_int(payload.get("last_run_at")),
         "notification_outbox": normalize_notification_outbox(payload.get("notification_outbox")),
+        "discord_delivery": normalize_discord_delivery(
+            payload.get("discord_delivery", payload.get("discordDelivery"))
+        ),
     }
     for key, value in payload.items():
         if key in state or value is None:
@@ -410,6 +419,179 @@ def normalize_notification_outbox_entry(entry: object, *, index: int) -> Dict[st
             "event",
             "pending_backends",
             "pendingBackends",
+            "attempt_count",
+            "attemptCount",
+            "last_attempted_at",
+            "lastAttemptedAt",
+            "last_error",
+            "lastError",
+        } or value is None:
+            continue
+        normalized[camel_to_snake(str(key))] = value
+    return normalized
+
+
+def normalize_discord_delivery(payload: object) -> Dict[str, object]:
+    if payload is None:
+        payload = {}
+    if not isinstance(payload, Mapping):
+        raise ValueError("state.discord_delivery must be an object")
+
+    normalized = {
+        "daily_notification": normalize_daily_notification_delivery_state(
+            payload.get("daily_notification", payload.get("dailyNotification"))
+        ),
+    }
+    for key, value in payload.items():
+        if key in {"daily_notification", "dailyNotification"} or value is None:
+            continue
+        normalized[camel_to_snake(str(key))] = value
+    return normalized
+
+
+def normalize_daily_notification_delivery_state(payload: object) -> Dict[str, object]:
+    if payload is None:
+        payload = {}
+    if not isinstance(payload, Mapping):
+        raise ValueError("state.discord_delivery.daily_notification must be an object")
+
+    normalized = {
+        "delivered_latest_keys": normalize_delivered_latest_keys(
+            payload.get("delivered_latest_keys", payload.get("deliveredLatestKeys"))
+        ),
+        "pending_messages": normalize_daily_notification_pending_messages(
+            payload.get("pending_messages", payload.get("pendingMessages"))
+        ),
+    }
+    for key, value in payload.items():
+        if key in {
+            "delivered_latest_keys",
+            "deliveredLatestKeys",
+            "pending_messages",
+            "pendingMessages",
+        } or value is None:
+            continue
+        normalized[camel_to_snake(str(key))] = value
+    return normalized
+
+
+def normalize_delivered_latest_keys(payload: object) -> Dict[str, Dict[str, Optional[str]]]:
+    if payload is None:
+        return {}
+    if not isinstance(payload, Mapping):
+        raise ValueError("state.discord_delivery.daily_notification.delivered_latest_keys must be an object")
+
+    normalized: Dict[str, Dict[str, Optional[str]]] = {}
+    for work_id, entry in payload.items():
+        latest_key = None
+        delivered_at = None
+        if isinstance(entry, Mapping):
+            latest_key = normalize_optional_text(entry.get("latest_key", entry.get("latestKey")))
+            delivered_at = normalize_optional_text(entry.get("delivered_at", entry.get("deliveredAt")))
+        else:
+            latest_key = normalize_optional_text(entry)
+        if latest_key is None:
+            raise ValueError(
+                f"state.discord_delivery.daily_notification.delivered_latest_keys[{work_id}] "
+                "must include latest_key"
+            )
+        normalized[str(work_id)] = {
+            "latest_key": latest_key,
+            "delivered_at": delivered_at,
+        }
+    return normalized
+
+
+def normalize_daily_notification_pending_messages(payload: object) -> List[Dict[str, object]]:
+    if payload is None:
+        return []
+    if not isinstance(payload, list):
+        raise ValueError("state.discord_delivery.daily_notification.pending_messages must be a list")
+
+    normalized_entries: List[Dict[str, object]] = []
+    for index, entry in enumerate(payload):
+        normalized_entries.append(normalize_daily_notification_pending_message(entry, index=index))
+    return normalized_entries
+
+
+def normalize_daily_notification_pending_message(entry: object, *, index: int) -> Dict[str, object]:
+    if not isinstance(entry, Mapping):
+        raise ValueError(
+            f"state.discord_delivery.daily_notification.pending_messages[{index}] must be an object"
+        )
+
+    channel_id = normalize_optional_text(entry.get("channel_id", entry.get("channelId")))
+    if channel_id is None:
+        raise ValueError(
+            f"state.discord_delivery.daily_notification.pending_messages[{index}].channel_id is required"
+        )
+
+    content = normalize_optional_text(entry.get("content"))
+    if content is None:
+        raise ValueError(
+            f"state.discord_delivery.daily_notification.pending_messages[{index}].content is required"
+        )
+
+    message_keys = entry.get("message_keys", entry.get("messageKeys", []))
+    if message_keys is None:
+        message_keys = []
+    if not isinstance(message_keys, list):
+        raise ValueError(
+            f"state.discord_delivery.daily_notification.pending_messages[{index}].message_keys must be a list"
+        )
+
+    normalized_message_keys: List[Dict[str, str]] = []
+    seen_keys = set()
+    for key_index, message_key in enumerate(message_keys):
+        if not isinstance(message_key, Mapping):
+            raise ValueError(
+                "state.discord_delivery.daily_notification.pending_messages"
+                f"[{index}].message_keys[{key_index}] must be an object"
+            )
+        work_id = normalize_optional_text(message_key.get("work_id", message_key.get("workId")))
+        latest_key = normalize_optional_text(message_key.get("latest_key", message_key.get("latestKey")))
+        if work_id is None or latest_key is None:
+            raise ValueError(
+                "state.discord_delivery.daily_notification.pending_messages"
+                f"[{index}].message_keys[{key_index}] must include work_id and latest_key"
+            )
+        stable_key = (work_id, latest_key)
+        if stable_key in seen_keys:
+            continue
+        seen_keys.add(stable_key)
+        normalized_message_keys.append(
+            {
+                "work_id": work_id,
+                "latest_key": latest_key,
+            }
+        )
+
+    attempt_count = int(entry.get("attempt_count", entry.get("attemptCount", 0)) or 0)
+    if attempt_count < 0:
+        raise ValueError(
+            f"state.discord_delivery.daily_notification.pending_messages[{index}].attempt_count must be >= 0"
+        )
+
+    normalized = {
+        "channel_id": channel_id,
+        "content": content,
+        "message_keys": normalized_message_keys,
+        "created_at": normalize_optional_text(entry.get("created_at", entry.get("createdAt"))),
+        "attempt_count": attempt_count,
+        "last_attempted_at": normalize_optional_text(
+            entry.get("last_attempted_at", entry.get("lastAttemptedAt"))
+        ),
+        "last_error": normalize_optional_text(entry.get("last_error", entry.get("lastError"))),
+    }
+    for key, value in entry.items():
+        if key in {
+            "channel_id",
+            "channelId",
+            "content",
+            "message_keys",
+            "messageKeys",
+            "created_at",
+            "createdAt",
             "attempt_count",
             "attemptCount",
             "last_attempted_at",

--- a/tests/test_discord_outbound.py
+++ b/tests/test_discord_outbound.py
@@ -1,0 +1,146 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from manga_watch.discord_outbound import (
+    DiscordChannelClient,
+    DiscordOutboundConfig,
+    build_daily_notification_message,
+)
+from manga_watch.storage import load_state, save_state
+
+
+class FakeResponse:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeSession:
+    def __init__(self, responses=None, error=None):
+        self.responses = list(responses or [])
+        self.error = error
+        self.calls = []
+
+    def post(self, url, json=None, headers=None, timeout=None, allow_redirects=None):
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+                "allow_redirects": allow_redirects,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        if not self.responses:
+            raise AssertionError("unexpected discord request")
+        return self.responses.pop(0)
+
+
+class DiscordOutboundTests(unittest.TestCase):
+    def make_update(self, *, series="作品A", latest_key="episode-2", episode_title="第2話", previous="第1話"):
+        return {
+            "id": "work-1",
+            "from": {
+                "seriesTitle": series,
+                "episodeTitle": previous,
+                "latestKey": "episode-1",
+            },
+            "to": {
+                "series_title": series,
+                "episode_title": episode_title,
+                "latest_key": latest_key,
+                "url": "https://example.com/latest",
+            },
+        }
+
+    def test_build_daily_notification_message_formats_lines_and_truncates_labels(self):
+        message = build_daily_notification_message(
+            [
+                self.make_update(episode_title="第71話 abcdefghijk"),
+                self.make_update(series="作品B", latest_key="episode-3", episode_title="第3話", previous="第2話"),
+            ],
+            now_ts=1_700_000_000,
+            timezone_name="Asia/Tokyo",
+        )
+
+        lines = message.splitlines()
+        self.assertEqual("新着エピソードを検知しました（2023-11-15）", lines[0])
+        self.assertEqual("[作品A：第71話 abcdefg…](<https://example.com/latest>)←第1話", lines[1])
+        self.assertEqual("[作品B：第3話](<https://example.com/latest>)←第2話", lines[2])
+
+    def test_discord_channel_client_posts_bot_message(self):
+        session = FakeSession(responses=[FakeResponse(200)])
+        client = DiscordChannelClient(
+            DiscordOutboundConfig(
+                bot_token="discord-bot-token",
+                main_channel_id="main-channel",
+                run_report_channel_id="run-report-channel",
+            ),
+            session=session,
+        )
+
+        client.send_message("run-report-channel", "hello")
+
+        self.assertEqual(1, len(session.calls))
+        self.assertEqual(
+            "https://discord.com/api/v10/channels/run-report-channel/messages",
+            session.calls[0]["url"],
+        )
+        self.assertEqual("Bot discord-bot-token", session.calls[0]["headers"]["Authorization"])
+        self.assertEqual({"content": "hello", "allowed_mentions": {"parse": []}}, session.calls[0]["json"])
+        self.assertEqual(10, session.calls[0]["timeout"])
+        self.assertFalse(session.calls[0]["allow_redirects"])
+
+    def test_state_round_trip_preserves_discord_delivery_state(self):
+        state = {
+            "version": 2,
+            "works": {},
+            "last_run_at": 1_700_000_000,
+            "notification_outbox": [],
+            "discord_delivery": {
+                "daily_notification": {
+                    "delivered_latest_keys": {
+                        "work-1": {
+                            "latest_key": "episode-2",
+                            "delivered_at": "2023-11-14T22:13:20Z",
+                        }
+                    },
+                    "pending_messages": [
+                        {
+                            "channel_id": "main-channel",
+                            "content": "pending message",
+                            "message_keys": [{"work_id": "work-2", "latest_key": "episode-9"}],
+                            "created_at": "2023-11-14T22:13:20Z",
+                            "attempt_count": 1,
+                            "last_attempted_at": "2023-11-14T22:14:00Z",
+                            "last_error": "discord delivery failed",
+                        }
+                    ],
+                }
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            save_state(state, path=str(state_path))
+            loaded = load_state(str(state_path))
+
+        self.assertEqual(
+            "episode-2",
+            loaded["discord_delivery"]["daily_notification"]["delivered_latest_keys"]["work-1"]["latest_key"],
+        )
+        self.assertEqual(
+            "main-channel",
+            loaded["discord_delivery"]["daily_notification"]["pending_messages"][0]["channel_id"],
+        )
+        self.assertEqual(
+            "episode-9",
+            loaded["discord_delivery"]["daily_notification"]["pending_messages"][0]["message_keys"][0]["latest_key"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import requests
 
+from manga_watch.discord_outbound import DiscordOutboundConfig
 from manga_watch.notifier import (
     NotifierConfig,
     StdoutNotifier,
@@ -73,6 +74,25 @@ class FakeSession:
         return self.responses.pop(0)
 
 
+class FakeDiscordClient:
+    def __init__(self, *, fail_on_call=None, fail_channels=None):
+        self.fail_on_call = fail_on_call
+        self.fail_channels = set(fail_channels or [])
+        self.calls = []
+
+    def send_message(self, channel_id, content):
+        self.calls.append(
+            {
+                "channel_id": channel_id,
+                "content": content,
+            }
+        )
+        if self.fail_on_call is not None and len(self.calls) - 1 == self.fail_on_call:
+            raise RuntimeError("discord delivery failed")
+        if channel_id in self.fail_channels:
+            raise RuntimeError(f"discord delivery failed for {channel_id}")
+
+
 class RunnerTests(unittest.TestCase):
     def wait_until(self, predicate, *, timeout=1.0):
         deadline = time.time() + timeout
@@ -101,7 +121,7 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("[runner] configuration error:", result.stderr)
         self.assertIn("MANGA_WATCH_NOTIFIER_BACKENDS", result.stderr)
 
-    def make_config(self):
+    def make_config(self, *, with_discord=False):
         return RunnerConfig(
             timezone_name="Asia/Tokyo",
             watchlist_path="/tmp/watchlist.json",
@@ -109,6 +129,15 @@ class RunnerTests(unittest.TestCase):
             crawl_interval=None,
             run_on_startup=True,
             notifier_config=NotifierConfig(backends=("stdout",)),
+            discord_outbound_config=(
+                DiscordOutboundConfig(
+                    bot_token="discord-bot-token",
+                    main_channel_id="main-channel",
+                    run_report_channel_id="run-report-channel",
+                )
+                if with_discord
+                else None
+            ),
         )
 
     def make_notification(
@@ -183,6 +212,12 @@ class RunnerTests(unittest.TestCase):
             },
             "last_run_at": None,
             "notification_outbox": [],
+            "discord_delivery": {
+                "daily_notification": {
+                    "delivered_latest_keys": {},
+                    "pending_messages": [],
+                }
+            },
         }
 
     def make_state_store(self, state=None):
@@ -316,10 +351,12 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(0, outcome["errorCount"])
         self.assertEqual([], notifier.events)
         self.assertEqual(1, len(reports))
-        self.assertIn("通知: 送信なし", reports[0])
+        self.assertIn("daily notification: 送信なし", reports[0])
         self.assertIn("通知対象: 0件", reports[0])
         self.assertIn("通知抑制: 0件", reports[0])
-        self.assertIn("エラー: 0件", reports[0])
+        self.assertIn("source failure: 0件", reports[0])
+        self.assertIn("run-level failure: 0件", reports[0])
+        self.assertIn("delivery failure: 0件", reports[0])
         self.assertEqual([], errors)
 
     def test_run_once_with_default_notify_update_sends_event_and_logs_report(self):
@@ -348,7 +385,7 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("main_story", payload["update_type"])
         self.assertEqual("2023-11-14T22:13:20Z", payload["detected_at"])
         self.assertTrue(payload["notification"]["should_notify"])
-        self.assertIn("通知: 送信した", reports[0])
+        self.assertIn("daily notification: 送信なし", reports[0])
         self.assertIn("通知対象: 1件", reports[0])
         self.assertIn("通知抑制: 0件", reports[0])
 
@@ -383,7 +420,7 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("更新検知: 1件", reports[0])
         self.assertIn("通知対象: 0件", reports[0])
         self.assertIn("通知抑制: 1件", reports[0])
-        self.assertIn("通知: 送信なし", reports[0])
+        self.assertIn("daily notification: 送信なし", reports[0])
 
     def test_run_once_unknown_updates_fail_open_to_notifier(self):
         notifier = FakeNotifier()
@@ -498,7 +535,7 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(1, len(notifier.events))
         self.assertIn("巡回実行に一部失敗がありました", reports[0])
         self.assertIn("通知対象: 1件", reports[0])
-        self.assertIn("エラー: 1件", reports[0])
+        self.assertIn("source failure: 1件", reports[0])
         self.assertIn("source/parse [fetch_latest] work-2: parse failed", reports[0])
 
     def test_run_once_logs_failure_report_when_notifier_fails(self):
@@ -616,8 +653,136 @@ class RunnerTests(unittest.TestCase):
         self.assertTrue(second_outcome["ok"])
         self.assertEqual(1, len(succeeding_notifier.events))
         self.assertEqual([], store["notification_outbox"])
-        self.assertIn("通知: 送信した", reports[0])
-        self.assertIn("通知outbox残件: 0件", reports[0])
+        self.assertIn("daily notification: 送信なし", reports[0])
+        self.assertIn("generic notifier outbox残件: 0件", reports[0])
+
+    def test_run_once_with_discord_outbound_sends_daily_notification_and_run_report(self):
+        notifier = FakeNotifier()
+        discord = FakeDiscordClient()
+        reports = []
+        store, load_from_store, save_to_store = self.make_state_store()
+
+        outcome = run_once(
+            self.make_config(with_discord=True),
+            notifier=notifier,
+            discord_client=discord,
+            checker=lambda _: {"updates": [self.make_update()]},
+            state_loader=load_from_store,
+            state_saver=save_to_store,
+            now_fn=lambda: 1_700_000_000,
+            report_logger=reports.append,
+            error_logger=lambda _: self.fail("unexpected error log"),
+        )
+
+        self.assertTrue(outcome["ok"])
+        self.assertTrue(outcome["dailyNotificationSent"])
+        self.assertEqual(1, len(notifier.events))
+        self.assertEqual(["main-channel", "run-report-channel"], [call["channel_id"] for call in discord.calls])
+        self.assertIn("新着エピソードを検知しました", discord.calls[0]["content"])
+        self.assertIn("[作品A：第2話](<https://example.com/2>)←第1話", discord.calls[0]["content"])
+        self.assertIn("daily notification: 送信した", discord.calls[1]["content"])
+        self.assertEqual(
+            "episode-2",
+            store["discord_delivery"]["daily_notification"]["delivered_latest_keys"]["work-1"]["latest_key"],
+        )
+        self.assertEqual([], store["discord_delivery"]["daily_notification"]["pending_messages"])
+        self.assertEqual(1, len(reports))
+        self.assertIn("daily notification: 送信した", reports[0])
+
+    def test_run_once_replays_pending_daily_notification_on_next_run(self):
+        failing_discord = FakeDiscordClient(fail_channels={"main-channel"})
+        store, load_from_store, save_to_store = self.make_state_store()
+        errors = []
+
+        first_outcome = run_once(
+            self.make_config(with_discord=True),
+            notifier=FakeNotifier(),
+            discord_client=failing_discord,
+            checker=lambda _: {"updates": [self.make_update()]},
+            state_loader=load_from_store,
+            state_saver=save_to_store,
+            now_fn=lambda: 1_700_000_000,
+            report_logger=lambda _: self.fail("unexpected report log"),
+            error_logger=errors.append,
+        )
+
+        self.assertFalse(first_outcome["ok"])
+        self.assertFalse(first_outcome["dailyNotificationSent"])
+        self.assertEqual(1, len(store["discord_delivery"]["daily_notification"]["pending_messages"]))
+        self.assertEqual({}, store["discord_delivery"]["daily_notification"]["delivered_latest_keys"])
+        self.assertEqual(1, len(errors))
+        self.assertIn("notification delivery failed", errors[0])
+
+        succeeding_discord = FakeDiscordClient()
+        reports = []
+        second_outcome = run_once(
+            self.make_config(with_discord=True),
+            notifier=FakeNotifier(),
+            discord_client=succeeding_discord,
+            checker=lambda _: {"updates": []},
+            state_loader=load_from_store,
+            state_saver=save_to_store,
+            now_fn=lambda: 1_700_000_300,
+            report_logger=reports.append,
+            error_logger=lambda _: self.fail("unexpected error log"),
+        )
+
+        self.assertTrue(second_outcome["ok"])
+        self.assertTrue(second_outcome["dailyNotificationSent"])
+        self.assertEqual(["main-channel", "run-report-channel"], [call["channel_id"] for call in succeeding_discord.calls])
+        self.assertEqual([], store["discord_delivery"]["daily_notification"]["pending_messages"])
+        self.assertEqual(
+            "episode-2",
+            store["discord_delivery"]["daily_notification"]["delivered_latest_keys"]["work-1"]["latest_key"],
+        )
+        self.assertIn("daily notification: 送信した", reports[0])
+
+    def test_run_once_logs_secondary_failure_when_run_report_delivery_fails(self):
+        discord = FakeDiscordClient(fail_channels={"run-report-channel"})
+        errors = []
+
+        outcome = run_once(
+            self.make_config(with_discord=True),
+            notifier=FakeNotifier(),
+            discord_client=discord,
+            checker=lambda _: {"updates": []},
+            state_loader=self.make_state,
+            state_saver=lambda _: None,
+            now_fn=lambda: 1_700_000_000,
+            report_logger=lambda _: self.fail("unexpected report log"),
+            error_logger=errors.append,
+        )
+
+        self.assertFalse(outcome["ok"])
+        self.assertEqual(1, len(discord.calls))
+        self.assertEqual("run-report-channel", discord.calls[0]["channel_id"])
+        self.assertEqual(1, len(errors))
+        self.assertIn("run report 自体の送信に失敗しました", errors[0])
+        self.assertIn("トリガー: scheduled", errors[0])
+
+    def test_run_once_sends_run_report_to_discord_when_checker_raises(self):
+        discord = FakeDiscordClient()
+        errors = []
+
+        outcome = run_once(
+            self.make_config(with_discord=True),
+            notifier=FakeNotifier(),
+            discord_client=discord,
+            checker=lambda _: (_ for _ in ()).throw(RuntimeError("boom")),
+            state_loader=self.make_state,
+            state_saver=lambda _: None,
+            now_fn=lambda: 1_700_000_000,
+            report_logger=lambda _: self.fail("unexpected report log"),
+            error_logger=errors.append,
+        )
+
+        self.assertFalse(outcome["ok"])
+        self.assertEqual(1, len(discord.calls))
+        self.assertEqual("run-report-channel", discord.calls[0]["channel_id"])
+        self.assertIn("run-level failure: 1件", discord.calls[0]["content"])
+        self.assertIn("boom", discord.calls[0]["content"])
+        self.assertEqual(1, len(errors))
+        self.assertIn("boom", errors[0])
 
     def test_handle_fetch_trigger_accepts_when_idle_and_runs_in_background(self):
         checker_started = threading.Event()


### PR DESCRIPTION
## Summary
- implement Discord outbound as a separate surface from generic notifier backends
- add durable daily-notification dedupe/pending state and send aggregate daily notifications to the configured Discord main channel
- send a Discord run report on every run with trigger/count/failure breakdowns and add secondary stderr reporting when the run report itself fails

## Issue
- Closes #71

## Verification
- `.venv/bin/python -m unittest tests.test_discord_outbound tests.test_discord_latest tests.test_discord_fetch tests.test_runner`
- `.venv/bin/python -m unittest discover -s tests`

## Residual Risks
- Discord HTTP delivery still depends on live token/channel correctness and real-world rate-limit behavior; unit tests cover request shape and retry-visible failure handling, not a live Discord smoke test.
