### PR TITLE
fix: verify Cloud Run deploy against configured image refs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -173,16 +173,16 @@ jobs:
             --project="${GCP_PROJECT_ID}" \
             --region="${GCP_REGION}" \
             --format='value(status.latestReadyRevisionName)')"
-          service_image_digest="$(gcloud run revisions describe "${latest_ready_revision}" \
+          service_image_ref="$(gcloud run services describe comic-crawler-service \
             --project="${GCP_PROJECT_ID}" \
             --region="${GCP_REGION}" \
-            --format='value(status.imageDigest)')"
+            --format='value(spec.template.spec.containers[0].image)')"
           job_image_ref="$(gcloud run jobs describe comic-crawler-job \
             --project="${GCP_PROJECT_ID}" \
             --region="${GCP_REGION}" \
-            --format='value(spec.template.template.containers[0].image)')"
-          if [[ "${service_image_digest}" != "${IMAGE_DIGEST}" ]]; then
-            echo "service digest mismatch: expected ${IMAGE_DIGEST}, got ${service_image_digest}" >&2
+            --format='value(spec.template.template.spec.containers[0].image)')"
+          if [[ "${service_image_ref}" != "${IMAGE_REF}" ]]; then
+            echo "service image ref mismatch: expected ${IMAGE_REF}, got ${service_image_ref}" >&2
             exit 1
           fi
           if [[ "${job_image_ref}" != "${IMAGE_REF}" ]]; then
@@ -190,7 +190,7 @@ jobs:
             exit 1
           fi
           echo "latest_ready_revision=${latest_ready_revision}" >> "${GITHUB_OUTPUT}"
-          echo "service_image_digest=${service_image_digest}" >> "${GITHUB_OUTPUT}"
+          echo "service_image_ref=${service_image_ref}" >> "${GITHUB_OUTPUT}"
           echo "job_image_ref=${job_image_ref}" >> "${GITHUB_OUTPUT}"
 
       - name: Summarize deploy output
@@ -202,6 +202,6 @@ jobs:
             echo "- Image digest: \`${IMAGE_DIGEST}\`"
             echo "- Image ref: \`${IMAGE_REF}\`"
             echo "- Latest ready revision: \`${{ steps.verify.outputs.latest_ready_revision }}\`"
-            echo "- Service image digest: \`${{ steps.verify.outputs.service_image_digest }}\`"
+            echo "- Service image ref: \`${{ steps.verify.outputs.service_image_ref }}\`"
             echo "- Job image ref: \`${{ steps.verify.outputs.job_image_ref }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -39,7 +39,15 @@ class GitHubWorkflowContractTests(unittest.TestCase):
         self.assertIn("gcloud run jobs update comic-crawler-job", content)
         self.assertIn("gcloud run deploy comic-crawler-service", content)
         self.assertIn("DISCORD_BOT_TOKEN_SECRET_VERSION=${DISCORD_BOT_TOKEN_SECRET_VERSION}", service_section)
-        self.assertIn('if [[ "${service_image_digest}" != "${IMAGE_DIGEST}" ]]', content)
+        self.assertIn('if [[ "${service_image_ref}" != "${IMAGE_REF}" ]]', content)
+        self.assertIn('if [[ "${job_image_ref}" != "${IMAGE_REF}" ]]', content)
+
+    def test_deploy_workflow_verifies_service_and_job_image_refs_from_resource_configs(self):
+        content = read_workflow("deploy-production.yml")
+
+        self.assertIn("--format='value(spec.template.spec.containers[0].image)'", content)
+        self.assertIn("--format='value(spec.template.template.spec.containers[0].image)'", content)
+        self.assertIn('if [[ "${service_image_ref}" != "${IMAGE_REF}" ]]', content)
         self.assertIn('if [[ "${job_image_ref}" != "${IMAGE_REF}" ]]', content)
 
     def test_deploy_workflow_sets_up_buildx_before_using_gha_cache(self):


### PR DESCRIPTION
## Summary
- verify deploy success against the Cloud Run service config image ref instead of the revision digest
- fix the Cloud Run job image path so the workflow reads the configured container image
- cover the new verify contract in workflow tests

## Testing
- TZ=Asia/Tokyo /Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_github_workflows -v
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-production.yml"); YAML.load_file(".github/workflows/rollback-production.yml"); puts "workflow yaml ok"'\n- TZ=Asia/Tokyo /Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest discover -s tests -p 'test_*.py'