### PR TITLE
Add PR unit test workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run unit tests
+        env:
+          TZ: Asia/Tokyo
+        run: python -m unittest discover -s tests -p 'test_*.py'


### PR DESCRIPTION
## Issue
- Closes #109

## 変更概要
- `pull_request` / `merge_group` / `workflow_dispatch` で動く GitHub Actions の unit test workflow を追加
- `ubuntu-latest` + `Python 3.12` で `requirements.txt` を install して `python -m unittest discover -s tests -p 'test_*.py'` を実行

## 補足
- 当初は `migrate_v2` の legacy `latest_key` 補完もこの PR に含めていたが、PR 作成後に #110 が `main` へ merge され、v1 migration flow 自体が削除された
- そのため、現在の `main` に対する Issue #109 の残作業は unit test workflow 追加のみ

## 検証結果
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest discover -s tests -p 'test_*.py'`
- PR check `unittest`

## 残留リスク
- 追加した CI gate は既存 `unittest` suite のみを対象とし、外部依存の Discord 実機 E2E は対象外
