### PR TITLE
fix: correct Cloud Run job deploy verification path

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -180,7 +180,7 @@ jobs:
           job_image_ref="$(gcloud run jobs describe comic-crawler-job \
             --project="${GCP_PROJECT_ID}" \
             --region="${GCP_REGION}" \
-            --format='value(spec.template.template.spec.containers[0].image)')"
+            --format='value(spec.template.spec.template.spec.containers[0].image)')"
           if [[ "${service_image_ref}" != "${IMAGE_REF}" ]]; then
             echo "service image ref mismatch: expected ${IMAGE_REF}, got ${service_image_ref}" >&2
             exit 1

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -46,7 +46,7 @@ class GitHubWorkflowContractTests(unittest.TestCase):
         content = read_workflow("deploy-production.yml")
 
         self.assertIn("--format='value(spec.template.spec.containers[0].image)'", content)
-        self.assertIn("--format='value(spec.template.template.spec.containers[0].image)'", content)
+        self.assertIn("--format='value(spec.template.spec.template.spec.containers[0].image)'", content)
         self.assertIn('if [[ "${service_image_ref}" != "${IMAGE_REF}" ]]', content)
         self.assertIn('if [[ "${job_image_ref}" != "${IMAGE_REF}" ]]', content)
 


### PR DESCRIPTION
## Summary
- fix the deploy workflow verify step to read the Cloud Run Job image from the actual nested spec path
- tighten the workflow contract test so future edits keep the working gcloud format path

## Root cause
The post-merge Deploy Production run for #167 updated both Cloud Run resources successfully, but the final verify step still failed because `gcloud run jobs describe` was reading `spec.template.template.spec.containers[0].image`. The actual Job schema is `spec.template.spec.template.spec.containers[0].image`, so the workflow compared against an empty value and reported a false failure.

## Testing
- TZ=Asia/Tokyo /Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_github_workflows -v
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-production.yml"); YAML.load_file(".github/workflows/rollback-production.yml"); puts "workflow yaml ok"'\n- TZ=Asia/Tokyo /Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest discover -s tests -p 'test_*.py'