### PR TITLE
Add Champion Cross source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ runner が backend に送る update event は次の schema です。
 | --- | --- | --- | --- | --- |
 | ComicWalker | canonical series URL, episode URL | `https://comic-walker.com/detail/<series>` | `KC_XXXXXX_S` | `episodeCode` |
 | webアクション | episode URL, RSS/Atom series feed URL | canonical episode URL または canonical series feed URL | `comic-action:<series_id>` | 最終到達 episode URL |
+| Champion Cross | episode URL, series URL, series RSS URL | canonical episode URL / canonical series URL / canonical series RSS URL | `champion-cross:<series_hash>` | 最新 episode URL |
 | Kakuyomu | work URL, episode URL | 入力 URL のまま | `kakuyomu:<numeric_work_id>` | 最新 episode id |
 
 Phase 1 では source ごとの capability 差を隠しません。`watchlist add` が受け付ける URL 種別は上の表だけです。

--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -19,6 +19,10 @@ from manga_watch.sources import (
     normalize_seed_url,
 )
 from manga_watch.sources.base import SourceParseError
+from manga_watch.sources.champion_cross import (
+    extract_champion_cross_series_hash,
+    extract_champion_cross_series_hash_from_seed_url,
+)
 from manga_watch.sources.comic_action import (
     extract_comic_action_series_id,
     extract_comic_action_series_id_from_seed_url,
@@ -459,6 +463,26 @@ def stable_work_id_for_item(
     http_client: Optional[HttpClient] = None,
 ) -> str:
     source = str(item.get("source") or "")
+    if source == "champion-cross":
+        stable_series = str(item.get("series") or "")
+        if stable_series.startswith("champion-cross:"):
+            return stable_series
+
+        seed_url = str(item.get("seedUrl") or "")
+        if not seed_url:
+            raise RuntimeError("champion-cross: seedUrl is required to derive work_id")
+
+        series_hash = str(item.get("seriesHash") or "") or extract_champion_cross_series_hash_from_seed_url(seed_url)
+        if series_hash:
+            return f"champion-cross:{series_hash}"
+
+        client = http_client or RequestsHttpClient()
+        html = client.get_text(seed_url)
+        series_hash = extract_champion_cross_series_hash(html)
+        if not series_hash:
+            raise RuntimeError("champion-cross: series hash not found")
+        return f"champion-cross:{series_hash}"
+
     if source != "comic-action":
         return item_id_for_state(item)
 

--- a/manga_watch/source_drift.py
+++ b/manga_watch/source_drift.py
@@ -9,6 +9,12 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 from .sources import HttpClient, RequestsHttpClient, registered_sources
 from .sources.base import SourceParseError
+from .sources.champion_cross import (
+    ChampionCrossAdapter,
+    canonical_champion_cross_series_rss_url,
+    extract_champion_cross_series_hash,
+    parse_champion_cross_rss_latest,
+)
 from .sources.comic_action import ComicActionAdapter, extract_comic_action_series_id, parse_comic_action_title
 from .sources.comic_walker import ComicWalkerAdapter, parse_comic_walker_title
 from .sources.kakuyomu import KakuyomuAdapter
@@ -82,6 +88,16 @@ DEFAULT_SOURCE_CANARY_CONTRACTS: Dict[str, SourceCanaryContract] = {
             "seed episode page exposes series_id",
             "seed episode page exposes nextReadableProductUri",
             "latest episode page title still parses into series / episode labels",
+        ),
+    ),
+    "champion-cross": SourceCanaryContract(
+        source="champion-cross",
+        seed_url="https://championcross.jp/episodes/f35108c56e75d",
+        fixture_bundle="tests/fixtures/champion-cross/normal",
+        monitored_signals=(
+            "seed episode page exposes a stable series hash",
+            "series RSS feed keeps the latest episode URL",
+            "series RSS feed keeps the latest episode title",
         ),
     ),
     "kakuyomu": SourceCanaryContract(
@@ -211,9 +227,39 @@ def _kakuyomu_canary(contract: SourceCanaryContract, http_client: HttpClient) ->
     )
 
 
+def _champion_cross_canary(
+    contract: SourceCanaryContract,
+    http_client: HttpClient,
+) -> Tuple[Tuple[str, ...], Tuple[CanaryObservation, ...]]:
+    adapter = ChampionCrossAdapter()
+    work = adapter.normalize(contract.seed_url)
+
+    episode_html = http_client.get_text(work.seed_url)
+    series_hash = extract_champion_cross_series_hash(episode_html)
+    if not series_hash:
+        raise SourceParseError("champion-cross: series hash not found")
+
+    rss_url = canonical_champion_cross_series_rss_url(series_hash)
+    feed_text = http_client.get_text(rss_url)
+    latest_url, latest_title, series_title = parse_champion_cross_rss_latest(feed_text)
+    if not latest_title:
+        raise SourceParseError("champion-cross: latest episode title not found")
+
+    return (
+        (work.seed_url, rss_url),
+        (
+            CanaryObservation("series_hash", series_hash),
+            CanaryObservation("series_title", series_title or ""),
+            CanaryObservation("latest_episode_url", latest_url),
+            CanaryObservation("latest_episode_title", latest_title),
+        ),
+    )
+
+
 CANARY_RUNNERS = {
     "comic-walker": _comic_walker_canary,
     "comic-action": _comic_action_canary,
+    "champion-cross": _champion_cross_canary,
     "kakuyomu": _kakuyomu_canary,
 }
 

--- a/manga_watch/sources/champion_cross.py
+++ b/manga_watch/sources/champion_cross.py
@@ -1,0 +1,184 @@
+import html
+import re
+import xml.etree.ElementTree as ET
+from typing import Optional, Tuple
+
+from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
+
+
+_EPISODE_URL = re.compile(
+    r"^https?://(?:www\.)?championcross\.jp/episodes/([0-9a-z]{8,})/?(?:\?.*)?$"
+)
+_SERIES_URL = re.compile(
+    r"^https?://(?:www\.)?championcross\.jp/series/([0-9a-z]{8,})/?(?:\?.*)?$"
+)
+_SERIES_RSS_URL = re.compile(
+    r"^https?://(?:www\.)?championcross\.jp/series/([0-9a-z]{8,})/rss/?(?:\?.*)?$"
+)
+_SERIES_HASH_IN_HTML = re.compile(
+    r"https?://(?:www\.)?championcross\.jp/series/([0-9a-z]{8,})(?:/rss)?(?:[/?\"'])"
+)
+
+
+def canonical_champion_cross_episode_url(episode_hash: str) -> str:
+    return f"https://championcross.jp/episodes/{episode_hash}"
+
+
+def canonical_champion_cross_series_url(series_hash: str) -> str:
+    return f"https://championcross.jp/series/{series_hash}"
+
+
+def canonical_champion_cross_series_rss_url(series_hash: str) -> str:
+    return f"{canonical_champion_cross_series_url(series_hash)}/rss"
+
+
+def parse_champion_cross_episode_url(seed_url: str) -> Optional[str]:
+    match = _EPISODE_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_champion_cross_episode_url(match.group(1))
+
+
+def parse_champion_cross_series_url(seed_url: str) -> Optional[str]:
+    match = _SERIES_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_champion_cross_series_url(match.group(1))
+
+
+def parse_champion_cross_series_rss_url(seed_url: str) -> Optional[str]:
+    match = _SERIES_RSS_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_champion_cross_series_rss_url(match.group(1))
+
+
+def extract_champion_cross_series_hash_from_seed_url(seed_url: str) -> Optional[str]:
+    for pattern in (_SERIES_RSS_URL, _SERIES_URL):
+        match = pattern.match(seed_url)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_champion_cross_series_hash(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    normalized = html.unescape(html_text).replace("\\/", "/")
+    match = _SERIES_HASH_IN_HTML.search(normalized)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def parse_champion_cross_rss_latest(feed_text: str) -> Tuple[str, Optional[str], Optional[str]]:
+    if not feed_text or not feed_text.strip():
+        raise SourceParseError("champion-cross: empty RSS feed")
+
+    try:
+        root = ET.fromstring(feed_text)
+    except ET.ParseError as exc:
+        raise SourceParseError(f"champion-cross: invalid RSS feed: {exc}") from exc
+
+    channel = root.find("channel")
+    if channel is None:
+        raise SourceParseError("champion-cross: RSS channel not found")
+
+    series_title = (channel.findtext("title") or "").strip() or None
+    for item in channel.findall("item"):
+        latest_url = parse_champion_cross_episode_url((item.findtext("link") or "").strip())
+        if not latest_url:
+            continue
+        episode_title = (item.findtext("title") or "").strip() or None
+        return latest_url, episode_title, series_title
+
+    raise SourceParseError("champion-cross: latest episode not found in RSS feed")
+
+
+class ChampionCrossAdapter(SourceAdapter):
+    source = "champion-cross"
+
+    def can_handle(self, seed_url: str) -> bool:
+        return bool(
+            parse_champion_cross_episode_url(seed_url)
+            or parse_champion_cross_series_url(seed_url)
+            or parse_champion_cross_series_rss_url(seed_url)
+        )
+
+    def normalize(self, seed_url: str) -> WorkDescriptor:
+        normalized_episode_url = parse_champion_cross_episode_url(seed_url)
+        if normalized_episode_url:
+            return WorkDescriptor(
+                source=self.source,
+                work_id=normalized_episode_url,
+                seed_url=normalized_episode_url,
+            )
+
+        series_hash = extract_champion_cross_series_hash_from_seed_url(seed_url)
+        if not series_hash:
+            raise RuntimeError(f"champion-cross: could not parse seed URL: {seed_url}")
+
+        stable_work_id = f"{self.source}:{series_hash}"
+        normalized_series_rss_url = parse_champion_cross_series_rss_url(seed_url)
+        if normalized_series_rss_url:
+            return WorkDescriptor(
+                source=self.source,
+                work_id=stable_work_id,
+                seed_url=normalized_series_rss_url,
+                metadata={
+                    "series": stable_work_id,
+                    "seriesHash": series_hash,
+                    "feedKind": "rss",
+                },
+            )
+
+        normalized_series_url = parse_champion_cross_series_url(seed_url)
+        if normalized_series_url:
+            return WorkDescriptor(
+                source=self.source,
+                work_id=stable_work_id,
+                seed_url=normalized_series_url,
+                metadata={
+                    "series": stable_work_id,
+                    "seriesHash": series_hash,
+                },
+            )
+
+        raise RuntimeError(f"champion-cross: unsupported seed URL: {seed_url}")
+
+    def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
+        series_hash, rss_url = self._resolve_series_hash_and_rss_url(work, http_client)
+        feed_text = http_client.get_text(rss_url)
+        latest_url, episode_title, series_title = parse_champion_cross_rss_latest(feed_text)
+        return LatestEpisode(
+            source=self.source,
+            work_id=work.work_id,
+            latest_key=latest_url,
+            url=latest_url,
+            series=f"{self.source}:{series_hash}",
+            series_title=series_title,
+            episode_title=episode_title,
+        )
+
+    def _resolve_series_hash_and_rss_url(
+        self,
+        work: WorkDescriptor,
+        http_client: HttpClient,
+    ) -> Tuple[str, str]:
+        series_hash = (
+            work.metadata.get("seriesHash")
+            or extract_champion_cross_series_hash_from_seed_url(work.seed_url)
+        )
+        if series_hash:
+            return series_hash, canonical_champion_cross_series_rss_url(series_hash)
+
+        normalized_episode_url = parse_champion_cross_episode_url(work.seed_url)
+        if not normalized_episode_url:
+            raise RuntimeError("champion-cross: unsupported seed URL")
+
+        episode_html = http_client.get_text(normalized_episode_url)
+        series_hash = extract_champion_cross_series_hash(episode_html)
+        if not series_hash:
+            raise SourceParseError("champion-cross: series hash not found")
+
+        return series_hash, canonical_champion_cross_series_rss_url(series_hash)

--- a/manga_watch/sources/registry.py
+++ b/manga_watch/sources/registry.py
@@ -1,6 +1,7 @@
 from typing import Optional, Sequence, Tuple
 
 from .base import HttpClient, LatestEpisode, RequestsHttpClient, SourceAdapter, WorkDescriptor
+from .champion_cross import ChampionCrossAdapter
 from .comic_action import ComicActionAdapter
 from .comic_walker import ComicWalkerAdapter
 from .kakuyomu import KakuyomuAdapter
@@ -9,6 +10,7 @@ from .kakuyomu import KakuyomuAdapter
 REGISTERED_ADAPTERS = (
     ComicWalkerAdapter(),
     ComicActionAdapter(),
+    ChampionCrossAdapter(),
     KakuyomuAdapter(),
 )
 REGISTERED_SOURCES = tuple(adapter.source for adapter in REGISTERED_ADAPTERS)

--- a/manga_watch/watchlist.json
+++ b/manga_watch/watchlist.json
@@ -60,6 +60,26 @@
         "mode": "all",
         "allowed_update_types": null
       }
+    },
+    {
+      "id": "champion-cross:4756324e1c1b1",
+      "source": "champion-cross",
+      "seed_url": "https://championcross.jp/episodes/f35108c56e75d",
+      "enabled": true,
+      "notification_policy": {
+        "mode": "all",
+        "allowed_update_types": null
+      }
+    },
+    {
+      "id": "champion-cross:6504eab816435",
+      "source": "champion-cross",
+      "seed_url": "https://championcross.jp/episodes/f36f12cbe8810",
+      "enabled": true,
+      "notification_policy": {
+        "mode": "all",
+        "allowed_update_types": null
+      }
     }
   ]
 }

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -38,6 +38,16 @@ SOURCE_CAPABILITIES = (
         ),
     ),
     SourceCapability(
+        source="champion-cross",
+        domains=("championcross.jp",),
+        input_labels=("episode URL", "series URL", "series RSS URL"),
+        examples=(
+            "https://championcross.jp/episodes/0123456789ab",
+            "https://championcross.jp/series/0123456789ab",
+            "https://championcross.jp/series/0123456789ab/rss",
+        ),
+    ),
+    SourceCapability(
         source="kakuyomu",
         domains=("kakuyomu.jp",),
         input_labels=("work URL", "episode URL"),

--- a/tests/fixtures/champion-cross/normal/01-episode.html
+++ b/tests/fixtures/champion-cross/normal/01-episode.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <title>織津江大志の異世界クリ娘サバイバル日誌・第71話 ウェンディゴ2 | チャンピオンクロス</title>
+</head>
+<body>
+  <a href="https://championcross.jp/series/4756324e1c1b1/">作品詳細</a>
+  <a href="https://championcross.jp/series/4756324e1c1b1/rss">RSS</a>
+</body>
+</html>

--- a/tests/fixtures/champion-cross/normal/02-rss.xml
+++ b/tests/fixtures/champion-cross/normal/02-rss.xml
@@ -1,0 +1,9 @@
+<rss version="2.0">
+  <channel>
+    <title>織津江大志の異世界クリ娘サバイバル日誌</title>
+    <item>
+      <title><![CDATA[第71話　ウェンディゴ2]]></title>
+      <link>https://championcross.jp/episodes/f35108c56e75d/?utm_source=rss&amp;utm_medium=referral</link>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/champion-cross/normal/manifest.json
+++ b/tests/fixtures/champion-cross/normal/manifest.json
@@ -1,0 +1,28 @@
+{
+  "seedUrl": "https://championcross.jp/episodes/f35108c56e75d",
+  "expectedWork": {
+    "source": "champion-cross",
+    "kind": "champion-cross",
+    "workId": "https://championcross.jp/episodes/f35108c56e75d",
+    "seedUrl": "https://championcross.jp/episodes/f35108c56e75d"
+  },
+  "steps": [
+    {
+      "url": "https://championcross.jp/episodes/f35108c56e75d",
+      "response": "01-episode.html"
+    },
+    {
+      "url": "https://championcross.jp/series/4756324e1c1b1/rss",
+      "response": "02-rss.xml"
+    }
+  ],
+  "expectedLatest": {
+    "source": "champion-cross",
+    "workId": "https://championcross.jp/episodes/f35108c56e75d",
+    "latestKey": "https://championcross.jp/episodes/f35108c56e75d",
+    "url": "https://championcross.jp/episodes/f35108c56e75d",
+    "series": "champion-cross:4756324e1c1b1",
+    "seriesTitle": "織津江大志の異世界クリ娘サバイバル日誌",
+    "episodeTitle": "第71話　ウェンディゴ2"
+  }
+}

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -305,6 +305,31 @@ class CheckTests(unittest.TestCase):
         self.assertEqual("comic-action:13933686331663374228", entry["id"])
         self.assertEqual("comic-action", entry["source"])
 
+    def test_build_watchlist_entry_uses_stable_champion_cross_work_id(self):
+        fake_client = mock.Mock()
+        fake_client.get_text.return_value = """
+        <html>
+          <body>
+            <a href="https://championcross.jp/series/4756324e1c1b1/rss">RSS</a>
+          </body>
+        </html>
+        """
+        with mock.patch(
+            "manga_watch.check.normalize_item",
+            return_value={
+                "source": "champion-cross",
+                "workId": "https://championcross.jp/episodes/f35108c56e75d",
+                "seedUrl": "https://championcross.jp/episodes/f35108c56e75d",
+            },
+        ):
+            entry = check.build_watchlist_entry(
+                "https://championcross.jp/episodes/f35108c56e75d",
+                http_client=fake_client,
+            )
+
+        self.assertEqual("champion-cross:4756324e1c1b1", entry["id"])
+        self.assertEqual("champion-cross", entry["source"])
+
     def test_validate_watchlist_rejects_unknown_notification_policy_mode(self):
         with self.assertRaisesRegex(ValueError, "notification_policy.mode must be one of"):
             validate_watchlist(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import manga_watch.sources as source_package
 from manga_watch.sources import REGISTERED_ADAPTERS, REGISTERED_SOURCES, SourceAdapter
 from manga_watch.sources.base import SourceParseError
+from manga_watch.sources.champion_cross import ChampionCrossAdapter
 from manga_watch.sources.comic_action import ComicActionAdapter
 from manga_watch.sources.comic_walker import ComicWalkerAdapter
 from manga_watch.sources.kakuyomu import KakuyomuAdapter
@@ -34,6 +35,7 @@ SOURCE_CASES = {
         "broken_missing_next",
         "broken_loop",
     ),
+    "champion-cross": ("normal",),
 }
 ADAPTERS = {adapter.source: adapter.__class__ for adapter in REGISTERED_ADAPTERS}
 ERROR_TYPES = {
@@ -57,6 +59,9 @@ EXPECTED_LATEST_CLASSIFICATIONS = {
         "escaped_next_uri": "main_story",
         "broken_missing_next": "main_story",
         "broken_loop": "main_story",
+    },
+    "champion-cross": {
+        "normal": "main_story",
     },
 }
 
@@ -141,7 +146,7 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_registry_pins_supported_sources(self):
         self.assertEqual(
-            ("comic-walker", "comic-action", "kakuyomu"),
+            ("comic-walker", "comic-action", "champion-cross", "kakuyomu"),
             REGISTERED_SOURCES,
         )
 
@@ -165,6 +170,9 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_kakuyomu_fixtures(self):
         self._assert_fixture_matrix("kakuyomu")
+
+    def test_champion_cross_fixtures(self):
+        self._assert_fixture_matrix("champion-cross")
 
     def test_comic_walker_normalize_accepts_canonical_series_url(self):
         work = ComicWalkerAdapter().normalize("https://comic-walker.com/detail/KC_123456_S/?from=detail")
@@ -289,6 +297,53 @@ class SourceAdapterTests(unittest.TestCase):
                 "https://comic-action.com/rss/series/13933686331606207128",
                 "https://comic-action.com/episode/11341664176570134078",
             ],
+            client.calls,
+        )
+
+    def test_champion_cross_normalize_accepts_series_rss_url(self):
+        work = ChampionCrossAdapter().normalize("https://championcross.jp/series/4756324e1c1b1/rss?from=share")
+
+        self.assertEqual(
+            {
+                "source": "champion-cross",
+                "kind": "champion-cross",
+                "workId": "champion-cross:4756324e1c1b1",
+                "seedUrl": "https://championcross.jp/series/4756324e1c1b1/rss",
+                "series": "champion-cross:4756324e1c1b1",
+                "seriesHash": "4756324e1c1b1",
+                "feedKind": "rss",
+            },
+            work.to_dict(),
+        )
+
+    def test_champion_cross_fetch_latest_accepts_series_url(self):
+        adapter = ChampionCrossAdapter()
+        work = adapter.normalize("https://championcross.jp/series/4756324e1c1b1/")
+        client = StaticHttpClient(
+            {
+                "https://championcross.jp/series/4756324e1c1b1/rss": """
+                <rss>
+                  <channel>
+                    <title>織津江大志の異世界クリ娘サバイバル日誌</title>
+                    <item>
+                      <title><![CDATA[第71話 ウェンディゴ2]]></title>
+                      <link>https://championcross.jp/episodes/f35108c56e75d/?utm_source=rss&amp;utm_medium=referral</link>
+                    </item>
+                  </channel>
+                </rss>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("champion-cross:4756324e1c1b1", latest["workId"])
+        self.assertEqual("champion-cross:4756324e1c1b1", latest["series"])
+        self.assertEqual("https://championcross.jp/episodes/f35108c56e75d", latest["latestKey"])
+        self.assertEqual("織津江大志の異世界クリ娘サバイバル日誌", latest["seriesTitle"])
+        self.assertEqual("第71話 ウェンディゴ2", latest["episodeTitle"])
+        self.assertEqual(
+            ["https://championcross.jp/series/4756324e1c1b1/rss"],
             client.calls,
         )
 

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -5,12 +5,24 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from manga_watch.watchlist import add_watchlist_url
+
 
 def write_watchlist(path: Path, works):
     path.write_text(
         json.dumps({"version": 2, "works": works}, ensure_ascii=False),
         encoding="utf-8",
     )
+
+
+class StaticHttpClient:
+    def __init__(self, responses):
+        self.responses = dict(responses)
+
+    def get_text(self, url: str) -> str:
+        if url not in self.responses:
+            raise AssertionError(f"unexpected request: {url!r}")
+        return self.responses[url]
 
 
 class WatchlistCliTests(unittest.TestCase):
@@ -124,6 +136,37 @@ class WatchlistCliTests(unittest.TestCase):
         self.assertEqual(existing_entry, payload["existing"])
         self.assertEqual(1, payload["work_count"])
         self.assertEqual([existing_entry], saved["works"])
+
+    def test_watchlist_add_accepts_champion_cross_episode_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            payload = add_watchlist_url(
+                "https://championcross.jp/episodes/f35108c56e75d/?utm_source=rss&utm_medium=referral",
+                watchlist_path=str(watchlist_path),
+                http_client=StaticHttpClient(
+                    {
+                        "https://championcross.jp/episodes/f35108c56e75d": """
+                        <html>
+                          <body>
+                            <a href="https://championcross.jp/series/4756324e1c1b1/rss">RSS</a>
+                          </body>
+                        </html>
+                        """
+                    }
+                ),
+            )
+            saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("added", payload["action"])
+        self.assertEqual("champion-cross:4756324e1c1b1", payload["entry"]["id"])
+        self.assertEqual(
+            "https://championcross.jp/episodes/f35108c56e75d",
+            payload["entry"]["seed_url"],
+        )
+        self.assertEqual(1, payload["work_count"])
+        self.assertEqual(1, len(saved["works"]))
 
     def test_watchlist_add_reports_unsupported_source(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- add a `champion-cross` source adapter that accepts episode URLs, series URLs, and series RSS URLs and resolves latest episodes from the series RSS feed
- wire Champion Cross into `watchlist add`, stable work id resolution, source drift canaries, fixtures, and unit tests
- add two Champion Cross subscriptions to the sample watchlist: 織津江大志の異世界クリ娘サバイバル日誌 and 科学的に存在しうるクリーチャー娘の観察日誌

## Testing
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_sources tests.test_check tests.test_watchlist tests.test_source_drift`