### PR TITLE
ci: update unit test workflow actions for Node 24

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## Issue
- Closes #120

## 変更概要
- `.github/workflows/unit-tests.yml` の `actions/checkout` を `v5` へ更新
- `.github/workflows/unit-tests.yml` の `actions/setup-python` を `v6` へ更新
- Python 3.12 / pip cache / `TZ=Asia/Tokyo` を含む既存 workflow の挙動は維持

## 検証結果
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest discover -s tests -p 'test_*.py'`
- GitHub Actions `Unit Tests` run: https://github.com/kentoku24/comic_crawler/actions/runs/22933931844
- `gh api repos/kentoku24/comic_crawler/check-runs/66561081127/annotations` が `[]` を返し、Node.js 20 deprecation warning が残っていないことを確認

## 残留リスク
- 今回の確認は `Unit Tests` workflow に限定しており、他 workflow に同種 warning が残っていてもこの PR では扱わない
