### PR TITLE
Update docs for GCP-first operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
 # comic_crawler
 
-Docker コンテナ 1 つで定期クロールし、generic notifier backend (`stdout` / webhook) に update event を送れる漫画更新監視アプリです。Discord surface は別契約で、daily notification を main channel、run report を run-report channel へ送ります。stdout/stderr はローカル運用ログとして引き続き使います。Issue #7 の cutover 以降、runtime は `watchlist/state v2` のみを読み書きし、Issue #17 以降は state v2 に更新履歴と未読イベントも保持します。
+GCP では Cloud Run Job / Cloud Run Service / Cloud Scheduler を primary path として定期クロールし、generic notifier backend (`stdout` / webhook) に update event を送る漫画更新監視アプリです。Discord surface は別契約で、daily notification を main channel、run report を run-report channel へ送ります。stdout/stderr はローカル運用ログとして引き続き使います。Issue #7 の cutover 以降、runtime は `watchlist/state v2` のみを読み書きし、Issue #17 以降は state v2 に更新履歴と未読イベントも保持します。
 
 ## Canonical docs
 
-この repo の source of truth は次の 5 文書です。
+この repo の source of truth は次の 6 文書です。
 
 - `doc/要件定義書.md`
 - `doc/設計書.md`
+- `doc/gcp-deploy.md`
 - `spec.md` (document title: `SPEC.md`)
 - `doc/運用手順書.md`
 - `doc/受け入れテスト計画書.md`
 
 GCP runtime の backend env / Firestore schema / Secret Manager mapping / migration command は [`doc/gcp-runtime.md`](doc/gcp-runtime.md) を source of truth とします。
+
+GCP の deploy / run / verify の source of truth は [`doc/gcp-deploy.md`](doc/gcp-deploy.md)、日常運用の確認手順は [`doc/運用手順書.md`](doc/運用手順書.md) を参照します。
+
+## GCP runtime
+
+- Cloud Run Job `comic-crawler-job`: 定期クロールと手動実行の実体
+- Cloud Run Service `comic-crawler-service`: Discord interaction endpoint
+- Cloud Scheduler helper: `python3 scripts/print_cloud_scheduler_job.py create|update --schedule "<cron>"`
+- Scheduler force-run: `gcloud scheduler jobs run comic-crawler-scheduled-run --project=star-light-breaker --location=asia-northeast1`
 
 root の受け入れ仕様書は Git 上の実ファイル名を `spec.md` にしていますが、文書名と cross-document 参照では `SPEC.md` と表記します。これは macOS などの case-insensitive filesystem で path 衝突を避けるためです。canonical docs や新しい issue / PR で `SPEC.md` と書かれている場合は、この `spec.md` を指します。旧 single-file spec への過去の言及は reference 扱いで、source of truth ではありません。
 
@@ -269,7 +279,39 @@ python3 -m manga_watch.watchlist add <url> --watchlist /path/to/watchlist.json
 }
 ```
 
-## Docker run
+## GCP run / verify
+
+GCP での運用は Cloud Run Job / Cloud Run Service / Cloud Scheduler を基準にします。詳細な resource contract は [`doc/gcp-deploy.md`](doc/gcp-deploy.md) を見てください。
+
+```bash
+gcloud run jobs execute comic-crawler-job \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --wait
+
+gcloud scheduler jobs run comic-crawler-scheduled-run \
+  --project=star-light-breaker \
+  --location=asia-northeast1
+
+gcloud run jobs logs read comic-crawler-job \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --limit=20
+
+gcloud run services logs read comic-crawler-service \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --limit=20
+```
+
+- Cloud Run Job は手動 run と定期 run の実行主体
+- Cloud Run Service は `latest` / `fetch` を受ける Discord interaction endpoint
+- Cloud Scheduler helper script は `create` / `update` の command shape を出すので、Scheduler 側の設定確認に使う
+- 詳細な日次確認は [`doc/運用手順書.md`](doc/運用手順書.md) を参照する
+
+## Legacy / local fallback
+
+`docker compose` は GCP の代替ではなく、ローカル検証や一時的な fallback 用です。
 
 1. `.env.example` を `.env` にコピーして notifier 設定を入れる
 2. 必要なら `manga_watch/watchlist.json` を編集する
@@ -282,9 +324,9 @@ docker compose logs -f
 
 compose は `manga_watch/watchlist.json` を read-only mount し、state v2 は volume `crawler-data` に保存します。
 
-### Updating an existing deployment
+### Legacy local update
 
-`main` にデプロイ済み環境を `origin/main` の最新へ更新するときは、repo root で次を実行します。
+ローカル fallback を更新するときは、repo root で次を実行します。
 
 ```bash
 git pull --ff-only origin main

--- a/doc/gcp-deploy.md
+++ b/doc/gcp-deploy.md
@@ -3,6 +3,12 @@
 この文書は `comic_crawler` repo の canonical GCP naming / deploy contract である。  
 GCP 上の resource 名、artifact image、Scheduler 呼び出し契約、未解決 blocker をここで固定する。
 
+## 0. Related source of truth
+
+- 日常運用の入口は [`README.md`](../README.md)
+- operator 向けの手順は [`doc/運用手順書.md`](./運用手順書.md)
+- runtime の backend env / Firestore schema / Secret Manager mapping は [`doc/gcp-runtime.md`](./gcp-runtime.md)
+
 ## 1. Canonical contract
 
 | 項目 | Canonical value |
@@ -277,3 +283,67 @@ helper script は次を固定で出力する。
 - time zone default: `Asia/Tokyo`
 
 `SCHEDULE` の cron 自体は deployment decision であり、この task では canonical 値として固定しない。
+
+## 9. Practical run / verify
+
+この節は、上の contract を GCP で実際に確認するための実用コマンドをまとめる。
+個別の運用判断は [`README.md`](../README.md) と [`doc/運用手順書.md`](./運用手順書.md) を優先し、この文書では command shape を source of truth として残す。
+
+### Cloud Run Job の手動 run
+
+```bash
+gcloud run jobs execute comic-crawler-job \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --wait
+```
+
+### Cloud Scheduler の force-run
+
+```bash
+gcloud scheduler jobs run comic-crawler-scheduled-run \
+  --project=star-light-breaker \
+  --location=asia-northeast1
+```
+
+### Cloud Run Job / Service の logs 確認
+
+```bash
+gcloud run jobs logs read comic-crawler-job \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --limit=50
+
+gcloud run services logs read comic-crawler-service \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --limit=50
+```
+
+### Cloud Logging の直接確認
+
+```bash
+gcloud logging read 'resource.type="cloud_run_job" AND resource.labels.job_name="comic-crawler-job"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=20 \
+  --format='value(timestamp,resource.type,textPayload)'
+
+gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="comic-crawler-service"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=20 \
+  --format='value(timestamp,resource.type,textPayload)'
+```
+
+### Helper script の確認
+
+```bash
+python3 scripts/print_cloud_scheduler_job.py create --schedule "0 * * * *"
+python3 scripts/print_cloud_scheduler_job.py update --schedule "0 * * * *"
+```
+
+- helper script は Cloud Scheduler の create / update command shape を固定する
+- Cloud Run Job は `comic-crawler-job`
+- Cloud Run Service は `comic-crawler-service`
+- Scheduler force-run は `comic-crawler-scheduled-run` に対して実行する

--- a/doc/運用手順書.md
+++ b/doc/運用手順書.md
@@ -25,6 +25,7 @@
 - 更新検知は定期 run または `fetch` により行う
 - Daily notification は更新があった run のみ送信される
 - run report は毎 run 送信される
+- GCP では Cloud Run Job / Cloud Run Service / Cloud Scheduler を primary path とし、確認は run report と Cloud Logging を併用する
 - state 安全性は最優先であり、異常時は state 破損有無を先に確認する
 - Discord 実表示確認は補助的確認であり、主たる品質確認は自動試験を前提とする
 
@@ -79,6 +80,48 @@
 - 同一話の通知が繰り返される
 - `latest` と run report の整合が取れない
 
+## 4.3 GCP 上での起動・稼働確認
+
+GCP での確認では、Cloud Run Job / Cloud Run Service / Cloud Scheduler の describe と logs を先に見る。
+
+```bash
+gcloud run jobs describe comic-crawler-job \
+  --project=star-light-breaker \
+  --region=asia-northeast1
+
+gcloud run services describe comic-crawler-service \
+  --project=star-light-breaker \
+  --region=asia-northeast1
+
+gcloud scheduler jobs describe comic-crawler-scheduled-run \
+  --project=star-light-breaker \
+  --location=asia-northeast1
+```
+
+Scheduler の force-run は次を使う。
+
+```bash
+gcloud scheduler jobs run comic-crawler-scheduled-run \
+  --project=star-light-breaker \
+  --location=asia-northeast1
+```
+
+Cloud Logging で直接確認する場合は次を使う。
+
+```bash
+gcloud logging read 'resource.type="cloud_run_job" AND resource.labels.job_name="comic-crawler-job"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=20 \
+  --format='value(timestamp,resource.type,textPayload)'
+
+gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="comic-crawler-service"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=20 \
+  --format='value(timestamp,resource.type,textPayload)'
+```
+
 ---
 
 ## 5. `latest` の使い方
@@ -104,6 +147,26 @@ latest
 	•	現在の一覧が watchlist 順で表示される
 	•	URL がある作品は link 形式になる
 	•	未取得作品は未取得と分かる表示になる
+
+### GCP での確認
+
+`latest` を送った後は、Cloud Run Service の logs で interaction の受理と応答を確認する。
+
+```bash
+gcloud run services logs read comic-crawler-service \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --limit=50
+```
+
+必要なら Cloud Logging を直接見る。
+
+```bash
+gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="comic-crawler-service"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=20
+```
 
 ⸻
 
@@ -148,6 +211,28 @@ fetch
 	•	受理されたことが分かる初期応答が返る
 	•	詳細結果は Daily notification または run report で確認できる
 	•	run 完了後、更新有無に応じた通知が行われる
+
+### GCP での確認
+
+`fetch` を送った後は、Cloud Run Job の logs と run report をあわせて確認する。
+
+```bash
+gcloud run jobs logs read comic-crawler-job \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --limit=50
+```
+
+Cloud Logging で直近の run を確認する場合は次を使う。
+
+```bash
+gcloud logging read 'resource.type="cloud_run_job" AND resource.labels.job_name="comic-crawler-job"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=20
+```
+
+run report は Discord の run-report channel にも届くので、Cloud Run Job logs と合わせて確認する。
 
 ⸻
 
@@ -240,6 +325,23 @@ delivery failure
 	•	更新検知は成功している
 	•	ただし通知送信が一部または全部失敗している
 	•	再送対象が残っている可能性が高い
+
+### GCP での確認
+
+run report を確認するときは、Discord の run-report channel だけでなく、Cloud Run Job logs と Cloud Logging でも同じ run の痕跡を確認する。
+
+```bash
+gcloud run jobs logs read comic-crawler-job \
+  --project=star-light-breaker \
+  --region=asia-northeast1 \
+  --limit=50
+
+gcloud logging read 'resource.type="cloud_run_job" AND resource.labels.job_name="comic-crawler-job"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=20 \
+  --format='value(timestamp,resource.type,textPayload)'
+```
 
 ⸻
 
@@ -367,6 +469,24 @@ state に異常が疑われる場合、最初に確認するのは以下とす�
 	•	error message に秘匿情報が混入していないことを確認する
 	•	source failure と run-level failure を混同しない
 	•	delivery failure と更新なしを混同しない
+
+### Cloud Logging の確認例
+
+原因切り分けが必要なときは、Cloud Run Job / Service の logs を直接見る。
+
+```bash
+gcloud logging read 'resource.type="cloud_run_job" AND resource.labels.job_name="comic-crawler-job"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=50 \
+  --format='value(timestamp,severity,textPayload)'
+
+gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="comic-crawler-service"' \
+  --project=star-light-breaker \
+  --freshness=1d \
+  --limit=50 \
+  --format='value(timestamp,severity,textPayload)'
+```
 
 ⸻
 


### PR DESCRIPTION
## Summary
- make README GCP-first for deploy/run/verify and move `docker compose` to legacy/local fallback
- add practical Cloud Run / Scheduler / Cloud Logging runbook commands to `doc/gcp-deploy.md`
- add GCP-side confirmation steps for `latest`, `fetch`, Scheduler force-run, run report, and logging to `doc/運用手順書.md`

## Issue
- closes #141

## Verification
- `git diff --check -- README.md doc/gcp-deploy.md 'doc/運用手順書.md'`
- `python3 scripts/print_cloud_scheduler_job.py create --schedule '0 * * * *'`
- `python3 scripts/print_cloud_scheduler_job.py update --schedule '0 * * * *'`

## Residual Risks
- docs-only change; command examples depend on current `gcloud` CLI shape and canonical resource names staying consistent with `star-light-breaker`
