### PR TITLE
Add one-shot Cloud Run job entrypoint

### DIFF
--- a/doc/GCP移行確認手順.md
+++ b/doc/GCP移行確認手順.md
@@ -130,9 +130,11 @@ gcloud run jobs create comic-crawler-job \
   --project=star-light-breaker \
   --region=asia-northeast1 \
   --image=ghcr.io/kentoku24/comic_crawler:latest \
+  --command=python \
+  --args=-m,manga_watch.run_job \
   --tasks=1 \
   --max-retries=0 \
-  --set-env-vars=TZ=Asia/Tokyo,MANGA_WATCH_NOTIFIER_BACKENDS=stdout
+  --set-env-vars=TZ=Asia/Tokyo,MANGA_WATCH_NOTIFIER_BACKENDS=stdout,DISCORD_MAIN_CHANNEL_ID=<main-channel-id>,DISCORD_RUN_REPORT_CHANNEL_ID=<run-report-channel-id>,DISCORD_BOT_TOKEN_SECRET_VERSION=projects/star-light-breaker/secrets/comic-crawler-discord-bot-token/versions/latest
 ```
 
 Service deploy skeleton:
@@ -147,6 +149,7 @@ gcloud run deploy comic-crawler-service \
 確認ポイント:
 
 - image が `ghcr.io/kentoku24/comic_crawler:latest`
+- Job が `python -m manga_watch.run_job` を command override している
 - Job 名と Service 名を取り違えていない
 - region が `asia-northeast1`
 - Service auth / ingress / public-or-private exposure 方針は #146 が解くため、この packet では固定されていない
@@ -167,7 +170,7 @@ gcloud run jobs execute comic-crawler-job \
 - Firestore / Secret Manager / migration contract 自体は `doc/gcp-runtime.md` を参照する
 - 実環境 smoke test は #139 が未解決なので未完了
 - #146 が未解決なので Discord interaction service path は未完了
-- 現在の image は `python -m manga_watch.runner` を起動する long-running container であり、Cloud Run Job 完全対応をまだ主張しない
+- default image entrypoint は `python -m manga_watch.runner` のままだが、Cloud Run Job contract では `python -m manga_watch.run_job` を command override して使う
 
 したがって、手動実行を success criteria に含めるのは後続 runtime packet 完了後とする。
 

--- a/doc/gcp-deploy.md
+++ b/doc/gcp-deploy.md
@@ -18,6 +18,7 @@ GCP 上の resource 名、artifact image、Scheduler 呼び出し契約、未解
 | Artifact image | `ghcr.io/kentoku24/comic_crawler:latest` |
 | Local Compose service | `comic-crawler` |
 | Current container entrypoint | `python -m manga_watch.runner` |
+| Cloud Run Job command override | `python -m manga_watch.run_job` |
 
 使い分けは次で固定する。
 
@@ -81,7 +82,7 @@ gcloud scheduler jobs describe comic-crawler-scheduled-run \
 
 ## 5. Cloud Run Job contract
 
-Cloud Run Job の canonical name は `comic-crawler-job`。artifact image は `ghcr.io/kentoku24/comic_crawler:latest` を使う。
+Cloud Run Job の canonical name は `comic-crawler-job`。artifact image は `ghcr.io/kentoku24/comic_crawler:latest` を使い、Job 側では one-shot 実行のため `python -m manga_watch.run_job` を command override する。
 
 作成:
 
@@ -90,9 +91,11 @@ gcloud run jobs create comic-crawler-job \
   --project=star-light-breaker \
   --region=asia-northeast1 \
   --image=ghcr.io/kentoku24/comic_crawler:latest \
+  --command=python \
+  --args=-m,manga_watch.run_job \
   --tasks=1 \
   --max-retries=0 \
-  --set-env-vars=TZ=Asia/Tokyo,MANGA_WATCH_NOTIFIER_BACKENDS=stdout
+  --set-env-vars=TZ=Asia/Tokyo,MANGA_WATCH_NOTIFIER_BACKENDS=stdout,DISCORD_MAIN_CHANNEL_ID=<main-channel-id>,DISCORD_RUN_REPORT_CHANNEL_ID=<run-report-channel-id>,DISCORD_BOT_TOKEN_SECRET_VERSION=projects/star-light-breaker/secrets/comic-crawler-discord-bot-token/versions/latest
 ```
 
 更新:
@@ -102,9 +105,11 @@ gcloud run jobs update comic-crawler-job \
   --project=star-light-breaker \
   --region=asia-northeast1 \
   --image=ghcr.io/kentoku24/comic_crawler:latest \
+  --command=python \
+  --args=-m,manga_watch.run_job \
   --tasks=1 \
   --max-retries=0 \
-  --update-env-vars=TZ=Asia/Tokyo,MANGA_WATCH_NOTIFIER_BACKENDS=stdout
+  --update-env-vars=TZ=Asia/Tokyo,MANGA_WATCH_NOTIFIER_BACKENDS=stdout,DISCORD_MAIN_CHANNEL_ID=<main-channel-id>,DISCORD_RUN_REPORT_CHANNEL_ID=<run-report-channel-id>,DISCORD_BOT_TOKEN_SECRET_VERSION=projects/star-light-breaker/secrets/comic-crawler-discord-bot-token/versions/latest
 ```
 
 手動実行:
@@ -119,7 +124,7 @@ gcloud run jobs execute comic-crawler-job \
 注意:
 
 - 上の `execute` command は API / CLI shape の source of truth として残す
-- 現在の image は long-running runner を起動するため、Job 実行成功をこの task では保証しない
+- default container entrypoint は long-running runner のままだが、Cloud Run Job では `python -m manga_watch.run_job` を command override して 1 execution で終了させる
 - Firestore / Secret Manager / migration contract は `doc/gcp-runtime.md` を参照する
 - production-ready な Job 実行経路の実環境確認は #139 と後続 runtime packet が入るまで未完了
 

--- a/manga_watch/run_job.py
+++ b/manga_watch/run_job.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+from typing import Mapping, Optional
+
+from manga_watch.discord_outbound import DiscordChannelClient
+from manga_watch.notifier import build_named_notifiers
+from manga_watch.runner import (
+    TRIGGER_SOURCE_DISCORD_FETCH,
+    TRIGGER_SOURCE_SCHEDULED,
+    RunnerConfig,
+    report_to_stderr,
+    run_once,
+)
+
+JOB_TRIGGER_SOURCE_ALIASES = {
+    "discord_fetch": TRIGGER_SOURCE_DISCORD_FETCH,
+    "fetch": TRIGGER_SOURCE_DISCORD_FETCH,
+    "manual": TRIGGER_SOURCE_DISCORD_FETCH,
+    "scheduled": TRIGGER_SOURCE_SCHEDULED,
+}
+
+
+def job_trigger_source_from_env(
+    environ: Optional[Mapping[str, str]] = None,
+) -> str:
+    env = os.environ if environ is None else environ
+    raw_value = str(env.get("MANGA_WATCH_TRIGGER_SOURCE") or "").strip().lower()
+    if not raw_value:
+        return TRIGGER_SOURCE_SCHEDULED
+    return JOB_TRIGGER_SOURCE_ALIASES.get(raw_value, raw_value)
+
+
+def main() -> int:
+    try:
+        config = RunnerConfig.from_env()
+    except Exception as exc:
+        print(f"[run_job] configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    named_notifiers = build_named_notifiers(config.notifier_config)
+    discord_client = (
+        DiscordChannelClient(config.discord_outbound_config)
+        if config.discord_outbound_config is not None
+        else None
+    )
+    outcome = run_once(
+        config,
+        named_notifiers=named_notifiers,
+        discord_client=discord_client,
+        trigger_source=job_trigger_source_from_env(),
+    )
+    if outcome.get("ok"):
+        print(f"[run_job] outcome: {outcome}", flush=True)
+        return 0
+
+    report_to_stderr(f"[run_job] failed: {outcome}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -1,0 +1,44 @@
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from manga_watch.run_job import job_trigger_source_from_env
+from manga_watch.runner import TRIGGER_SOURCE_DISCORD_FETCH, TRIGGER_SOURCE_SCHEDULED
+
+
+class RunJobTests(unittest.TestCase):
+    def test_job_trigger_source_defaults_to_scheduled(self):
+        self.assertEqual(TRIGGER_SOURCE_SCHEDULED, job_trigger_source_from_env({}))
+
+    def test_job_trigger_source_maps_manual_aliases_to_discord_fetch(self):
+        self.assertEqual(
+            TRIGGER_SOURCE_DISCORD_FETCH,
+            job_trigger_source_from_env({"MANGA_WATCH_TRIGGER_SOURCE": "manual"}),
+        )
+        self.assertEqual(
+            TRIGGER_SOURCE_DISCORD_FETCH,
+            job_trigger_source_from_env({"MANGA_WATCH_TRIGGER_SOURCE": "fetch"}),
+        )
+
+    def test_run_job_module_runs_until_config_validation(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        env = os.environ.copy()
+        env.pop("MANGA_WATCH_NOTIFIER_BACKENDS", None)
+        env.pop("DISCORD_BOT_TOKEN", None)
+        env.pop("DISCORD_BOT_TOKEN_SECRET_VERSION", None)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "manga_watch.run_job"],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("[run_job] configuration error:", result.stderr)
+


### PR DESCRIPTION
## Summary
- add a one-shot `python -m manga_watch.run_job` entrypoint for Cloud Run Job executions so scheduled runs can execute once and exit cleanly
- update the canonical GCP deploy/verification docs to use the Job command override and Secret Manager-backed Discord bot token contract
- add focused tests for the new job entrypoint and alias mapping

## Issue
- Closes #138

## Validation
- `.venv/bin/python -m unittest tests.test_run_job tests.test_print_cloud_scheduler_job tests.test_runner`
- `.venv/bin/python -m unittest discover -s tests -p 'test_*.py'`
