### PR TITLE
Guarantee state safety during concurrent persistence

### DIFF
--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -691,6 +691,7 @@ def run_check(
 
     state["last_run_at"] = now
     try:
+        # Persist source observations before control returns to the runner's delivery phase.
         save_state(state)
     except Exception as exc:
         errors["run"].append(run_error_record("save_state", exc))

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -463,6 +463,7 @@ def run_once(
     checker_completed = primary_failure is None
 
     try:
+        # Re-open the durable snapshot written by the checker for delivery/outbox persistence.
         state = state_loader()
     except Exception as exc:
         errors["run"].append(runner_error_record("load_runner_state", exc))

--- a/manga_watch/storage.py
+++ b/manga_watch/storage.py
@@ -1,7 +1,11 @@
 import json
 import os
 import re
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+import tempfile
+from contextlib import contextmanager
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+import fcntl
 
 from manga_watch.update_classification import DEFAULT_NOTIFY_UPDATE_TYPES, SUPPORTED_UPDATE_TYPES
 
@@ -90,20 +94,43 @@ def save_watchlist(watchlist: Mapping[str, object], path: Optional[str] = None) 
     atomic_write_json(path or get_watchlist_path(), validate_watchlist(watchlist))
 
 
+@contextmanager
+def advisory_file_lock(path: str) -> Iterator[None]:
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    lock_path = f"{path}.lock"
+    lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
 def atomic_write_json(path: str, payload: Mapping[str, object]) -> None:
     directory = os.path.dirname(path) or "."
     os.makedirs(directory, exist_ok=True)
-    tmp_path = f"{path}.tmp"
-    with open(tmp_path, "w", encoding="utf-8") as f:
-        json.dump(payload, f, ensure_ascii=False, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp_path, path)
-    dir_fd = os.open(directory, os.O_RDONLY)
-    try:
-        os.fsync(dir_fd)
-    finally:
-        os.close(dir_fd)
+    prefix = f".{os.path.basename(path) or 'state'}."
+    with advisory_file_lock(path):
+        fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=prefix, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+            dir_fd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
 
 
 def validate_watchlist(payload: Mapping[str, object]) -> Dict[str, object]:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,133 @@
+import json
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest import mock
+
+from manga_watch.storage import load_state, save_state
+
+
+def make_state(*, latest_key: str, last_run_at: int) -> dict:
+    return {
+        "version": 2,
+        "works": {
+            "work-1": {
+                "latest": {
+                    "series_title": "作品A",
+                    "episode_title": latest_key,
+                    "latest_key": latest_key,
+                    "url": f"https://example.com/{latest_key}",
+                },
+                "history": [],
+                "health": {
+                    "last_checked_at": last_run_at,
+                    "last_success_at": last_run_at,
+                    "consecutive_failures": 0,
+                },
+                "unread": {
+                    "event_ids": [latest_key],
+                },
+            }
+        },
+        "last_run_at": last_run_at,
+        "notification_outbox": [],
+        "discord_delivery": {
+            "daily_notification": {
+                "delivered_latest_keys": {},
+                "pending_messages": [],
+            }
+        },
+    }
+
+
+class StorageTests(unittest.TestCase):
+    def test_save_state_keeps_previous_json_when_write_fails_before_replace(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            save_state(make_state(latest_key="episode-1", last_run_at=1), path=str(state_path))
+            original = load_state(str(state_path))
+
+            def interrupted_dump(payload, fp, **kwargs):
+                fp.write('{"version": 2')
+                fp.flush()
+                raise RuntimeError("simulated crash")
+
+            with mock.patch("manga_watch.storage.json.dump", side_effect=interrupted_dump):
+                with self.assertRaisesRegex(RuntimeError, "simulated crash"):
+                    save_state(make_state(latest_key="episode-2", last_run_at=2), path=str(state_path))
+
+            self.assertEqual(original, load_state(str(state_path)))
+            self.assertEqual(original["last_run_at"], json.loads(state_path.read_text(encoding="utf-8"))["last_run_at"])
+            self.assertEqual([], list(Path(tmpdir).glob("*.tmp")))
+
+    def test_load_state_never_observes_partial_json_during_repeated_writes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            save_state(make_state(latest_key="episode-initial", last_run_at=0), path=str(state_path))
+
+            stop_readers = threading.Event()
+            observed = []
+            reader_errors = []
+
+            def reader():
+                while not stop_readers.is_set():
+                    try:
+                        snapshot = load_state(str(state_path))
+                        observed.append(snapshot["works"]["work-1"]["latest"]["latest_key"])
+                    except Exception as exc:  # pragma: no cover - asserted via reader_errors
+                        reader_errors.append(exc)
+                        stop_readers.set()
+
+            reader_threads = [threading.Thread(target=reader, daemon=True) for _ in range(3)]
+            for thread in reader_threads:
+                thread.start()
+
+            try:
+                for index in range(60):
+                    save_state(
+                        make_state(latest_key=f"episode-{index}", last_run_at=index),
+                        path=str(state_path),
+                    )
+            finally:
+                stop_readers.set()
+                for thread in reader_threads:
+                    thread.join(timeout=1)
+
+            self.assertEqual([], reader_errors)
+            self.assertIn("episode-initial", observed)
+            self.assertIn(load_state(str(state_path))["works"]["work-1"]["latest"]["latest_key"], observed)
+
+    def test_concurrent_writers_keep_state_parseable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            save_state(make_state(latest_key="episode-initial", last_run_at=0), path=str(state_path))
+            written_keys = set()
+
+            def writer(worker_id: int):
+                latest_key = f"worker-{worker_id}"
+                written_keys.add(latest_key)
+                for attempt in range(25):
+                    save_state(
+                        make_state(
+                            latest_key=latest_key,
+                            last_run_at=worker_id * 100 + attempt,
+                        ),
+                        path=str(state_path),
+                    )
+
+            with ThreadPoolExecutor(max_workers=4) as executor:
+                futures = [executor.submit(writer, worker_id) for worker_id in range(4)]
+                for future in futures:
+                    future.result()
+
+            final_state = load_state(str(state_path))
+            final_latest_key = final_state["works"]["work-1"]["latest"]["latest_key"]
+
+            self.assertIn(final_latest_key, written_keys)
+            self.assertEqual(final_latest_key, json.loads(state_path.read_text(encoding="utf-8"))["works"]["work-1"]["latest"]["latest_key"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue
- Closes #86
- Parent #83

## What Changed
- serialize `atomic_write_json()` with an advisory lock and per-write temp files so repeated concurrent writers do not trample a shared `*.tmp`
- remove partial temp files when a write fails before replace, keeping the last durable JSON intact
- add persistence acceptance tests for interrupted writes, concurrent readers, and concurrent writers
- add small boundary comments clarifying that `check` persists crawl state before `runner` starts delivery/outbox persistence

## Verification
- `python -m unittest tests.test_storage tests.test_check tests.test_runner`

## Residual Risks
- writer coordination is advisory and POSIX-oriented (`fcntl`), so these guarantees are scoped to the repo's Unix-like runtime
- the change guarantees parseable old-or-new state visibility; it does not attempt cross-run semantic conflict resolution beyond serialized writes
