### PR TITLE
Support FireCROSS ebook series URLs in Discord /add

### DIFF
--- a/manga_watch/sources/firecross.py
+++ b/manga_watch/sources/firecross.py
@@ -10,6 +10,9 @@ _HOST = "firecross.jp"
 _READER_URL = re.compile(
     rf"^https?://(?:www\.)?{_HOST}/reader/([0-9A-Za-z_-]+)(?:/)?(?:\?.*)?$"
 )
+_EBOOK_SERIES_URL = re.compile(
+    rf"^https?://(?:www\.)?{_HOST}/ebook/series/([0-9A-Za-z_-]+)(?:/)?(?:\?.*)?$"
+)
 _SERIES_URL = re.compile(
     rf"^https?://(?:www\.)?{_HOST}/series/([0-9A-Za-z_-]+)(?:/)?(?:\?.*)?$"
 )
@@ -29,11 +32,26 @@ def canonical_firecross_series_url(series_id: str) -> str:
     return f"https://{_HOST}/series/{series_id}"
 
 
+def canonical_firecross_ebook_series_url(series_id: str) -> str:
+    return f"https://{_HOST}/ebook/series/{series_id}"
+
+
+def firecross_latest_ebook_series_url(series_id: str) -> str:
+    return f"{canonical_firecross_ebook_series_url(series_id)}?sort=latest"
+
+
 def parse_firecross_reader_url(seed_url: str) -> Optional[str]:
     match = _READER_URL.match(seed_url)
     if not match:
         return None
     return canonical_firecross_reader_url(match.group(1))
+
+
+def parse_firecross_ebook_series_url(seed_url: str) -> Optional[str]:
+    match = _EBOOK_SERIES_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_firecross_ebook_series_url(match.group(1))
 
 
 def parse_firecross_series_url(url: str) -> Optional[str]:
@@ -82,6 +100,21 @@ def extract_firecross_latest_reader_url(html_text: str) -> Optional[str]:
     return None
 
 
+def extract_first_firecross_reader_url(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    normalized = html.unescape(html_text).replace("\\/", "/").replace('\\"', '"')
+    for match in _ANCHOR_TAG_IN_HTML.finditer(normalized):
+        attrs = match.group("attrs") or ""
+        href_match = _ANCHOR_HREF.search(attrs)
+        if not href_match:
+            continue
+        parsed = parse_firecross_reader_url(href_match.group("href"))
+        if parsed:
+            return parsed
+    return None
+
+
 def parse_firecross_reader_title(page_title: str) -> Tuple[Optional[str], Optional[str]]:
     normalized = _TITLE_SITE_SUFFIX.sub("", str(page_title or "").strip())
     if not normalized:
@@ -105,22 +138,40 @@ class FirecrossAdapter(SourceAdapter):
     source = "firecross"
 
     def can_handle(self, seed_url: str) -> bool:
-        return bool(parse_firecross_reader_url(seed_url))
+        return bool(parse_firecross_reader_url(seed_url) or parse_firecross_ebook_series_url(seed_url))
 
     def normalize(self, seed_url: str) -> WorkDescriptor:
         normalized_reader_url = parse_firecross_reader_url(seed_url)
-        if not normalized_reader_url:
+        if normalized_reader_url:
+            return WorkDescriptor(
+                source=self.source,
+                work_id=normalized_reader_url,
+                seed_url=normalized_reader_url,
+            )
+
+        normalized_series_url = parse_firecross_ebook_series_url(seed_url)
+        if not normalized_series_url:
             raise RuntimeError(f"firecross: could not parse seed URL: {seed_url}")
+
+        series_id = normalized_series_url.rsplit("/", 1)[-1]
+        stable_series = f"{self.source}:{series_id}"
         return WorkDescriptor(
             source=self.source,
-            work_id=normalized_reader_url,
-            seed_url=normalized_reader_url,
+            work_id=stable_series,
+            seed_url=normalized_series_url,
+            metadata={
+                "series": stable_series,
+                "seriesId": series_id,
+                "seriesUrl": normalized_series_url,
+            },
         )
 
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         series_id, series_url = self._resolve_series(work, http_client)
         series_html = http_client.get_text(series_url)
         latest_url = extract_firecross_latest_reader_url(series_html)
+        if not latest_url and parse_firecross_ebook_series_url(series_url):
+            latest_url = extract_first_firecross_reader_url(series_html)
         if not latest_url:
             raise SourceParseError("firecross: latest reader URL not found")
 
@@ -140,10 +191,15 @@ class FirecrossAdapter(SourceAdapter):
 
     def _resolve_series(self, work: WorkDescriptor, http_client: HttpClient) -> Tuple[str, str]:
         series_id = str(work.metadata.get("seriesId") or "")
+        series_url = str(work.metadata.get("seriesUrl") or "")
         if not series_id and str(work.work_id).startswith(f"{self.source}:"):
             series_id = str(work.work_id).split(":", 1)[1]
         if series_id:
-            return series_id, canonical_firecross_series_url(series_id)
+            if parse_firecross_ebook_series_url(series_url) or parse_firecross_ebook_series_url(work.seed_url):
+                return series_id, firecross_latest_ebook_series_url(series_id)
+            if not series_url:
+                series_url = canonical_firecross_series_url(series_id)
+            return series_id, series_url
 
         normalized_reader_url = parse_firecross_reader_url(work.seed_url)
         if not normalized_reader_url:

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -49,9 +49,10 @@ SOURCE_CAPABILITIES = (
     SourceCapability(
         source="firecross",
         domains=("firecross.jp",),
-        input_labels=("reader URL",),
+        input_labels=("reader URL", "ebook series URL"),
         examples=(
             "https://firecross.jp/reader/19386",
+            "https://firecross.jp/ebook/series/358",
         ),
     ),
     SourceCapability(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -291,6 +291,23 @@ class SourceAdapterTests(unittest.TestCase):
             work.to_dict(),
         )
 
+    def test_firecross_normalize_accepts_ebook_series_url(self):
+        adapter = ADAPTERS["firecross"]()
+        work = adapter.normalize("https://firecross.jp/ebook/series/358?sort=latest")
+
+        self.assertEqual(
+            {
+                "source": "firecross",
+                "kind": "firecross",
+                "workId": "firecross:358",
+                "seedUrl": "https://firecross.jp/ebook/series/358",
+                "series": "firecross:358",
+                "seriesId": "358",
+                "seriesUrl": "https://firecross.jp/ebook/series/358",
+            },
+            work.to_dict(),
+        )
+
     def test_nicovideo_manga_normalize_accepts_sp_comic_url(self):
         work = NicovideoMangaAdapter().normalize("https://sp.manga.nicovideo.jp/comic/53764?track=share")
 
@@ -893,6 +910,44 @@ class SourceAdapterTests(unittest.TestCase):
 
         with self.assertRaisesRegex(SourceParseError, "firecross: latest reader URL not found"):
             adapter.fetch_latest(work, client)
+
+    def test_firecross_fetch_latest_accepts_ebook_series_url(self):
+        adapter = ADAPTERS["firecross"]()
+        work = adapter.normalize("https://firecross.jp/ebook/series/358?sort=latest")
+        client = StaticHttpClient(
+            {
+                "https://firecross.jp/ebook/series/358?sort=latest": """
+                <html>
+                  <head><title>作品E | ファイアCROSS</title></head>
+                  <body>
+                    <a href="https://firecross.jp/reader/19420?from=series">第13話</a>
+                    <a href="https://firecross.jp/reader/19000">第10話</a>
+                  </body>
+                </html>
+                """,
+                "https://firecross.jp/reader/19420": """
+                <html>
+                  <head><title>第13話 / 作品E | ファイアCROSS</title></head>
+                  <body></body>
+                </html>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("https://firecross.jp/reader/19420", latest["latestKey"])
+        self.assertEqual("https://firecross.jp/reader/19420", latest["url"])
+        self.assertEqual("firecross:358", latest["series"])
+        self.assertEqual("作品E", latest["seriesTitle"])
+        self.assertEqual("第13話", latest["episodeTitle"])
+        self.assertEqual(
+            [
+                "https://firecross.jp/ebook/series/358?sort=latest",
+                "https://firecross.jp/reader/19420",
+            ],
+            client.calls,
+        )
 
     def test_nicovideo_manga_fetch_latest_accepts_comic_url(self):
         adapter = NicovideoMangaAdapter()

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -196,6 +196,28 @@ class WatchlistAddLogicTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
+    def test_add_watchlist_url_accepts_firecross_ebook_series_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            payload = add_watchlist_url(
+                "https://firecross.jp/ebook/series/358?sort=latest",
+                watchlist_path=str(watchlist_path),
+                http_client=StaticHttpClient({}),
+            )
+            saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("added", payload["action"])
+        self.assertEqual("firecross:358", payload["entry"]["id"])
+        self.assertEqual(
+            "https://firecross.jp/ebook/series/358",
+            payload["entry"]["seed_url"],
+        )
+        self.assertEqual("firecross", payload["entry"]["source"])
+        self.assertEqual(1, payload["work_count"])
+        self.assertEqual(1, len(saved["works"]))
+
     def test_watchlist_add_accepts_nicovideo_sp_comic_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"


### PR DESCRIPTION
## Issue
- Closes #183

## 変更概要
- FireCROSS adapter が `https://firecross.jp/ebook/series/<id>` を canonical な series seed として受け付けるようにした
- FireCROSS `ebook/series` seed は stable な `firecross:<id>` work id に正規化し、latest 解決では内部的に `?sort=latest` の series page を使って最新 reader を解決するようにした
- Discord `/add` の capability hint を FireCROSS `reader URL` と `ebook series URL` の両対応に更新した
- FireCROSS `ebook/series` の normalize / fetch_latest / watchlist add を test で固定した

## 検証結果
- `/Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_sources tests.test_watchlist tests.test_discord_interactions -v`

## 残留リスク
- FireCROSS `ebook/series/<id>/book` など派生 URL は今回も対象外
- live site の HTML 変更で sorted series page 上の reader link 構造が変わると latest 解決の追従が必要になる
