### PR TITLE
Fix secret leakage in delivery failure paths

### DIFF
--- a/manga_watch/discord_outbound.py
+++ b/manga_watch/discord_outbound.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
 
+from manga_watch.secret_redaction import redact_secret_text
 from manga_watch.discord_text import (
     episode_label_for_snapshot,
     series_label_for_snapshot,
@@ -101,12 +102,17 @@ class DiscordChannelClient:
                 allow_redirects=False,
             )
         except requests.RequestException as exc:
-            raise RuntimeError(f"Discord delivery failed: {exc}") from exc
+            raise RuntimeError(
+                f"Discord delivery failed: {redact_secret_text(exc, secrets=(self.config.bot_token,))}"
+            ) from exc
 
         if 200 <= response.status_code < 300:
             return
 
-        detail = response.text.strip().replace("\n", " ")
+        detail = redact_secret_text(
+            response.text.strip().replace("\n", " "),
+            secrets=(self.config.bot_token,),
+        )
         raise RuntimeError(f"Discord returned HTTP {response.status_code}: {detail[:300]}")
 
     def get_current_user_id(self) -> str:
@@ -120,7 +126,10 @@ class DiscordChannelClient:
                 allow_redirects=False,
             )
         except requests.RequestException as exc:
-            raise RuntimeError(f"Discord current-user lookup failed: {exc}") from exc
+            raise RuntimeError(
+                "Discord current-user lookup failed: "
+                f"{redact_secret_text(exc, secrets=(self.config.bot_token,))}"
+            ) from exc
 
         if 200 <= response.status_code < 300:
             payload = response.json()
@@ -129,7 +138,10 @@ class DiscordChannelClient:
                 return user_id
             raise RuntimeError("Discord current-user lookup returned no id")
 
-        detail = response.text.strip().replace("\n", " ")
+        detail = redact_secret_text(
+            response.text.strip().replace("\n", " "),
+            secrets=(self.config.bot_token,),
+        )
         raise RuntimeError(f"Discord returned HTTP {response.status_code}: {detail[:300]}")
 
     def list_channel_messages(
@@ -159,7 +171,9 @@ class DiscordChannelClient:
                 allow_redirects=False,
             )
         except requests.RequestException as exc:
-            raise RuntimeError(f"Discord channel read failed: {exc}") from exc
+            raise RuntimeError(
+                f"Discord channel read failed: {redact_secret_text(exc, secrets=(self.config.bot_token,))}"
+            ) from exc
 
         if 200 <= response.status_code < 300:
             payload = response.json()
@@ -167,7 +181,10 @@ class DiscordChannelClient:
                 raise RuntimeError("Discord channel read returned an invalid payload")
             return [dict(message) for message in payload if isinstance(message, Mapping)]
 
-        detail = response.text.strip().replace("\n", " ")
+        detail = redact_secret_text(
+            response.text.strip().replace("\n", " "),
+            secrets=(self.config.bot_token,),
+        )
         raise RuntimeError(f"Discord returned HTTP {response.status_code}: {detail[:300]}")
 
 
@@ -367,6 +384,7 @@ def deliver_daily_notifications(
     *,
     client: DiscordTransport,
     attempted_at: str,
+    redaction_secrets: Sequence[object] = (),
 ) -> Dict[str, object]:
     daily_notification = _daily_notification_state(state)
     pending_messages = list(daily_notification.get("pending_messages", []) or [])
@@ -402,9 +420,12 @@ def deliver_daily_notifications(
             blocked = True
             entry["attempt_count"] = int(entry.get("attempt_count", 0) or 0) + 1
             entry["last_attempted_at"] = attempted_at
-            entry["last_error"] = str(exc)
+            entry["last_error"] = redact_secret_text(exc, secrets=redaction_secrets)
             remaining_messages.append(entry)
-            errors.append(f"daily_notification: {exc}")
+            errors.append(
+                "daily_notification: "
+                f"{redact_secret_text(exc, secrets=redaction_secrets)}"
+            )
 
     daily_notification["pending_messages"] = remaining_messages
     return {
@@ -447,6 +468,7 @@ def build_run_report_message(
     errors: Mapping[str, Sequence[Mapping[str, object]]],
     delivery_failures: Sequence[str],
     state_lines: Sequence[str],
+    redaction_secrets: Sequence[object] = (),
 ) -> str:
     source_failures = len(errors.get("sources", []))
     run_failures = len(errors.get("run", []))
@@ -472,13 +494,20 @@ def build_run_report_message(
         f"delivery failure: {delivery_failure_count}件",
     ]
     checker_error_lines = _format_checker_error_lines(errors)
+    if redaction_secrets:
+        checker_error_lines = [
+            redact_secret_text(line, secrets=redaction_secrets) for line in checker_error_lines
+        ]
     if checker_error_lines:
         lines.append("failure details:")
         lines.extend(checker_error_lines)
     if delivery_failures:
         if not checker_error_lines:
             lines.append("failure details:")
-        lines.extend(f"- delivery: {failure}" for failure in delivery_failures)
+        lines.extend(
+            f"- delivery: {redact_secret_text(failure, secrets=redaction_secrets)}"
+            for failure in delivery_failures
+        )
     lines.append("現在のリスト:")
     lines.extend(state_lines)
     return "\n".join(lines)
@@ -489,11 +518,13 @@ def format_run_report_delivery_failure(
     timestamp: str,
     trigger_source: str,
     exc: Exception,
+    redaction_secrets: Sequence[object] = (),
 ) -> str:
     return "\n".join(
         [
             f"{RUN_REPORT_FAILURE_HEADLINE} ({timestamp})",
             f"トリガー: {trigger_source}",
-            f"エラー: {exc.__class__.__name__}: {exc}",
+            "エラー: "
+            f"{exc.__class__.__name__}: {redact_secret_text(exc, secrets=redaction_secrets)}",
         ]
     )

--- a/manga_watch/notifier.py
+++ b/manga_watch/notifier.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Mapping, Optional, Protocol, Sequence, TextIO, Tu
 
 import requests
 
+from manga_watch.secret_redaction import redact_secret_text
+
 DEFAULT_WEBHOOK_TIMEOUT = 10
 SUPPORTED_NOTIFIER_BACKENDS = {"stdout", "webhook"}
 
@@ -298,12 +300,17 @@ class WebhookNotifier:
                 allow_redirects=False,
             )
         except requests.RequestException as exc:
-            raise RuntimeError(f"Webhook delivery failed: {exc}") from exc
+            raise RuntimeError(
+                f"Webhook delivery failed: {redact_secret_text(exc, secrets=(self.webhook_url,))}"
+            ) from exc
 
         if 200 <= response.status_code < 300:
             return
 
-        detail = response.text.strip().replace("\n", " ")
+        detail = redact_secret_text(
+            response.text.strip().replace("\n", " "),
+            secrets=(self.webhook_url,),
+        )
         raise RuntimeError(f"Webhook returned HTTP {response.status_code}: {detail[:300]}")
 
 

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -28,6 +28,7 @@ from manga_watch.notifier import (
     detected_at_for_timestamp,
     event_from_payload,
 )
+from manga_watch.secret_redaction import redact_secret_text
 from manga_watch.storage import DEFAULT_WATCHLIST_PATH, get_state_path, load_state, save_state
 from manga_watch.update_classification import DEFAULT_NOTIFY_UPDATE_TYPES
 
@@ -233,6 +234,7 @@ def deliver_notification_outbox(
     *,
     named_notifiers: Mapping[str, Notifier],
     attempted_at: str,
+    redaction_secrets: tuple[str, ...] = (),
 ) -> Dict[str, object]:
     outbox = load_notification_outbox(state)
     remaining: List[Dict[str, object]] = []
@@ -255,9 +257,10 @@ def deliver_notification_outbox(
                 backend_notifier.send(event)
                 delivered_count += 1
             except Exception as exc:
+                redacted_message = redact_secret_text(exc, secrets=redaction_secrets)
                 pending_backends.append(backend_name)
-                entry_failures.append(f"{backend_name}: {exc}")
-                failures.append(f"{event.event_id} {backend_name}: {exc}")
+                entry_failures.append(f"{backend_name}: {redacted_message}")
+                failures.append(f"{event.event_id} {backend_name}: {redacted_message}")
 
         if pending_backends:
             remaining.append(
@@ -283,12 +286,19 @@ def checker_error_count(errors: Dict[str, List[Dict[str, object]]]) -> int:
     return len(errors["sources"]) + len(errors["run"])
 
 
-def format_failure_report(timestamp: str, trigger_source: str, exc: Exception) -> str:
+def format_failure_report(
+    timestamp: str,
+    trigger_source: str,
+    exc: Exception,
+    *,
+    redaction_secrets: tuple[str, ...] = (),
+) -> str:
     return "\n".join(
         [
             f"巡回実行に失敗しました ({timestamp})",
             f"トリガー: {trigger_source}",
-            f"エラー: {exc.__class__.__name__}: {exc}",
+            "エラー: "
+            f"{exc.__class__.__name__}: {redact_secret_text(exc, secrets=redaction_secrets)}",
         ]
     )
 
@@ -310,21 +320,32 @@ def format_replay_report(
     )
 
 
-def format_replay_failure_report(timestamp: str, exc: Exception) -> str:
+def format_replay_failure_report(
+    timestamp: str,
+    exc: Exception,
+    *,
+    redaction_secrets: tuple[str, ...] = (),
+) -> str:
     return "\n".join(
         [
             f"通知 outbox の再送に失敗しました ({timestamp})",
-            f"エラー: {exc.__class__.__name__}: {exc}",
+            "エラー: "
+            f"{exc.__class__.__name__}: {redact_secret_text(exc, secrets=redaction_secrets)}",
         ]
     )
 
 
-def runner_error_record(stage: str, exc: Exception) -> Dict[str, str]:
+def runner_error_record(
+    stage: str,
+    exc: Exception,
+    *,
+    redaction_secrets: tuple[str, ...] = (),
+) -> Dict[str, str]:
     return {
         "stage": stage,
         "kind": "runtime",
         "errorType": exc.__class__.__name__,
-        "message": str(exc),
+        "message": redact_secret_text(exc, secrets=redaction_secrets),
     }
 
 
@@ -399,6 +420,15 @@ def rejected_run_outcome(trigger_source: str, *, timestamp: str) -> Dict[str, ob
     }
 
 
+def runner_redaction_secrets(config: "RunnerConfig") -> tuple[str, ...]:
+    secrets = []
+    if config.notifier_config.webhook_url:
+        secrets.append(config.notifier_config.webhook_url)
+    if config.discord_outbound_config is not None:
+        secrets.append(config.discord_outbound_config.bot_token)
+    return tuple(secrets)
+
+
 def run_once(
     config: RunnerConfig,
     *,
@@ -413,6 +443,7 @@ def run_once(
     error_logger: Callable[[str], None] = report_to_stderr,
     trigger_source: str = TRIGGER_SOURCE_SCHEDULED,
 ) -> Dict[str, object]:
+    redaction_secrets = runner_redaction_secrets(config)
     named_notifiers = resolve_named_notifiers(
         config,
         notifier=notifier,
@@ -451,10 +482,21 @@ def run_once(
         try:
             errors = normalize_checker_errors(result)
         except Exception as normalize_exc:
-            errors = {"sources": [], "run": [runner_error_record("normalize_checker_errors", normalize_exc)]}
+            errors = {
+                "sources": [],
+                "run": [
+                    runner_error_record(
+                        "normalize_checker_errors",
+                        normalize_exc,
+                        redaction_secrets=redaction_secrets,
+                    )
+                ],
+            }
     except Exception as exc:
         primary_failure = exc
-        errors["run"].append(runner_error_record("checker", exc))
+        errors["run"].append(
+            runner_error_record("checker", exc, redaction_secrets=redaction_secrets)
+        )
 
     update_count = len(updates)
     notify_updates, suppressed_updates = partition_updates_by_notification_policy(updates)
@@ -465,7 +507,9 @@ def run_once(
     try:
         state = state_loader()
     except Exception as exc:
-        errors["run"].append(runner_error_record("load_runner_state", exc))
+        errors["run"].append(
+            runner_error_record("load_runner_state", exc, redaction_secrets=redaction_secrets)
+        )
         if primary_failure is None:
             primary_failure = exc
 
@@ -484,6 +528,7 @@ def run_once(
                         runner_error_record(
                             "build_update_event",
                             RuntimeError(f"{work_id}: {exc}"),
+                            redaction_secrets=redaction_secrets,
                         )
                     )
 
@@ -500,6 +545,7 @@ def run_once(
                 state,
                 named_notifiers=named_notifiers,
                 attempted_at=detected_at,
+                redaction_secrets=redaction_secrets,
             )
             outbox_pending_count = int(delivery["remainingCount"])
             if had_existing_outbox or enqueued_count > 0 or outbox_pending_count > 0:
@@ -507,7 +553,9 @@ def run_once(
             if delivery["errors"]:
                 delivery_failures.extend(delivery["errors"])
         except Exception as exc:
-            errors["run"].append(runner_error_record("generic_notification", exc))
+            errors["run"].append(
+                runner_error_record("generic_notification", exc, redaction_secrets=redaction_secrets)
+            )
             if primary_failure is None:
                 primary_failure = exc
 
@@ -528,6 +576,7 @@ def run_once(
                     state,
                     client=resolved_discord_client,
                     attempted_at=detected_at,
+                    redaction_secrets=redaction_secrets,
                 )
                 daily_notification_sent = int(daily_delivery["deliveredCount"]) > 0
                 if enqueue_result["queued"] or int(daily_delivery["attemptedCount"]) > 0:
@@ -535,7 +584,13 @@ def run_once(
                 if daily_delivery["errors"]:
                     delivery_failures.extend(daily_delivery["errors"])
             except Exception as exc:
-                errors["run"].append(runner_error_record("discord_daily_notification", exc))
+                errors["run"].append(
+                    runner_error_record(
+                        "discord_daily_notification",
+                        exc,
+                        redaction_secrets=redaction_secrets,
+                    )
+                )
                 if primary_failure is None:
                     primary_failure = exc
 
@@ -553,6 +608,7 @@ def run_once(
         errors=errors,
         delivery_failures=delivery_failures,
         state_lines=format_state_lines(state),
+        redaction_secrets=redaction_secrets,
     )
 
     if resolved_discord_client is not None and config.discord_outbound_config is not None:
@@ -568,6 +624,7 @@ def run_once(
                     timestamp=timestamp,
                     trigger_source=trigger_source,
                     exc=exc,
+                    redaction_secrets=redaction_secrets,
                 )
             )
 
@@ -582,7 +639,14 @@ def run_once(
             f"{first_run_error.get('stage')}: {first_run_error.get('message')}"
         )
     if primary_failure is not None:
-        error_logger(format_failure_report(timestamp, trigger_source, primary_failure))
+        error_logger(
+            format_failure_report(
+                timestamp,
+                trigger_source,
+                primary_failure,
+                redaction_secrets=redaction_secrets,
+            )
+        )
 
     outcome = {
         "ok": error_count == 0 and not delivery_failures and run_report_delivery_error is None,
@@ -596,9 +660,15 @@ def run_once(
         "dailyNotificationSent": daily_notification_sent,
     }
     if primary_failure is not None:
-        outcome["error"] = f"{primary_failure.__class__.__name__}: {primary_failure}"
+        outcome["error"] = (
+            f"{primary_failure.__class__.__name__}: "
+            f"{redact_secret_text(primary_failure, secrets=redaction_secrets)}"
+        )
     elif run_report_delivery_error is not None:
-        outcome["error"] = f"{run_report_delivery_error.__class__.__name__}: {run_report_delivery_error}"
+        outcome["error"] = (
+            f"{run_report_delivery_error.__class__.__name__}: "
+            f"{redact_secret_text(run_report_delivery_error, secrets=redaction_secrets)}"
+        )
     return outcome
 
 
@@ -695,6 +765,7 @@ def replay_outbox_once(
     report_logger: Callable[[str], None] = report_to_stdout,
     error_logger: Callable[[str], None] = report_to_stderr,
 ) -> Dict[str, object]:
+    redaction_secrets = runner_redaction_secrets(config)
     named_notifiers = resolve_named_notifiers(
         config,
         notifier=notifier,
@@ -710,6 +781,7 @@ def replay_outbox_once(
             state,
             named_notifiers=named_notifiers,
             attempted_at=detected_at,
+            redaction_secrets=redaction_secrets,
         )
         state_saver(state)
         if delivery["errors"]:
@@ -731,14 +803,20 @@ def replay_outbox_once(
             "timestamp": timestamp,
         }
     except Exception as exc:
-        error_logger(format_replay_failure_report(timestamp, exc))
+        error_logger(
+            format_replay_failure_report(
+                timestamp,
+                exc,
+                redaction_secrets=redaction_secrets,
+            )
+        )
         return {
             "ok": False,
             "attemptedEventCount": 0,
             "deliveredCount": 0,
             "remainingCount": 0,
             "timestamp": timestamp,
-            "error": f"{exc.__class__.__name__}: {exc}",
+            "error": f"{exc.__class__.__name__}: {redact_secret_text(exc, secrets=redaction_secrets)}",
         }
 
 

--- a/manga_watch/secret_redaction.py
+++ b/manga_watch/secret_redaction.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+
+REDACTED_SECRET = "[REDACTED_SECRET]"
+REDACTED_WEBHOOK_URL = "[REDACTED_WEBHOOK_URL]"
+REDACTED_BOT_TOKEN = "[REDACTED_BOT_TOKEN]"
+
+_BOT_TOKEN_RE = re.compile(r"(Bot\s+)([^\s'\"<>]+)")
+_DISCORD_WEBHOOK_RE = re.compile(
+    r"https://(?:ptb\.|canary\.)?discord(?:app)?\.com/api/webhooks/[^\s'\"<>]+"
+)
+
+
+def _coerce_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _flatten_secret_values(values: Sequence[object]) -> Iterable[str]:
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple, set, frozenset)):
+            yield from _flatten_secret_values(tuple(value))
+            continue
+        text = _coerce_text(value)
+        if text:
+            yield text
+
+
+def collect_secret_values(*values: object) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for secret in _flatten_secret_values(values):
+        if secret in seen:
+            continue
+        seen.add(secret)
+        ordered.append(secret)
+    ordered.sort(key=len, reverse=True)
+    return tuple(ordered)
+
+
+def _placeholder_for_secret(secret: str) -> str:
+    if _DISCORD_WEBHOOK_RE.fullmatch(secret):
+        return REDACTED_WEBHOOK_URL
+    return REDACTED_SECRET
+
+
+def redact_secret_text(value: object, *, secrets: Sequence[object] = ()) -> str:
+    text = str(value)
+    redacted = _DISCORD_WEBHOOK_RE.sub(REDACTED_WEBHOOK_URL, text)
+    redacted = _BOT_TOKEN_RE.sub(rf"\1{REDACTED_BOT_TOKEN}", redacted)
+    for secret in collect_secret_values(secrets):
+        redacted = redacted.replace(secret, _placeholder_for_secret(secret))
+    return redacted

--- a/tests/test_discord_outbound.py
+++ b/tests/test_discord_outbound.py
@@ -2,6 +2,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import requests
+
 from manga_watch.discord_outbound import (
     DiscordChannelClient,
     DiscordOutboundConfig,
@@ -149,6 +151,44 @@ class DiscordOutboundTests(unittest.TestCase):
         )
         self.assertEqual({"limit": 100, "after": "10"}, session.calls[1]["params"])
         self.assertEqual("latest", messages[0]["content"])
+
+    def test_discord_channel_client_masks_bot_token_in_transport_error(self):
+        token = "discord-bot-token"
+        session = FakeSession(error=requests.Timeout(f"Authorization: Bot {token}"))
+        client = DiscordChannelClient(
+            DiscordOutboundConfig(
+                bot_token=token,
+                main_channel_id="main-channel",
+                run_report_channel_id="run-report-channel",
+            ),
+            session=session,
+        )
+
+        with self.assertRaises(RuntimeError) as exc_info:
+            client.send_message("run-report-channel", "hello")
+
+        self.assertNotIn(token, str(exc_info.exception))
+        self.assertIn("[REDACTED_BOT_TOKEN]", str(exc_info.exception))
+
+    def test_discord_channel_client_masks_bot_token_in_error_response(self):
+        token = "discord-bot-token"
+        session = FakeSession(
+            responses=[FakeResponse(401, text=f"Authorization header was Bot {token}")]
+        )
+        client = DiscordChannelClient(
+            DiscordOutboundConfig(
+                bot_token=token,
+                main_channel_id="main-channel",
+                run_report_channel_id="run-report-channel",
+            ),
+            session=session,
+        )
+
+        with self.assertRaises(RuntimeError) as exc_info:
+            client.send_message("run-report-channel", "hello")
+
+        self.assertNotIn(token, str(exc_info.exception))
+        self.assertIn("[REDACTED_BOT_TOKEN]", str(exc_info.exception))
 
     def test_state_round_trip_preserves_discord_delivery_state(self):
         state = {

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -46,6 +46,14 @@ class FakeNotifier:
         self.events.append(event)
 
 
+class SecretLeakingNotifier:
+    def __init__(self, message):
+        self.message = message
+
+    def send(self, event):
+        raise RuntimeError(self.message)
+
+
 class FakeResponse:
     def __init__(self, status_code, text=""):
         self.status_code = status_code
@@ -91,6 +99,22 @@ class FakeDiscordClient:
             raise RuntimeError("discord delivery failed")
         if channel_id in self.fail_channels:
             raise RuntimeError(f"discord delivery failed for {channel_id}")
+
+
+class SecretLeakingDiscordClient:
+    def __init__(self, token):
+        self.token = token
+        self.calls = []
+
+    def send_message(self, channel_id, content):
+        self.calls.append(
+            {
+                "channel_id": channel_id,
+                "content": content,
+            }
+        )
+        if channel_id == "main-channel":
+            raise RuntimeError(f"discord auth failed with Authorization: Bot {self.token}")
 
 
 class RunnerTests(unittest.TestCase):
@@ -328,6 +352,21 @@ class RunnerTests(unittest.TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "Webhook delivery failed"):
             notifier.send(event)
+
+    def test_webhook_notifier_masks_webhook_url_in_transport_error(self):
+        webhook_url = "https://discord.com/api/webhooks/123/secret"
+        event = build_update_event(
+            self.make_update(latest_key="episode-2"),
+            detected_at="2023-11-14T22:13:20Z",
+        )
+        session = FakeSession(error=requests.Timeout(f"POST {webhook_url} timed out"))
+        notifier = WebhookNotifier(webhook_url, session=session)
+
+        with self.assertRaises(RuntimeError) as exc_info:
+            notifier.send(event)
+
+        self.assertNotIn(webhook_url, str(exc_info.exception))
+        self.assertIn("[REDACTED_WEBHOOK_URL]", str(exc_info.exception))
 
     def test_run_once_without_updates_only_logs_report(self):
         notifier = FakeNotifier()
@@ -783,6 +822,61 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("boom", discord.calls[0]["content"])
         self.assertEqual(1, len(errors))
         self.assertIn("boom", errors[0])
+
+    def test_run_once_redacts_secrets_from_failure_outputs(self):
+        bot_token = "discord-bot-token"
+        webhook_url = "https://discord.com/api/webhooks/123/secret"
+        discord = SecretLeakingDiscordClient(bot_token)
+        errors = []
+        store, load_from_store, save_to_store = self.make_state_store()
+        config = RunnerConfig(
+            timezone_name="Asia/Tokyo",
+            watchlist_path="/tmp/watchlist.json",
+            crawl_schedule="0 19 * * *",
+            crawl_interval=None,
+            run_on_startup=True,
+            notifier_config=NotifierConfig(backends=("webhook",), webhook_url=webhook_url),
+            discord_outbound_config=DiscordOutboundConfig(
+                bot_token=bot_token,
+                main_channel_id="main-channel",
+                run_report_channel_id="run-report-channel",
+            ),
+        )
+
+        outcome = run_once(
+            config,
+            named_notifiers={"webhook": SecretLeakingNotifier(f"webhook delivery failed for {webhook_url}")},
+            discord_client=discord,
+            checker=lambda _: {"updates": [self.make_update()]},
+            state_loader=load_from_store,
+            state_saver=save_to_store,
+            now_fn=lambda: 1_700_000_000,
+            report_logger=lambda _: self.fail("unexpected report log"),
+            error_logger=errors.append,
+        )
+
+        self.assertFalse(outcome["ok"])
+        self.assertEqual(2, len(discord.calls))
+        run_report = discord.calls[1]["content"]
+        self.assertNotIn(bot_token, run_report)
+        self.assertNotIn(webhook_url, run_report)
+        self.assertIn("[REDACTED_BOT_TOKEN]", run_report)
+        self.assertIn("[REDACTED_WEBHOOK_URL]", run_report)
+        self.assertEqual(1, len(errors))
+        self.assertNotIn(bot_token, errors[0])
+        self.assertNotIn(webhook_url, errors[0])
+        self.assertIn("[REDACTED_BOT_TOKEN]", errors[0])
+        self.assertIn("[REDACTED_WEBHOOK_URL]", errors[0])
+        self.assertNotIn(webhook_url, store["notification_outbox"][0]["last_error"])
+        self.assertIn("[REDACTED_WEBHOOK_URL]", store["notification_outbox"][0]["last_error"])
+        self.assertNotIn(
+            bot_token,
+            store["discord_delivery"]["daily_notification"]["pending_messages"][0]["last_error"],
+        )
+        self.assertIn(
+            "[REDACTED_BOT_TOKEN]",
+            store["discord_delivery"]["daily_notification"]["pending_messages"][0]["last_error"],
+        )
 
     def test_handle_fetch_trigger_accepts_when_idle_and_runs_in_background(self):
         checker_started = threading.Event()


### PR DESCRIPTION
Closes #89

Parent: #83

## Summary
- add a shared redaction helper for Discord bot tokens and webhook URLs
- mask notifier, Discord transport, run report, and persisted delivery failure messages before they leave the runner path
- add focused transport and acceptance tests that lock the secret-safe failure behavior in place

## Testing
- python -m pytest tests/test_runner.py tests/test_discord_outbound.py

## Residual Risks
- the redaction policy is intentionally scoped to configured webhook/token values plus common Discord token/webhook shapes; unrelated secrets outside this path still need their own handling if introduced later
