### PR TITLE
Add Magapoke crawl target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ runner が backend に送る update event は次の schema です。
 | ComicWalker | canonical series URL, episode URL | `https://comic-walker.com/detail/<series>` | `KC_XXXXXX_S` | `episodeCode` |
 | webアクション | episode URL, RSS/Atom series feed URL | canonical episode URL または canonical series feed URL | `comic-action:<series_id>` | 最終到達 episode URL |
 | Champion Cross | episode URL, series URL, series RSS URL | canonical episode URL / canonical series URL / canonical series RSS URL | `champion-cross:<series_hash>` | 最新 episode URL |
+| マガポケ | title URL, episode URL | `https://pocket.shonenmagazine.com/title/<title_id>` | `magapoke:<title_id>` | 最新 episode URL |
 | Kakuyomu | work URL, episode URL | 入力 URL のまま | `kakuyomu:<numeric_work_id>` | 最新 episode id |
 
 Phase 1 では source ごとの capability 差を隠しません。作品追加で受け付ける URL 種別は上の表だけです。内部の source capability / normalize 契約もこの表を source of truth とします。
@@ -453,6 +454,7 @@ fixture regression だけでは拾えない upstream HTML / embedded JSON drift 
 | --- | --- | --- | --- |
 | ComicWalker | `https://comic-walker.com/detail/KC_003913_S` | canonical series page の `__NEXT_DATA__`、同一 series の最新 `episodeCode`、最新 episode page title parse | `tests/fixtures/comic-walker/normal` |
 | webアクション | `https://comic-action.com/episode/2550689798784879524` | seed episode page の `series_id`、`nextReadableProductUri`、最終到達 episode page title parse | `tests/fixtures/comic-action/normal` |
+| マガポケ | `https://pocket.shonenmagazine.com/title/03021` | title page の RSS feed URL、title page の次回更新ラベル、series RSS の最新 episode URL/title | `tests/fixtures/magapoke/normal` |
 | Kakuyomu | `https://kakuyomu.jp/works/16818093092974667738/episodes/822139844009936710` | work page の `__NEXT_DATA__`、最新 episode id/title、最新 episode page title | `tests/fixtures/kakuyomu/normal` |
 
 drift を検知したら、次の順で進めます。

--- a/manga_watch/source_drift.py
+++ b/manga_watch/source_drift.py
@@ -24,6 +24,13 @@ from .sources.firecross import (
     parse_firecross_reader_title,
 )
 from .sources.kakuyomu import KakuyomuAdapter
+from .sources.magapoke import (
+    MagapokeAdapter,
+    canonical_magapoke_rss_url,
+    extract_magapoke_next_update_label,
+    extract_magapoke_rss_url,
+    parse_magapoke_rss_latest,
+)
 from .sources.nicovideo_manga import (
     NicovideoMangaAdapter,
     canonical_nicovideo_manga_latest_url,
@@ -114,6 +121,16 @@ DEFAULT_SOURCE_CANARY_CONTRACTS: Dict[str, SourceCanaryContract] = {
             "seed episode page exposes a stable series hash",
             "series RSS feed keeps the latest episode URL",
             "series RSS feed keeps the latest episode title",
+        ),
+    ),
+    "magapoke": SourceCanaryContract(
+        source="magapoke",
+        seed_url="https://pocket.shonenmagazine.com/title/03021",
+        fixture_bundle="tests/fixtures/magapoke/normal",
+        monitored_signals=(
+            "title page exposes the series RSS feed URL",
+            "title page exposes the next update label",
+            "series RSS feed keeps the latest episode URL and title",
         ),
     ),
     "firecross": SourceCanaryContract(
@@ -302,6 +319,42 @@ def _champion_cross_canary(
     )
 
 
+def _magapoke_canary(
+    contract: SourceCanaryContract,
+    http_client: HttpClient,
+) -> Tuple[Tuple[str, ...], Tuple[CanaryObservation, ...]]:
+    adapter = MagapokeAdapter()
+    work = adapter.normalize(contract.seed_url)
+
+    title_html = http_client.get_text(work.seed_url)
+    rss_url = extract_magapoke_rss_url(title_html)
+    if not rss_url:
+        title_id = str(work.metadata.get("titleId") or "")
+        if not title_id:
+            raise SourceParseError("magapoke: title id not found")
+        rss_url = canonical_magapoke_rss_url(title_id)
+
+    next_update_label = extract_magapoke_next_update_label(title_html)
+    if not next_update_label:
+        raise SourceParseError("magapoke: next update label not found")
+
+    feed_text = http_client.get_text(rss_url)
+    latest_url, latest_title, series_title = parse_magapoke_rss_latest(feed_text)
+    if not latest_title:
+        raise SourceParseError("magapoke: latest episode title not found")
+
+    return (
+        (work.seed_url, rss_url),
+        (
+            CanaryObservation("rss_url", rss_url),
+            CanaryObservation("next_update_label", next_update_label),
+            CanaryObservation("series_title", series_title or ""),
+            CanaryObservation("latest_episode_url", latest_url),
+            CanaryObservation("latest_episode_title", latest_title),
+        ),
+    )
+
+
 def _takecomic_canary(
     contract: SourceCanaryContract,
     http_client: HttpClient,
@@ -392,6 +445,7 @@ CANARY_RUNNERS = {
     "comic-walker": _comic_walker_canary,
     "comic-action": _comic_action_canary,
     "champion-cross": _champion_cross_canary,
+    "magapoke": _magapoke_canary,
     "firecross": _firecross_canary,
     "kakuyomu": _kakuyomu_canary,
     "nicovideo-manga": _nicovideo_manga_canary,

--- a/manga_watch/sources/magapoke.py
+++ b/manga_watch/sources/magapoke.py
@@ -1,0 +1,136 @@
+import re
+import xml.etree.ElementTree as ET
+from typing import Optional, Tuple
+
+from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
+
+
+_TITLE_OR_EPISODE_URL = re.compile(
+    r"^https?://(?:www\.)?pocket\.shonenmagazine\.com/title/(\d+)(?:/episode/(\d+))?/?(?:\?.*)?$"
+)
+_RSS_URL = re.compile(
+    r'<link[^>]+rel="alternate"[^>]+type="application/rss\+xml"[^>]+href="([^"]+)"',
+    re.I,
+)
+
+
+def normalize_magapoke_title_id(raw_title_id: str) -> Tuple[str, str]:
+    title_slug = str(raw_title_id or "").strip()
+    if not title_slug or not title_slug.isdigit():
+        raise RuntimeError("magapoke: could not parse title id")
+    numeric_title_id = str(int(title_slug))
+    return numeric_title_id, title_slug
+
+
+def canonical_magapoke_title_url(title_slug: str) -> str:
+    return f"https://pocket.shonenmagazine.com/title/{title_slug}"
+
+
+def canonical_magapoke_rss_url(title_id: str) -> str:
+    return f"https://mgpk-cdn.magazinepocket.com/static/rss/{title_id}/feed.xml"
+
+
+def extract_magapoke_rss_url(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    match = _RSS_URL.search(html_text)
+    if not match:
+        return None
+    return match.group(1).strip() or None
+
+
+def extract_magapoke_next_update_label(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    match = re.search(r"次回更新[^<]+予定です。", html_text)
+    if not match:
+        return None
+    return re.sub(r"\s+", " ", match.group(0)).strip() or None
+
+
+def classification_page_title_for_magapoke(episode_title: Optional[str]) -> Optional[str]:
+    if not episode_title:
+        return None
+    return episode_title.replace("＃", "#")
+
+
+def parse_magapoke_rss_latest(feed_text: str) -> Tuple[str, Optional[str], Optional[str]]:
+    if not feed_text or not feed_text.strip():
+        raise SourceParseError("magapoke: empty RSS feed")
+
+    try:
+        root = ET.fromstring(feed_text)
+    except ET.ParseError as exc:
+        raise SourceParseError(f"magapoke: invalid RSS feed: {exc}") from exc
+
+    channel = root.find("channel")
+    if channel is None:
+        raise SourceParseError("magapoke: RSS channel not found")
+
+    channel_title = (channel.findtext("title") or "").strip()
+    for item in channel.findall("item"):
+        latest_url = (item.findtext("link") or "").strip()
+        if not _TITLE_OR_EPISODE_URL.match(latest_url):
+            continue
+        episode_title = (item.findtext("title") or "").strip() or None
+        series_title = (item.findtext("description") or "").strip() or None
+        if not series_title:
+            match = re.search(r"マガポケ（(.+?)）", channel_title)
+            if match:
+                series_title = match.group(1).strip() or None
+        return latest_url, episode_title, series_title
+
+    raise SourceParseError("magapoke: latest episode not found in RSS feed")
+
+
+class MagapokeAdapter(SourceAdapter):
+    source = "magapoke"
+
+    def can_handle(self, seed_url: str) -> bool:
+        return bool(_TITLE_OR_EPISODE_URL.match(seed_url))
+
+    def normalize(self, seed_url: str) -> WorkDescriptor:
+        match = _TITLE_OR_EPISODE_URL.match(seed_url)
+        if not match:
+            raise RuntimeError("magapoke: could not parse title/episode URL")
+
+        numeric_title_id, title_slug = normalize_magapoke_title_id(match.group(1))
+        work_id = f"{self.source}:{numeric_title_id}"
+        return WorkDescriptor(
+            source=self.source,
+            work_id=work_id,
+            seed_url=canonical_magapoke_title_url(title_slug),
+            metadata={
+                "series": work_id,
+                "titleId": numeric_title_id,
+                "titleSlug": title_slug,
+            },
+        )
+
+    def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
+        title_id = str(work.metadata.get("titleId") or "")
+        title_slug = str(work.metadata.get("titleSlug") or "")
+        if not title_id or not title_slug:
+            match = _TITLE_OR_EPISODE_URL.match(work.seed_url)
+            if not match:
+                raise RuntimeError("magapoke: work descriptor missing title id")
+            title_id, title_slug = normalize_magapoke_title_id(match.group(1))
+
+        title_url = canonical_magapoke_title_url(title_slug)
+        title_html = http_client.get_text(title_url)
+        rss_url = extract_magapoke_rss_url(title_html) or canonical_magapoke_rss_url(title_id)
+        feed_text = http_client.get_text(rss_url)
+        latest_url, episode_title, series_title = parse_magapoke_rss_latest(feed_text)
+        next_update_label = extract_magapoke_next_update_label(title_html)
+
+        return LatestEpisode(
+            source=self.source,
+            work_id=work.work_id,
+            latest_key=latest_url,
+            url=latest_url,
+            series=work.metadata.get("series") or work.work_id,
+            series_title=series_title,
+            episode_title=episode_title,
+            page_title=classification_page_title_for_magapoke(episode_title),
+            extra={"nextUpdateLabel": next_update_label} if next_update_label else {},
+        )

--- a/manga_watch/sources/registry.py
+++ b/manga_watch/sources/registry.py
@@ -6,6 +6,7 @@ from .comic_action import ComicActionAdapter
 from .comic_walker import ComicWalkerAdapter
 from .firecross import FirecrossAdapter
 from .kakuyomu import KakuyomuAdapter
+from .magapoke import MagapokeAdapter
 from .nicovideo_manga import NicovideoMangaAdapter
 from .takecomic import TakecomicAdapter
 
@@ -14,6 +15,7 @@ REGISTERED_ADAPTERS = (
     ComicWalkerAdapter(),
     ComicActionAdapter(),
     ChampionCrossAdapter(),
+    MagapokeAdapter(),
     FirecrossAdapter(),
     TakecomicAdapter(),
     NicovideoMangaAdapter(),

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -47,6 +47,15 @@ SOURCE_CAPABILITIES = (
         ),
     ),
     SourceCapability(
+        source="magapoke",
+        domains=("pocket.shonenmagazine.com",),
+        input_labels=("title URL", "episode URL"),
+        examples=(
+            "https://pocket.shonenmagazine.com/title/03021",
+            "https://pocket.shonenmagazine.com/title/03021/episode/427856",
+        ),
+    ),
+    SourceCapability(
         source="firecross",
         domains=("firecross.jp",),
         input_labels=("reader URL", "ebook series URL"),

--- a/tests/fixtures/magapoke/normal/01-title.html
+++ b/tests/fixtures/magapoke/normal/01-title.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>普通の本はありません！ / マガポケ</title>
+    <link rel="alternate" type="application/rss+xml" href="https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml">
+  </head>
+  <body>
+    <div class="p-episode__comic">
+      <h1 class="p-episode__comic-ttl">普通の本はありません！</h1>
+      <p class="p-episode__update">
+        <span class="p-episode__update-label">UP</span>
+        <span class="p-episode__update-txt">次回更新は4/20(月曜)予定です。</span>
+      </p>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/magapoke/normal/02-feed.xml
+++ b/tests/fixtures/magapoke/normal/02-feed.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>マガポケ（普通の本はありません！）</title>
+    <link>https://pocket.shonenmagazine.com/title/03021/episode/427856</link>
+    <description>刺激強めのラブコメディ!!</description>
+    <item>
+      <title>【＃17】ハルとギンギン丸</title>
+      <link>https://pocket.shonenmagazine.com/title/03021/episode/434393</link>
+      <guid isPermalink="false">434393</guid>
+      <pubDate>Mon, 06 Apr 2026 00:00:00 +0900</pubDate>
+      <description>普通の本はありません！</description>
+    </item>
+    <item>
+      <title>【＃16】擦り過ぎてテカテカやん</title>
+      <link>https://pocket.shonenmagazine.com/title/03021/episode/433916</link>
+      <guid isPermalink="false">433916</guid>
+      <pubDate>Mon, 30 Mar 2026 00:00:00 +0900</pubDate>
+      <description>普通の本はありません！</description>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/magapoke/normal/manifest.json
+++ b/tests/fixtures/magapoke/normal/manifest.json
@@ -1,0 +1,32 @@
+{
+  "seedUrl": "https://pocket.shonenmagazine.com/title/03021",
+  "expectedWork": {
+    "source": "magapoke",
+    "kind": "magapoke",
+    "workId": "magapoke:3021",
+    "seedUrl": "https://pocket.shonenmagazine.com/title/03021",
+    "series": "magapoke:3021",
+    "titleId": "3021",
+    "titleSlug": "03021"
+  },
+  "steps": [
+    {
+      "url": "https://pocket.shonenmagazine.com/title/03021",
+      "response": "01-title.html"
+    },
+    {
+      "url": "https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml",
+      "response": "02-feed.xml"
+    }
+  ],
+  "expectedLatest": {
+    "source": "magapoke",
+    "workId": "magapoke:3021",
+    "latestKey": "https://pocket.shonenmagazine.com/title/03021/episode/434393",
+    "url": "https://pocket.shonenmagazine.com/title/03021/episode/434393",
+    "series": "magapoke:3021",
+    "seriesTitle": "普通の本はありません！",
+    "episodeTitle": "【＃17】ハルとギンギン丸",
+    "nextUpdateLabel": "次回更新は4/20(月曜)予定です。"
+  }
+}

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -13,6 +13,7 @@ from manga_watch.sources.champion_cross import ChampionCrossAdapter
 from manga_watch.sources.comic_action import ComicActionAdapter
 from manga_watch.sources.comic_walker import ComicWalkerAdapter
 from manga_watch.sources.kakuyomu import KakuyomuAdapter
+from manga_watch.sources.magapoke import MagapokeAdapter
 from manga_watch.sources.nicovideo_manga import NicovideoMangaAdapter
 from manga_watch.sources.util import html_title
 from manga_watch.sources.takecomic import TakecomicAdapter
@@ -41,6 +42,9 @@ SOURCE_CASES = {
     "champion-cross": (
         "normal",
         "episode_seed_missing_next_update",
+    ),
+    "magapoke": (
+        "normal",
     ),
     "firecross": (
         "normal",
@@ -80,6 +84,9 @@ EXPECTED_LATEST_CLASSIFICATIONS = {
     "champion-cross": {
         "normal": "main_story",
         "episode_seed_missing_next_update": "main_story",
+    },
+    "magapoke": {
+        "normal": "main_story",
     },
     "firecross": {
         "normal": "main_story",
@@ -180,7 +187,16 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_registry_pins_supported_sources(self):
         self.assertEqual(
-            ("comic-walker", "comic-action", "champion-cross", "firecross", "takecomic", "nicovideo-manga", "kakuyomu"),
+            (
+                "comic-walker",
+                "comic-action",
+                "champion-cross",
+                "magapoke",
+                "firecross",
+                "takecomic",
+                "nicovideo-manga",
+                "kakuyomu",
+            ),
             REGISTERED_SOURCES,
         )
 
@@ -211,11 +227,81 @@ class SourceAdapterTests(unittest.TestCase):
     def test_firecross_fixtures(self):
         self._assert_fixture_matrix("firecross")
 
+    def test_magapoke_fixtures(self):
+        self._assert_fixture_matrix("magapoke")
+
     def test_takecomic_fixtures(self):
         self._assert_fixture_matrix("takecomic")
 
     def test_nicovideo_manga_fixtures(self):
         self._assert_fixture_matrix("nicovideo-manga")
+
+    def test_magapoke_normalize_accepts_episode_url(self):
+        work = MagapokeAdapter().normalize(
+            "https://pocket.shonenmagazine.com/title/03021/episode/427856?utm_source=share"
+        )
+
+        self.assertEqual(
+            {
+                "source": "magapoke",
+                "kind": "magapoke",
+                "workId": "magapoke:3021",
+                "seedUrl": "https://pocket.shonenmagazine.com/title/03021",
+                "series": "magapoke:3021",
+                "titleId": "3021",
+                "titleSlug": "03021",
+            },
+            work.to_dict(),
+        )
+
+    def test_magapoke_fetch_latest_reads_series_rss_from_title_page(self):
+        adapter = MagapokeAdapter()
+        work = adapter.normalize("https://pocket.shonenmagazine.com/title/03021/episode/427856")
+        client = StaticHttpClient(
+            {
+                "https://pocket.shonenmagazine.com/title/03021": """
+                <html>
+                  <head>
+                    <title>普通の本はありません！ / マガポケ</title>
+                    <link rel="alternate" type="application/rss+xml" href="https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml">
+                  </head>
+                  <body>
+                    <p class="p-episode__update-txt">次回更新は4/20(月曜)予定です。</p>
+                  </body>
+                </html>
+                """,
+                "https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml": """
+                <rss>
+                  <channel>
+                    <title>マガポケ（普通の本はありません！）</title>
+                    <item>
+                      <title>【＃17】ハルとギンギン丸</title>
+                      <link>https://pocket.shonenmagazine.com/title/03021/episode/434393</link>
+                      <description>普通の本はありません！</description>
+                    </item>
+                  </channel>
+                </rss>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("magapoke:3021", latest["workId"])
+        self.assertEqual(
+            "https://pocket.shonenmagazine.com/title/03021/episode/434393",
+            latest["latestKey"],
+        )
+        self.assertEqual("普通の本はありません！", latest["seriesTitle"])
+        self.assertEqual("【＃17】ハルとギンギン丸", latest["episodeTitle"])
+        self.assertEqual("次回更新は4/20(月曜)予定です。", latest["nextUpdateLabel"])
+        self.assertEqual(
+            [
+                "https://pocket.shonenmagazine.com/title/03021",
+                "https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml",
+            ],
+            client.calls,
+        )
 
     def test_comic_walker_normalize_accepts_canonical_series_url(self):
         work = ComicWalkerAdapter().normalize("https://comic-walker.com/detail/KC_123456_S/?from=detail")

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -142,6 +142,39 @@ class WatchlistAddLogicTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
+    def test_add_watchlist_url_accepts_magapoke_episode_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            payload = add_watchlist_url(
+                "https://pocket.shonenmagazine.com/title/03021/episode/427856?utm_source=share",
+                watchlist_path=str(watchlist_path),
+                http_client=StaticHttpClient(
+                    {
+                        "https://pocket.shonenmagazine.com/title/03021": """
+                        <html>
+                          <head>
+                            <link rel="alternate" type="application/rss+xml" href="https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml">
+                          </head>
+                          <body></body>
+                        </html>
+                        """
+                    }
+                ),
+            )
+            saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("added", payload["action"])
+        self.assertEqual("magapoke:3021", payload["entry"]["id"])
+        self.assertEqual(
+            "https://pocket.shonenmagazine.com/title/03021",
+            payload["entry"]["seed_url"],
+        )
+        self.assertEqual("magapoke", payload["entry"]["source"])
+        self.assertEqual(1, payload["work_count"])
+        self.assertEqual(1, len(saved["works"]))
+
     def test_add_watchlist_url_accepts_takecomic_series_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"


### PR DESCRIPTION
## Issue
- Refs #187

## 変更概要
- `pocket.shonenmagazine.com` 向けの `magapoke` source adapter を追加し、episode/title URL を canonical title seed に正規化するようにしました。
- title page の RSS feed と次回更新ラベルを使って latest episode を取得する contract を追加し、source drift canary / fixture bundle を整備しました。
- watchlist capability と README の supported sources / canary table を Magapoke 対応に更新しました。

## 検証
- `/Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_source_drift tests.test_sources tests.test_check tests.test_watchlist tests.test_runner`

## 残留リスク
- Magapoke は series RSS feed と title page の `link rel="alternate"` / 次回更新ラベルに依存しているため、上流 HTML か RSS contract が変わると drift します。その検知用に live canary を追加しています。
