### PR TITLE
[codex] retire duplicated watchlist add CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,28 +216,20 @@ runner が backend に送る update event は次の schema です。
 
 ## Supported sources
 
-| Source | `watchlist add` accepted inputs | Stored `seed_url` | `work_id` | `latest_key` |
+| Source | Discord `/add` accepted inputs | Stored `seed_url` | `work_id` | `latest_key` |
 | --- | --- | --- | --- | --- |
 | ComicWalker | canonical series URL, episode URL | `https://comic-walker.com/detail/<series>` | `KC_XXXXXX_S` | `episodeCode` |
 | webアクション | episode URL, RSS/Atom series feed URL | canonical episode URL または canonical series feed URL | `comic-action:<series_id>` | 最終到達 episode URL |
 | Champion Cross | episode URL, series URL, series RSS URL | canonical episode URL / canonical series URL / canonical series RSS URL | `champion-cross:<series_hash>` | 最新 episode URL |
 | Kakuyomu | work URL, episode URL | 入力 URL のまま | `kakuyomu:<numeric_work_id>` | 最新 episode id |
 
-Phase 1 では source ごとの capability 差を隠しません。`watchlist add` が受け付ける URL 種別は上の表だけです。
+Phase 1 では source ごとの capability 差を隠しません。作品追加で受け付ける URL 種別は上の表だけです。
 
-## Watchlist add CLI
+## Discord `/add`
 
-```bash
-python3 -m manga_watch.watchlist add <url>
-python3 -m manga_watch.watchlist add <url> --watchlist /path/to/watchlist.json
-```
+作品追加の正式導線は Discord slash command `/add url:<作品URL>` です。内部では shared add logic が URL を normalize し、duplicate / unsupported 判定を行ってから watchlist を更新します。
 
-- デフォルトの watchlist パスは `MANGA_WATCH_WATCHLIST`、未設定時は `MANGA_WATCH_URLS`、さらに未設定なら `manga_watch/watchlist.json`
-- 出力は常に JSON
-- `action=added` と `action=duplicate` は exit code `0`
-- `action=error` は exit code `1`
-
-成功時は normalize preview を `entry` に返します。
+成功時は normalize preview 相当の結果から、登録された `work_id` と `seed_url` を返します。
 
 ```json
 {
@@ -266,14 +258,14 @@ python3 -m manga_watch.watchlist add <url> --watchlist /path/to/watchlist.json
 }
 ```
 
-エラー時は `kind`, `message`, `next_action` を返します。`kind` は少なくとも `invalid_url`, `unsupported_source`, `unsupported_url_type`, `normalize_failed` を使います。
+エラー時は shared add logic の `kind`, `message`, `next_action` をもとに応答します。`kind` は少なくとも `invalid_url`, `unsupported_source`, `unsupported_url_type`, `normalize_failed` を使います。
 
 ```json
 {
   "action": "error",
   "error": {
     "kind": "unsupported_url_type",
-    "message": "comic-action does not support this URL type for `watchlist add`: https://comic-action.com/series/123",
+    "message": "comic-action does not support this URL type for work registration: https://comic-action.com/series/123",
     "next_action": "Supported input types for comic-action: episode URL, series feed URL. Examples: https://comic-action.com/episode/123456 / https://comic-action.com/rss/series/123456"
   }
 }
@@ -402,7 +394,7 @@ export DISCORD_RUN_REPORT_CHANNEL_ID=...
 .venv/bin/python -m manga_watch.replay_outbox
 ```
 
-Discord main channel では trim 後に本文がちょうど `latest` のメッセージで保存済み最新話一覧を返し、`fetch` のメッセージで手動巡回を受け付けます。Discord interaction endpoint では slash command として `/add url:<作品URL>` も受け付け、既存 `watchlist add` ロジックで対応できる URL のみクロール対象へ追加します。
+Discord main channel では trim 後に本文がちょうど `latest` のメッセージで保存済み最新話一覧を返し、`fetch` のメッセージで手動巡回を受け付けます。Discord interaction endpoint では slash command として `/add url:<作品URL>` も受け付け、shared add logic で対応できる URL のみクロール対象へ追加します。
 Cloud Run Service の interaction endpoint では slash command として `/latest` `/fetch` `/add` `/remove` を扱います。`/remove` は ephemeral な select menu と confirm/cancel button を返し、watchlist と state から対象作品を完全削除します。
 Discord 実機補助確認は test guild / test channel だけで `.venv/bin/python -m manga_watch.discord_real_e2e --case all --json` を実行します。これは primary gate ではなく、差異が出たときは先に mocked acceptance (`manga_watch.run_mocked_acceptance`) と formatter / builder を確認します。
 
@@ -487,7 +479,7 @@ drift を検知したら、次の順で進めます。
 - `manga_watch/discord_text.py`: Discord 表示向け label fallback / truncate helper
 - `manga_watch/discord_outbound.py`: Discord daily notification / run report formatter と sender
 - `manga_watch/notifier.py`: update event schema + stdout/webhook backend
-- `manga_watch/watchlist.py`: `watchlist add <url>` CLI
+- `manga_watch/watchlist.py`: Discord `/add` が使う shared add logic と source capability 定義
 - `manga_watch/runner.py`: スケジューラ + notifier fan-out + Discord outbound orchestration
 - `manga_watch/update_classification.py`: 更新種別と既定通知対象の分類ロジック
 - `manga_watch/watchlist.json`: watchlist v2 sample

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import argparse
 import json
 from dataclasses import dataclass
 from typing import Dict, Optional, Sequence
@@ -84,15 +83,6 @@ class WatchlistAddError(RuntimeError):
         }
 
 
-class WatchlistArgumentParser(argparse.ArgumentParser):
-    def error(self, message: str) -> None:
-        raise WatchlistAddError(
-            "usage",
-            message,
-            "Run `python3 -m manga_watch.watchlist add <url> [--watchlist <path>]`.",
-        )
-
-
 def add_watchlist_url(
     url: str,
     *,
@@ -113,7 +103,7 @@ def add_watchlist_url(
         raise WatchlistAddError(
             "load_watchlist",
             f"Failed to load watchlist: {exc}",
-            "Fix the watchlist path or JSON payload, then rerun `watchlist add`.",
+            "Fix the watchlist path or JSON payload, then retry the work registration flow.",
         ) from exc
 
     existing = find_duplicate_entry(watchlist["works"], str(entry["id"]))
@@ -136,7 +126,7 @@ def add_watchlist_url(
         raise WatchlistAddError(
             "save_watchlist",
             f"Failed to save watchlist: {exc}",
-            "Check write permissions and disk state, then rerun `watchlist add`.",
+            "Check write permissions and disk state, then retry the work registration flow.",
         ) from exc
 
     return {
@@ -174,7 +164,7 @@ def build_watchlist_preview(
         if message.startswith("Unsupported URL:") or "could not parse" in message:
             raise WatchlistAddError(
                 "unsupported_url_type",
-                f"{capability.source} does not support this URL type for `watchlist add`: {url}",
+                f"{capability.source} does not support this URL type for work registration: {url}",
                 capability_hint(capability),
             ) from exc
         raise WatchlistAddError(
@@ -218,38 +208,24 @@ def find_duplicate_entry(works, work_id: str) -> Optional[Dict[str, object]]:
     return None
 
 
-def parse_args(argv=None):
-    parser = WatchlistArgumentParser(description="Manage comic_crawler watchlist v2.")
-    subparsers = parser.add_subparsers(dest="command")
-
-    add_parser = subparsers.add_parser("add", help="Normalize a URL and add it to watchlist v2.")
-    add_parser.add_argument("url")
-    add_parser.add_argument("--watchlist", dest="watchlist_path")
-    return parser.parse_args(argv)
+def retired_cli_payload() -> Dict[str, object]:
+    error = WatchlistAddError(
+        "deprecated_cli",
+        "`python -m manga_watch.watchlist add ...` has been retired.",
+        "Use Discord `/add url:<作品URL>` for work registration.",
+    )
+    return {
+        "action": "error",
+        "input_url": "",
+        "watchlist_path": get_watchlist_path(),
+        "error": error.to_dict(),
+    }
 
 
 def main(argv=None) -> int:
-    args = None
-    try:
-        args = parse_args(argv)
-        if args.command != "add":
-            raise WatchlistAddError(
-                "usage",
-                "missing command",
-                "Run `python3 -m manga_watch.watchlist add <url> [--watchlist <path>]`.",
-            )
-        payload = add_watchlist_url(args.url, watchlist_path=args.watchlist_path)
-        print(json.dumps(payload, ensure_ascii=False))
-        return 0
-    except WatchlistAddError as exc:
-        payload = {
-            "action": "error",
-            "input_url": str(getattr(args, "url", "") or "").strip(),
-            "watchlist_path": getattr(args, "watchlist_path", None) or get_watchlist_path(),
-            "error": exc.to_dict(),
-        }
-        print(json.dumps(payload, ensure_ascii=False))
-        return 1
+    del argv
+    print(json.dumps(retired_cli_payload(), ensure_ascii=False))
+    return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from manga_watch.watchlist import add_watchlist_url
+from manga_watch.watchlist import WatchlistAddError, add_watchlist_url
 
 
 def write_watchlist(path: Path, works):
@@ -25,41 +25,27 @@ class StaticHttpClient:
         return self.responses[url]
 
 
-class WatchlistCliTests(unittest.TestCase):
+class WatchlistAddLogicTests(unittest.TestCase):
     maxDiff = None
 
-    def run_watchlist_module(self, *args):
-        repo_root = Path(__file__).resolve().parents[1]
-        return subprocess.run(
-            [sys.executable, "-m", "manga_watch.watchlist", *args],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-    def test_watchlist_add_adds_entry_from_supported_work_url(self):
+    def test_add_watchlist_url_adds_entry_from_supported_work_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"
             write_watchlist(watchlist_path, [])
 
-            result = self.run_watchlist_module(
-                "add",
+            payload = add_watchlist_url(
                 "https://kakuyomu.jp/works/123",
-                "--watchlist",
-                str(watchlist_path),
+                watchlist_path=str(watchlist_path),
             )
             saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
 
-        self.assertEqual(0, result.returncode, msg=result.stderr)
-        payload = json.loads(result.stdout)
         self.assertEqual("added", payload["action"])
         self.assertEqual("kakuyomu:123", payload["entry"]["id"])
         self.assertEqual("https://kakuyomu.jp/works/123", payload["entry"]["seed_url"])
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
-    def test_watchlist_add_reports_duplicate_without_writing_second_entry(self):
+    def test_add_watchlist_url_reports_duplicate_without_writing_second_entry(self):
         existing_entry = {
             "id": "kakuyomu:123",
             "source": "kakuyomu",
@@ -71,36 +57,28 @@ class WatchlistCliTests(unittest.TestCase):
             watchlist_path = Path(tmpdir) / "watchlist.json"
             write_watchlist(watchlist_path, [existing_entry])
 
-            result = self.run_watchlist_module(
-                "add",
+            payload = add_watchlist_url(
                 "https://kakuyomu.jp/works/123",
-                "--watchlist",
-                str(watchlist_path),
+                watchlist_path=str(watchlist_path),
             )
             saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
 
-        self.assertEqual(0, result.returncode, msg=result.stderr)
-        payload = json.loads(result.stdout)
         self.assertEqual("duplicate", payload["action"])
         self.assertEqual(existing_entry, payload["existing"])
         self.assertEqual(1, payload["work_count"])
         self.assertEqual([existing_entry], saved["works"])
 
-    def test_watchlist_add_adds_entry_from_comic_action_series_feed_url(self):
+    def test_add_watchlist_url_adds_entry_from_comic_action_series_feed_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"
             write_watchlist(watchlist_path, [])
 
-            result = self.run_watchlist_module(
-                "add",
+            payload = add_watchlist_url(
                 "https://comic-action.com/rss/series/13933686331606207128?free_only=1",
-                "--watchlist",
-                str(watchlist_path),
+                watchlist_path=str(watchlist_path),
             )
             saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
 
-        self.assertEqual(0, result.returncode, msg=result.stderr)
-        payload = json.loads(result.stdout)
         self.assertEqual("added", payload["action"])
         self.assertEqual("comic-action:13933686331606207128", payload["entry"]["id"])
         self.assertEqual(
@@ -110,7 +88,7 @@ class WatchlistCliTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
-    def test_watchlist_add_reports_duplicate_for_comic_action_series_feed_url(self):
+    def test_add_watchlist_url_reports_duplicate_for_comic_action_series_feed_url(self):
         existing_entry = {
             "id": "comic-action:13933686331606207128",
             "source": "comic-action",
@@ -122,22 +100,18 @@ class WatchlistCliTests(unittest.TestCase):
             watchlist_path = Path(tmpdir) / "watchlist.json"
             write_watchlist(watchlist_path, [existing_entry])
 
-            result = self.run_watchlist_module(
-                "add",
+            payload = add_watchlist_url(
                 "https://comic-action.com/atom/series/13933686331606207128",
-                "--watchlist",
-                str(watchlist_path),
+                watchlist_path=str(watchlist_path),
             )
             saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
 
-        self.assertEqual(0, result.returncode, msg=result.stderr)
-        payload = json.loads(result.stdout)
         self.assertEqual("duplicate", payload["action"])
         self.assertEqual(existing_entry, payload["existing"])
         self.assertEqual(1, payload["work_count"])
         self.assertEqual([existing_entry], saved["works"])
 
-    def test_watchlist_add_accepts_champion_cross_episode_url(self):
+    def test_add_watchlist_url_accepts_champion_cross_episode_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"
             write_watchlist(watchlist_path, [])
@@ -168,7 +142,7 @@ class WatchlistCliTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
-    def test_watchlist_add_accepts_takecomic_series_url(self):
+    def test_add_watchlist_url_accepts_takecomic_series_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"
             write_watchlist(watchlist_path, [])
@@ -190,72 +164,76 @@ class WatchlistCliTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
-    def test_watchlist_add_reports_unsupported_source(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            watchlist_path = Path(tmpdir) / "watchlist.json"
-            write_watchlist(watchlist_path, [])
 
-            result = self.run_watchlist_module(
-                "add",
-                "https://example.com/work/1",
-                "--watchlist",
-                str(watchlist_path),
-            )
+class WatchlistCliRetirementTests(unittest.TestCase):
+    maxDiff = None
 
-        self.assertEqual(1, result.returncode)
-        payload = json.loads(result.stdout)
-        self.assertEqual("error", payload["action"])
-        self.assertEqual("unsupported_source", payload["error"]["kind"])
+    def run_watchlist_module(self, *args):
+        repo_root = Path(__file__).resolve().parents[1]
+        return subprocess.run(
+            [sys.executable, "-m", "manga_watch.watchlist", *args],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
-    def test_watchlist_add_reports_unsupported_url_type_for_supported_source(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            watchlist_path = Path(tmpdir) / "watchlist.json"
-            write_watchlist(watchlist_path, [])
-
-            result = self.run_watchlist_module(
-                "add",
-                "https://comic-action.com/series/123",
-                "--watchlist",
-                str(watchlist_path),
-            )
+    def test_watchlist_cli_reports_deprecated_when_called_with_add(self):
+        result = self.run_watchlist_module("add", "https://example.com/work/1")
 
         self.assertEqual(1, result.returncode)
         payload = json.loads(result.stdout)
         self.assertEqual("error", payload["action"])
-        self.assertEqual("unsupported_url_type", payload["error"]["kind"])
+        self.assertEqual("deprecated_cli", payload["error"]["kind"])
+        self.assertIn("retired", payload["error"]["message"])
+        self.assertIn("/add", payload["error"]["next_action"])
 
-    def test_watchlist_add_reports_invalid_url(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            watchlist_path = Path(tmpdir) / "watchlist.json"
-            write_watchlist(watchlist_path, [])
-
-            result = self.run_watchlist_module(
-                "add",
-                "not-a-url",
-                "--watchlist",
-                str(watchlist_path),
-            )
-
-        self.assertEqual(1, result.returncode)
-        payload = json.loads(result.stdout)
-        self.assertEqual("error", payload["action"])
-        self.assertEqual("invalid_url", payload["error"]["kind"])
-
-    def test_watchlist_add_reports_usage_errors_as_json(self):
+    def test_watchlist_cli_reports_deprecated_without_arguments(self):
         result = self.run_watchlist_module()
 
         self.assertEqual(1, result.returncode)
         payload = json.loads(result.stdout)
         self.assertEqual("error", payload["action"])
-        self.assertEqual("usage", payload["error"]["kind"])
+        self.assertEqual("deprecated_cli", payload["error"]["kind"])
 
-    def test_watchlist_add_missing_url_reports_usage_as_json(self):
-        result = self.run_watchlist_module("add")
+    def test_add_watchlist_url_reports_unsupported_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
 
-        self.assertEqual(1, result.returncode)
-        payload = json.loads(result.stdout)
-        self.assertEqual("error", payload["action"])
-        self.assertEqual("usage", payload["error"]["kind"])
+            with self.assertRaisesRegex(WatchlistAddError, "Unsupported source host: example.com"):
+                add_watchlist_url(
+                    "https://example.com/work/1",
+                    watchlist_path=str(watchlist_path),
+                )
+
+    def test_add_watchlist_url_reports_unsupported_url_type_for_supported_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            with self.assertRaisesRegex(
+                WatchlistAddError,
+                "does not support this URL type for work registration",
+            ):
+                add_watchlist_url(
+                    "https://comic-action.com/series/123",
+                    watchlist_path=str(watchlist_path),
+                )
+
+    def test_add_watchlist_url_reports_invalid_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            with self.assertRaisesRegex(
+                WatchlistAddError,
+                "Input must be an absolute http\\(s\\) URL",
+            ):
+                add_watchlist_url(
+                    "not-a-url",
+                    watchlist_path=str(watchlist_path),
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retire the `python -m manga_watch.watchlist add ...` CLI surface with a deprecation stub
- keep the shared add logic that Discord `/add` depends on
- update watchlist tests and README guidance to center Discord `/add`

## Issue
Closes #172

## Verification
- `. .venv/bin/activate && python -m unittest tests.test_watchlist tests.test_discord_add tests.test_discord_interactions tests.test_discord_command_registration`
- `. .venv/bin/activate && python -m manga_watch.watchlist add https://kakuyomu.jp/works/123`

## Residual Risks
- `manga_watch.watchlist` remains importable for shared add logic, so any undiscovered external CLI callers will now receive a deprecation JSON error instead of the old add behavior.
