### PR TITLE
Align latest warning semantics with canonical contract

### DIFF
--- a/manga_watch/discord_latest.py
+++ b/manga_watch/discord_latest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from datetime import datetime
 from typing import Callable, Dict, List, Mapping, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -10,6 +11,7 @@ from manga_watch.discord_text import (
     latest_display_label_for_snapshot,
     series_label_for_snapshot,
 )
+from manga_watch.status import default_expected_interval_seconds, derive_health_status
 from manga_watch.storage import load_state, load_watchlist
 
 DEFAULT_TIMEZONE = "Asia/Tokyo"
@@ -50,11 +52,32 @@ def render_work_line(work_id: str, latest: Mapping[str, object]) -> str:
     return f"{format_discord_link(latest_label(latest), latest.get('url'), truncate_label=False)}　{series}"
 
 
+def has_saved_data_warning(
+    work_entry: Mapping[str, object],
+    health: Mapping[str, object],
+    *,
+    now: int,
+    timezone_name: str,
+) -> bool:
+    health_policy = work_entry.get("health_policy") or {}
+    expected_interval_seconds = int(
+        health_policy.get("expected_interval_seconds")
+        or default_expected_interval_seconds(now=now, timezone_name=timezone_name)
+    )
+    derived_health = derive_health_status(
+        health,
+        now=now,
+        expected_interval_seconds=expected_interval_seconds,
+    )
+    return derived_health["state"] in {"degraded", "broken", "stale"}
+
+
 def build_latest_query_lines(
     watchlist: Mapping[str, object],
     state: Mapping[str, object],
     *,
     timezone_name: Optional[str] = None,
+    now: Optional[int] = None,
 ) -> List[str]:
     works = watchlist.get("works", [])
     if not isinstance(works, list):
@@ -65,6 +88,7 @@ def build_latest_query_lines(
         raise ValueError("state.works must be an object")
 
     timezone_name = validated_timezone_name(timezone_name or os.environ.get("TZ", DEFAULT_TIMEZONE))
+    current_time = int(time.time()) if now is None else int(now)
     lines = [
         HEADER_LINE,
         f"最終巡回: {format_last_run(state.get('last_run_at'), timezone_name)}",
@@ -100,7 +124,12 @@ def build_latest_query_lines(
         if not isinstance(health, Mapping):
             raise ValueError(f"state entry {work_id}.health must be an object")
 
-        partial_failure = partial_failure or int(health.get("consecutive_failures") or 0) > 0
+        partial_failure = partial_failure or has_saved_data_warning(
+            raw_entry,
+            health,
+            now=current_time,
+            timezone_name=timezone_name,
+        )
         rendered_works.append(render_work_line(work_id, latest))
 
     if not rendered_works or all(line.startswith("（未取得）") for line in rendered_works):
@@ -118,8 +147,9 @@ def build_latest_query_response(
     state: Mapping[str, object],
     *,
     timezone_name: Optional[str] = None,
+    now: Optional[int] = None,
 ) -> str:
-    return "\n".join(build_latest_query_lines(watchlist, state, timezone_name=timezone_name))
+    return "\n".join(build_latest_query_lines(watchlist, state, timezone_name=timezone_name, now=now))
 
 
 def handle_latest_query(

--- a/tests/test_discord_latest.py
+++ b/tests/test_discord_latest.py
@@ -254,6 +254,78 @@ class DiscordLatestTests(unittest.TestCase):
             response,
         )
 
+    def test_build_latest_query_response_uses_plain_text_and_fallback_labels_without_url(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-1",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-1",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                }
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-1": {
+                    "latest": {
+                        "series": "作品A fallback",
+                        "episode_code": "ep-2",
+                    },
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                }
+            },
+            last_run_at=1_700_000_000,
+        )
+
+        response = build_latest_query_response(watchlist, state, timezone_name="Asia/Tokyo")
+
+        self.assertIn("ep-2　作品A fallback", response)
+        self.assertNotIn("[ep-2]", response)
+
+    def test_build_latest_query_response_warns_for_stale_saved_data(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-1",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-1",
+                    "enabled": True,
+                    "health_policy": {"expected_interval_seconds": 3_600},
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                }
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-1": {
+                    "latest": {
+                        "series_title": "作品A",
+                        "episode_title": "第2話",
+                        "url": "https://example.com/2",
+                    },
+                    "history": [],
+                    "health": {
+                        "last_checked_at": 1_700_010_000,
+                        "last_success_at": 1_700_000_000,
+                        "consecutive_failures": 0,
+                    },
+                }
+            },
+            last_run_at=1_700_010_000,
+        )
+
+        response = build_latest_query_response(
+            watchlist,
+            state,
+            timezone_name="Asia/Tokyo",
+            now=1_700_008_000,
+        )
+
+        self.assertTrue(response.endswith(PARTIAL_FAILURE_WARNING))
+
     def test_episode_label_truncation_matches_spec_examples(self):
         self.assertEqual("第71話 abcdefg…", truncate_episode_label("第71話 abcdefghijk"))
         self.assertEqual("第71話 あいうえおかき…", truncate_episode_label("第71話 あいうえおかきくけ"))


### PR DESCRIPTION
## Issue
- closes #85
- parent #83

## What Changed
- align Discord `latest` saved-data warning semantics with the canonical stale/partial-failure contract
- derive stale warning eligibility from existing watchlist health policy and stored health timestamps without adding any live crawl or state mutation
- add focused acceptance coverage for stale warning behavior and URL-less fallback rendering

## Verification
- `python -m unittest tests.test_discord_latest tests.test_discord_inbound tests.test_status`

## Residual Risks
- stale warning derivation shares the current default schedule logic; if the benchmark / scheduling contract changes, warning timing should be rechecked against #96
