### PR TITLE
Avoid replaying already-posted daily notifications

### DIFF
--- a/manga_watch/discord_outbound.py
+++ b/manga_watch/discord_outbound.py
@@ -44,6 +44,20 @@ class DiscordTransport(Protocol):
         ...
 
 
+class DiscordReadTransport(Protocol):
+    def get_current_user_id(self) -> str:
+        ...
+
+    def list_channel_messages(
+        self,
+        channel_id: str,
+        *,
+        after: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, object]]:
+        ...
+
+
 @dataclass(frozen=True)
 class DiscordOutboundConfig:
     bot_token: str
@@ -402,19 +416,25 @@ def deliver_daily_notifications(
         if blocked:
             remaining_messages.append(entry)
             continue
+        if int(entry.get("attempt_count", 0) or 0) > 0 and _pending_daily_message_was_already_sent(
+            client,
+            entry,
+        ):
+            delivered_count += 1
+            _mark_daily_message_delivered(
+                delivered_latest_keys,
+                entry,
+                attempted_at=attempted_at,
+            )
+            continue
         try:
             client.send_message(str(entry.get("channel_id") or ""), str(entry.get("content") or ""))
             delivered_count += 1
-            for message_key in entry.get("message_keys", []):
-                if not isinstance(message_key, Mapping):
-                    continue
-                work_id = _coerce_text(message_key.get("work_id"))
-                latest_key = _coerce_text(message_key.get("latest_key"))
-                if work_id and latest_key:
-                    delivered_latest_keys[work_id] = {
-                        "latest_key": latest_key,
-                        "delivered_at": attempted_at,
-                    }
+            _mark_daily_message_delivered(
+                delivered_latest_keys,
+                entry,
+                attempted_at=attempted_at,
+            )
         except Exception as exc:
             blocked = True
             entry["attempt_count"] = int(entry.get("attempt_count", 0) or 0) + 1
@@ -433,6 +453,64 @@ def deliver_daily_notifications(
         "remainingCount": len(remaining_messages),
         "errors": errors,
     }
+
+
+def _mark_daily_message_delivered(
+    delivered_latest_keys: Dict[str, object],
+    entry: Mapping[str, object],
+    *,
+    attempted_at: str,
+) -> None:
+    for message_key in entry.get("message_keys", []):
+        if not isinstance(message_key, Mapping):
+            continue
+        work_id = _coerce_text(message_key.get("work_id"))
+        latest_key = _coerce_text(message_key.get("latest_key"))
+        if work_id and latest_key:
+            delivered_latest_keys[work_id] = {
+                "latest_key": latest_key,
+                "delivered_at": attempted_at,
+            }
+
+
+def _pending_daily_message_was_already_sent(
+    client: DiscordTransport,
+    entry: Mapping[str, object],
+) -> bool:
+    read_client = client if _supports_discord_reads(client) else None
+    if read_client is None:
+        return False
+
+    channel_id = _coerce_text(entry.get("channel_id"))
+    content = str(entry.get("content") or "")
+    if not channel_id or not content:
+        return False
+
+    try:
+        bot_user_id = _coerce_text(read_client.get_current_user_id())
+        if not bot_user_id:
+            return False
+        recent_messages = read_client.list_channel_messages(channel_id, limit=10)
+    except Exception:
+        return False
+
+    for message in recent_messages:
+        if not isinstance(message, Mapping):
+            continue
+        author = message.get("author") or {}
+        if not isinstance(author, Mapping):
+            author = {}
+        if _coerce_text(author.get("id")) != bot_user_id:
+            continue
+        if str(message.get("content") or "") == content:
+            return True
+    return False
+
+
+def _supports_discord_reads(client: object) -> bool:
+    return callable(getattr(client, "get_current_user_id", None)) and callable(
+        getattr(client, "list_channel_messages", None)
+    )
 
 
 def _format_checker_error_lines(errors: Mapping[str, Sequence[Mapping[str, object]]]) -> List[str]:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -81,9 +81,14 @@ class FakeSession:
 
 
 class FakeDiscordClient:
-    def __init__(self, *, fail_on_call=None, fail_channels=None):
+    def __init__(self, *, fail_on_call=None, fail_channels=None, bot_user_id="bot-user", channel_messages=None):
         self.fail_on_call = fail_on_call
         self.fail_channels = set(fail_channels or [])
+        self.bot_user_id = bot_user_id
+        self.channel_messages = {
+            channel_id: [dict(message) for message in messages]
+            for channel_id, messages in (channel_messages or {}).items()
+        }
         self.calls = []
 
     def send_message(self, channel_id, content):
@@ -97,6 +102,21 @@ class FakeDiscordClient:
             raise RuntimeError("discord delivery failed")
         if channel_id in self.fail_channels:
             raise RuntimeError(f"discord delivery failed for {channel_id}")
+        self.channel_messages.setdefault(channel_id, []).insert(
+            0,
+            {
+                "id": str(len(self.channel_messages.get(channel_id, [])) + 1),
+                "content": content,
+                "author": {"id": self.bot_user_id},
+            },
+        )
+
+    def get_current_user_id(self):
+        return self.bot_user_id
+
+    def list_channel_messages(self, channel_id, *, after=None, limit=50):
+        del after
+        return [dict(message) for message in self.channel_messages.get(channel_id, [])[:limit]]
 
 
 class SecretLeakingDiscordClient:
@@ -894,6 +914,65 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(1, len(store["discord_delivery"]["daily_notification"]["pending_messages"]))
         self.assertEqual(1, len(errors))
         self.assertIn("notification delivery failed", errors[0])
+
+    def test_run_once_clears_pending_daily_notification_if_message_is_already_visible(self):
+        pending_content = "pending message"
+        store, load_from_store, save_to_store = self.make_state_store(
+            {
+                **self.make_state(),
+                "discord_delivery": {
+                    "daily_notification": {
+                        "delivered_latest_keys": {},
+                        "pending_messages": [
+                            {
+                                "channel_id": "main-channel",
+                                "content": pending_content,
+                                "message_keys": [{"work_id": "work-1", "latest_key": "episode-2"}],
+                                "created_at": "2023-11-14T22:13:20Z",
+                                "attempt_count": 1,
+                                "last_attempted_at": "2023-11-14T22:14:00Z",
+                                "last_error": "discord delivery failed",
+                            }
+                        ],
+                    }
+                },
+            }
+        )
+        discord = FakeDiscordClient(
+            channel_messages={
+                "main-channel": [
+                    {
+                        "id": "42",
+                        "content": pending_content,
+                        "author": {"id": "bot-user"},
+                    }
+                ]
+            }
+        )
+        reports = []
+
+        outcome = run_once(
+            self.make_config(with_discord=True),
+            notifier=FakeNotifier(),
+            discord_client=discord,
+            checker=lambda _: {"updates": []},
+            state_loader=load_from_store,
+            state_saver=save_to_store,
+            now_fn=lambda: 1_700_000_300,
+            report_logger=reports.append,
+            error_logger=lambda _: self.fail("unexpected error log"),
+        )
+
+        self.assertTrue(outcome["ok"])
+        self.assertTrue(outcome["dailyNotificationSent"])
+        self.assertEqual(["run-report-channel"], [call["channel_id"] for call in discord.calls])
+        self.assertEqual([], store["discord_delivery"]["daily_notification"]["pending_messages"])
+        self.assertEqual(
+            "episode-2",
+            store["discord_delivery"]["daily_notification"]["delivered_latest_keys"]["work-1"]["latest_key"],
+        )
+        self.assertEqual(1, len(reports))
+        self.assertIn("daily notification: 送信した", reports[0])
 
     def test_run_once_logs_secondary_failure_when_run_report_delivery_fails(self):
         discord = FakeDiscordClient(fail_channels={"run-report-channel"})


### PR DESCRIPTION
## Summary
- treat a pending Discord daily notification as delivered if the exact message is already visible from the bot in the target channel
- avoid replaying the same pending daily notification every scheduled run after an ambiguous delivery failure
- cover the recovery path with a runner test and extend the fake Discord client with read helpers

## Context
- observed duplicate daily notifications on March 26, 2026 JST after earlier runs reported `delivery failure: 1件`
- the repeated hourly posts are consistent with a pending daily message being replayed on every scheduled run

## Verification
- `/Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_runner tests.test_discord_outbound`
- `/Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest discover -s tests -p 'test_*.py'`
- `git diff --check`

## Residual Risks
- this fixes the "message actually appeared but delivery was treated as failed" replay case by checking recent channel history; it does not change genuine repeated failures where Discord never accepted the message
