### PR TITLE
Align fetch trigger with serialized concurrent-run contract

### DIFF
--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+from collections import deque
 import os
 import sys
 import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Callable, Dict, List, Mapping, Optional
+from typing import Callable, Deque, Dict, List, Mapping, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from manga_watch.check import CheckRunError, run_check
@@ -420,6 +421,28 @@ def rejected_run_outcome(trigger_source: str, *, timestamp: str) -> Dict[str, ob
     }
 
 
+def queued_run_outcome(
+    trigger_source: str,
+    *,
+    timestamp: str,
+    background: bool,
+) -> Dict[str, object]:
+    return {
+        "ok": True,
+        "accepted": True,
+        "queued": True,
+        "serialized": True,
+        "background": background,
+        "updateCount": 0,
+        "notifiedUpdateCount": 0,
+        "suppressedUpdateCount": 0,
+        "errorCount": 0,
+        "outboxPendingCount": 0,
+        "timestamp": timestamp,
+        "triggerSource": trigger_source,
+    }
+
+
 def runner_redaction_secrets(config: "RunnerConfig") -> tuple[str, ...]:
     secrets = []
     if config.notifier_config.webhook_url:
@@ -687,6 +710,8 @@ class RunCoordinator:
     error_logger: Callable[[str], None] = report_to_stderr
     thread_factory: Callable[..., threading.Thread] = threading.Thread
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _pending_trigger_sources: Deque[str] = field(default_factory=deque, init=False, repr=False)
+    _pending_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def is_running(self) -> bool:
         return self._lock.locked()
@@ -711,18 +736,35 @@ class RunCoordinator:
 
     def _run_with_lock(self, *, trigger_source: str) -> Dict[str, object]:
         try:
-            return self._run_once(trigger_source=trigger_source)
+            outcome = self._run_once(trigger_source=trigger_source)
+            while True:
+                next_trigger_source = self._dequeue_trigger_source()
+                if next_trigger_source is None:
+                    return outcome
+                outcome = self._run_once(trigger_source=next_trigger_source)
         finally:
             self._lock.release()
 
+    def _enqueue_trigger_source(self, trigger_source: str) -> None:
+        with self._pending_lock:
+            self._pending_trigger_sources.append(trigger_source)
+
+    def _dequeue_trigger_source(self) -> Optional[str]:
+        with self._pending_lock:
+            if not self._pending_trigger_sources:
+                return None
+            return self._pending_trigger_sources.popleft()
+
     def run(self, trigger_source: str) -> Dict[str, object]:
         if not self._lock.acquire(blocking=False):
-            return rejected_run_outcome(trigger_source, timestamp=self._timestamp())
+            self._enqueue_trigger_source(trigger_source)
+            return queued_run_outcome(trigger_source, timestamp=self._timestamp(), background=False)
         return self._run_with_lock(trigger_source=trigger_source)
 
     def start_background(self, trigger_source: str) -> Dict[str, object]:
         if not self._lock.acquire(blocking=False):
-            return rejected_run_outcome(trigger_source, timestamp=self._timestamp())
+            self._enqueue_trigger_source(trigger_source)
+            return queued_run_outcome(trigger_source, timestamp=self._timestamp(), background=True)
 
         thread = self.thread_factory(
             target=self._run_with_lock,
@@ -747,10 +789,6 @@ class RunCoordinator:
 
 def start_fetch_run(coordinator: RunCoordinator) -> Dict[str, object]:
     outcome = coordinator.start_background(TRIGGER_SOURCE_DISCORD_FETCH)
-    if outcome.get("rejected"):
-        outcome["message"] = FETCH_REJECTED_MESSAGE
-        return outcome
-
     outcome["message"] = FETCH_ACCEPTED_MESSAGE
     return outcome
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -21,8 +21,6 @@ from manga_watch.notifier import (
 )
 from manga_watch.runner import (
     FETCH_ACCEPTED_MESSAGE,
-    FETCH_REJECTED_MESSAGE,
-    RUN_IN_PROGRESS_REASON,
     TRIGGER_SOURCE_DISCORD_FETCH,
     TRIGGER_SOURCE_SCHEDULED,
     TRIGGER_SOURCE_STARTUP,
@@ -927,13 +925,17 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(1, len(reports))
         self.assertEqual([], notifier.events)
 
-    def test_run_coordinator_rejects_startup_while_fetch_is_in_progress(self):
+    def test_run_coordinator_queues_startup_while_fetch_is_in_progress(self):
         checker_started = threading.Event()
         allow_finish = threading.Event()
+        reports = []
+        call_count = {"value": 0}
 
         def checker(_):
-            checker_started.set()
-            allow_finish.wait(1.0)
+            call_count["value"] += 1
+            if call_count["value"] == 1:
+                checker_started.set()
+                allow_finish.wait(1.0)
             return {"updates": []}
 
         coordinator = RunCoordinator(
@@ -943,7 +945,7 @@ class RunnerTests(unittest.TestCase):
             state_loader=self.make_state,
             state_saver=lambda _: None,
             now_fn=lambda: 1_700_000_000,
-            report_logger=lambda _: None,
+            report_logger=reports.append,
             error_logger=lambda _: self.fail("unexpected error log"),
         )
 
@@ -953,21 +955,29 @@ class RunnerTests(unittest.TestCase):
 
         startup_outcome = coordinator.run(TRIGGER_SOURCE_STARTUP)
 
-        self.assertFalse(startup_outcome["ok"])
-        self.assertTrue(startup_outcome["rejected"])
+        self.assertTrue(startup_outcome["ok"])
+        self.assertTrue(startup_outcome["accepted"])
+        self.assertTrue(startup_outcome["queued"])
+        self.assertTrue(startup_outcome["serialized"])
         self.assertEqual(TRIGGER_SOURCE_STARTUP, startup_outcome["triggerSource"])
-        self.assertEqual(RUN_IN_PROGRESS_REASON, startup_outcome["error"])
 
         allow_finish.set()
         self.wait_until(lambda: not coordinator.is_running())
+        self.assertEqual(2, call_count["value"])
+        self.assertEqual(2, len(reports))
+        self.assertIn("トリガー: startup", reports[1])
 
-    def test_run_coordinator_rejects_scheduled_while_fetch_is_in_progress(self):
+    def test_run_coordinator_queues_scheduled_while_fetch_is_in_progress(self):
         checker_started = threading.Event()
         allow_finish = threading.Event()
+        reports = []
+        call_count = {"value": 0}
 
         def checker(_):
-            checker_started.set()
-            allow_finish.wait(1.0)
+            call_count["value"] += 1
+            if call_count["value"] == 1:
+                checker_started.set()
+                allow_finish.wait(1.0)
             return {"updates": []}
 
         coordinator = RunCoordinator(
@@ -977,7 +987,7 @@ class RunnerTests(unittest.TestCase):
             state_loader=self.make_state,
             state_saver=lambda _: None,
             now_fn=lambda: 1_700_000_000,
-            report_logger=lambda _: None,
+            report_logger=reports.append,
             error_logger=lambda _: self.fail("unexpected error log"),
         )
 
@@ -987,13 +997,17 @@ class RunnerTests(unittest.TestCase):
 
         scheduled_outcome = coordinator.run(TRIGGER_SOURCE_SCHEDULED)
 
-        self.assertFalse(scheduled_outcome["ok"])
-        self.assertTrue(scheduled_outcome["rejected"])
+        self.assertTrue(scheduled_outcome["ok"])
+        self.assertTrue(scheduled_outcome["accepted"])
+        self.assertTrue(scheduled_outcome["queued"])
+        self.assertTrue(scheduled_outcome["serialized"])
         self.assertEqual(TRIGGER_SOURCE_SCHEDULED, scheduled_outcome["triggerSource"])
-        self.assertEqual(RUN_IN_PROGRESS_REASON, scheduled_outcome["error"])
 
         allow_finish.set()
         self.wait_until(lambda: not coordinator.is_running())
+        self.assertEqual(2, call_count["value"])
+        self.assertEqual(2, len(reports))
+        self.assertIn("トリガー: scheduled", reports[1])
 
     def test_handle_fetch_trigger_accepts_again_after_failure(self):
         call_count = {"value": 0}
@@ -1031,7 +1045,7 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("boom", errors[0])
         self.assertEqual(1, len(reports))
 
-    def test_rejected_fetch_does_not_invoke_checker_state_or_notifier(self):
+    def test_queued_fetch_defers_second_run_until_current_run_finishes(self):
         checker_started = threading.Event()
         allow_finish = threading.Event()
         calls = {"checker": 0, "state_loader": 0, "state_saver": 0}
@@ -1065,11 +1079,13 @@ class RunnerTests(unittest.TestCase):
         self.assertTrue(accepted_outcome["accepted"])
         self.assertTrue(checker_started.wait(0.5))
 
-        rejected_outcome = start_fetch_run(coordinator)
+        queued_outcome = start_fetch_run(coordinator)
 
-        self.assertFalse(rejected_outcome["ok"])
-        self.assertTrue(rejected_outcome["rejected"])
-        self.assertEqual(FETCH_REJECTED_MESSAGE, rejected_outcome["message"])
+        self.assertTrue(queued_outcome["ok"])
+        self.assertTrue(queued_outcome["accepted"])
+        self.assertTrue(queued_outcome["queued"])
+        self.assertTrue(queued_outcome["serialized"])
+        self.assertEqual(FETCH_ACCEPTED_MESSAGE, queued_outcome["message"])
         self.assertEqual(1, calls["checker"])
         self.assertEqual(0, calls["state_loader"])
         self.assertEqual(0, calls["state_saver"])
@@ -1077,6 +1093,7 @@ class RunnerTests(unittest.TestCase):
 
         allow_finish.set()
         self.wait_until(lambda: not coordinator.is_running())
+        self.assertEqual(2, calls["checker"])
 
     def test_replay_outbox_once_delivers_pending_events_and_clears_outbox(self):
         event = build_update_event(


### PR DESCRIPTION
## Issue
- closes #90
- parent #83

## What Changed
- replace busy-time fetch/startup/scheduled rejection with accepted + queued serialized execution inside `RunCoordinator`
- drain queued trigger sources in order after the current run finishes so `fetch` stays a write path without violating the state-safety boundary from #86
- update coordinator tests to lock the new queued/serialized behavior instead of the old reject contract

## Verification
- `python -m pytest tests/test_runner.py tests/test_discord_fetch.py tests/test_discord_inbound.py`

## Residual Risks
- multiple concurrent requests now serialize FIFO within one process; cross-process coordination is still intentionally left to the file-level durability guarantees and deployment model
