### PR TITLE
refactor: deduplicate _coerce_text and validated_timezone_name

### DIFF
--- a/manga_watch/discord_latest.py
+++ b/manga_watch/discord_latest.py
@@ -4,14 +4,18 @@ import os
 import time
 from datetime import datetime
 from typing import Callable, Dict, List, Mapping, Optional
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from zoneinfo import ZoneInfo
 
 from manga_watch.discord_text import (
     format_discord_link,
     latest_display_label_for_snapshot,
     series_label_for_snapshot,
 )
-from manga_watch.status import default_expected_interval_seconds, derive_health_status
+from manga_watch.status import (
+    default_expected_interval_seconds,
+    derive_health_status,
+    validated_timezone_name,
+)
 from manga_watch.storage import load_state, load_watchlist
 
 DEFAULT_TIMEZONE = "Asia/Tokyo"
@@ -20,14 +24,6 @@ HEADER_LINE = "保存済みの最新話一覧です"
 LIST_HEADER_LINE = "現在のリスト:"
 EMPTY_LINE = "- まだ保存済みの監視結果がありません"
 PARTIAL_FAILURE_WARNING = "注意: 一部作品は直近巡回で失敗しており、表示内容は保存済みデータです"
-
-
-def validated_timezone_name(timezone_name: str) -> str:
-    try:
-        ZoneInfo(timezone_name)
-    except ZoneInfoNotFoundError as exc:
-        raise ValueError(f"Unknown TZ value: {timezone_name}") from exc
-    return timezone_name
 
 
 def format_last_run(last_run_at: object, timezone_name: str) -> str:

--- a/manga_watch/discord_outbound.py
+++ b/manga_watch/discord_outbound.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from zoneinfo import ZoneInfo
 
 import requests
 
@@ -14,6 +14,8 @@ from manga_watch.discord_text import (
     series_label_for_snapshot,
     truncate_episode_label,
 )
+from manga_watch.status import validated_timezone_name
+from manga_watch.storage import normalize_optional_text as _coerce_text
 
 DEFAULT_DISCORD_API_BASE_URL = "https://discord.com/api/v10"
 DEFAULT_DISCORD_TIMEOUT = 10
@@ -21,21 +23,6 @@ DEFAULT_TIMEZONE = "Asia/Tokyo"
 DISCORD_DELIVERY_STATE_KEY = "discord_delivery"
 DAILY_NOTIFICATION_STATE_KEY = "daily_notification"
 RUN_REPORT_FAILURE_HEADLINE = "run report 自体の送信に失敗しました"
-
-
-def _coerce_text(value: object) -> Optional[str]:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
-
-def validated_timezone_name(timezone_name: str) -> str:
-    try:
-        ZoneInfo(timezone_name)
-    except ZoneInfoNotFoundError as exc:
-        raise ValueError(f"Unknown TZ value: {timezone_name}") from exc
-    return timezone_name
 
 
 class DiscordTransport(Protocol):

--- a/manga_watch/notifier.py
+++ b/manga_watch/notifier.py
@@ -9,16 +9,10 @@ from typing import Dict, List, Mapping, Optional, Protocol, Sequence, TextIO, Tu
 import requests
 
 from manga_watch.secret_redaction import redact_secret_text
+from manga_watch.storage import normalize_optional_text as _coerce_text
 
 DEFAULT_WEBHOOK_TIMEOUT = 10
 SUPPORTED_NOTIFIER_BACKENDS = {"stdout", "webhook"}
-
-
-def _coerce_text(value: object) -> Optional[str]:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
 
 
 def _snapshot_latest_key(snapshot: Mapping[str, object]) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Replace duplicated `_coerce_text()` in `discord_outbound.py` and `notifier.py` with `normalize_optional_text` import from `storage.py`
- Replace duplicated `validated_timezone_name()` in `discord_outbound.py` and `discord_latest.py` with import from `status.py`
- Remove unused `ZoneInfoNotFoundError` imports

## Test plan
- [x] All 163 unit tests pass (`python -m unittest discover -s tests -p 'test_*.py'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)