### PR TITLE
Clarify stale watchlist add wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ runner が backend に送る update event は次の schema です。
 | Champion Cross | episode URL, series URL, series RSS URL | canonical episode URL / canonical series URL / canonical series RSS URL | `champion-cross:<series_hash>` | 最新 episode URL |
 | Kakuyomu | work URL, episode URL | 入力 URL のまま | `kakuyomu:<numeric_work_id>` | 最新 episode id |
 
-Phase 1 では source ごとの capability 差を隠しません。作品追加で受け付ける URL 種別は上の表だけです。
+Phase 1 では source ごとの capability 差を隠しません。作品追加で受け付ける URL 種別は上の表だけです。内部の source capability / normalize 契約もこの表を source of truth とします。
 
 ## Discord `/add`
 


### PR DESCRIPTION
## Issue
- Closes #179

## 変更概要
- README の supported sources 表記を Discord `/add` 起点の user-facing wording に揃えた
- `manga_watch/watchlist.py` の説明を internal source normalization helper と明示した
- GitHub 上では #171 の本文と reviewer comment を current wording に更新した

## 検証結果
- `/Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_watchlist tests.test_discord_interactions -v`
- open issue body search で `watchlist add` が残るのは #179 自身のみ
- open issue comment search で `watchlist add` が残るのは #179 自身のみ

## 残留リスク
- internal helper の具体例として README に `python3 -m manga_watch.watchlist add ...` のコマンド例は残している
- close 済み issue や runtime error message は今回のスコープ外
