### PR TITLE
Document alphapolis public title-page contract

### DIFF
--- a/doc/alphapolis_public_title_contract.md
+++ b/doc/alphapolis_public_title_contract.md
@@ -1,0 +1,107 @@
+# alphapolis.co.jp public title/work contract
+
+Issue: #199
+Observed: 2026-04-08 JST
+
+## Summary
+
+`alphapolis.co.jp` can be treated as a Family B host whose canonical seed is the public title/work page:
+
+- `https://www.alphapolis.co.jp/manga/official/<work_id>`
+
+The title/work page exposes enough public information to define a stable normalize contract and a conditional latest detection contract without using login, browser automation, or private APIs.
+
+## Accepted input URL
+
+- Accepted now: public title/work URL
+  - Example: `https://www.alphapolis.co.jp/manga/official/208000499`
+- Not accepted yet in this issue:
+  - landing page URLs such as `https://www.alphapolis.co.jp/manga/official`
+  - episode URLs such as `/manga/official/<work_id>/<episode_no>`
+
+## Canonical seed
+
+- Canonical seed: `https://www.alphapolis.co.jp/manga/official/<work_id>`
+- The public page exposes a canonical `<link rel="canonical">` that matches the title/work URL.
+
+## Stable identifier
+
+- `work_id` rule: `alphapolis:<mangaId>`
+- Evidence:
+  - page canonical URL contains the numeric title/work id
+  - inline JSON under `#app-official-manga-toc` repeats the same `mangaId`
+
+## Latest detection contract
+
+The public title/work page contains an inline JSON payload under `#app-official-manga-toc` with:
+
+- `mangaId`
+- `mangaTitle`
+- `episodes`
+
+Rule:
+
+1. Parse the title/work page.
+2. Read the inline JSON payload.
+3. If `episodes` is non-empty, use the last episode entry as the current latest public episode.
+4. Build `latest_key` from the absolute episode URL:
+   - `https://www.alphapolis.co.jp` + `episodes[-1].url`
+
+For `https://www.alphapolis.co.jp/manga/official/208000499`, the observed latest public episode on 2026-04-08 was:
+
+- `episodeNo`: `11676`
+- `latest_key`: `https://www.alphapolis.co.jp/manga/official/208000499/11676`
+- `upTime`: `2026.04.06更新`
+
+## Blocker contract
+
+Some title/work pages exist before the first public episode is released.
+
+Observed pre-publication contract on `https://www.alphapolis.co.jp/manga/official/920000640`:
+
+- canonical title/work page exists
+- inline JSON exposes `mangaId` and `mangaTitle`
+- `episodes` is an empty array
+- page body exposes `2026.04.10公開予定`
+- the "第1回を読む" button is disabled
+
+For this state:
+
+- normalize is possible
+- canonical seed is stable
+- `work_id` is stable
+- latest episode detection is blocked until at least one public episode appears
+
+This means the adapter contract must distinguish:
+
+- `ready`: `episodes.length > 0`
+- `blocked_prepublication`: `episodes.length == 0` and the page exposes a publish-scheduled marker
+
+## Non-authoritative signals
+
+These signals are useful for display or future canaries, but should not be the primary latest key:
+
+- schedule text such as `毎月第3月曜日更新`
+- next update text such as `次回更新日 : 2026.04.27`
+- landing page "最近更新された漫画"
+
+These are helpful hints, but they do not uniquely identify the latest public episode for a single work.
+
+## Implementation-ready outcome
+
+Alphapolis is implementation-ready for Family B if a follow-up adapter:
+
+- accepts only title/work URLs
+- normalizes to `https://www.alphapolis.co.jp/manga/official/<work_id>`
+- derives `work_id = alphapolis:<mangaId>`
+- derives `latest_key` from the last public episode URL when `episodes` is non-empty
+- returns a clear blocker state for pre-publication pages with `episodes == []`
+- adds representative fixtures for both:
+  - an active title/work page with episodes
+  - a pre-publication title/work page without episodes
+
+## Evidence captured in this branch
+
+- `tests/fixtures/alphapolis/contract/208000499.json`
+- `tests/fixtures/alphapolis/contract/920000640.json`
+- `tests/test_alphapolis_contract.py`

--- a/tests/fixtures/alphapolis/contract/208000499.json
+++ b/tests/fixtures/alphapolis/contract/208000499.json
@@ -1,0 +1,26 @@
+{
+  "observedAt": "2026-04-08",
+  "inputUrl": "https://www.alphapolis.co.jp/manga/official/208000499",
+  "canonicalUrl": "https://www.alphapolis.co.jp/manga/official/208000499",
+  "pageTitle": "ワーキングダンジョン！~新卒勇者の異世界業務日誌~ | 公式Web漫画 | アルファポリス",
+  "scheduleLabel": "毎月第３月曜日更新",
+  "nextUpdateLabel": "2026.04.27",
+  "inlinePayload": {
+    "mangaId": 208000499,
+    "mangaTitle": "ワーキングダンジョン！~新卒勇者の異世界業務日誌~",
+    "episodes": [
+      {
+        "episodeNo": 11595,
+        "url": "/manga/official/208000499/11595",
+        "mainTitle": "連載再開のご挨拶 『期間限定全話無料公開！』",
+        "upTime": "2026.03.30更新"
+      },
+      {
+        "episodeNo": 11676,
+        "url": "/manga/official/208000499/11676",
+        "mainTitle": "Episode04-01『夢幻の龍が墜ちる時 Part1』",
+        "upTime": "2026.04.06更新"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/alphapolis/contract/920000640.json
+++ b/tests/fixtures/alphapolis/contract/920000640.json
@@ -1,0 +1,14 @@
+{
+  "observedAt": "2026-04-08",
+  "inputUrl": "https://www.alphapolis.co.jp/manga/official/920000640",
+  "canonicalUrl": "https://www.alphapolis.co.jp/manga/official/920000640",
+  "pageTitle": "完璧御曹司はウブな許嫁を愛してやまない | 公式Web漫画 | アルファポリス",
+  "scheduleLabel": "毎月第2金曜日更新",
+  "prepublicationLabel": "2026.04.10公開予定",
+  "firstEpisodeButtonDisabled": true,
+  "inlinePayload": {
+    "mangaId": 920000640,
+    "mangaTitle": "完璧御曹司はウブな許嫁を愛してやまない",
+    "episodes": []
+  }
+}

--- a/tests/test_alphapolis_contract.py
+++ b/tests/test_alphapolis_contract.py
@@ -1,0 +1,55 @@
+import json
+import unittest
+from pathlib import Path
+
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures" / "alphapolis" / "contract"
+ORIGIN = "https://www.alphapolis.co.jp"
+
+
+def load_fixture(name: str):
+    return json.loads((FIXTURES_ROOT / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def candidate_work_id(payload):
+    return f"alphapolis:{payload['inlinePayload']['mangaId']}"
+
+
+def candidate_latest_key(payload):
+    episodes = payload["inlinePayload"]["episodes"]
+    if not episodes:
+        return None
+    return f"{ORIGIN}{episodes[-1]['url']}"
+
+
+class AlphapolisContractTests(unittest.TestCase):
+    maxDiff = None
+
+    def test_active_title_page_supports_canonical_seed_and_latest_episode_detection(self):
+        payload = load_fixture("208000499")
+
+        self.assertEqual(payload["inputUrl"], payload["canonicalUrl"])
+        self.assertEqual("alphapolis:208000499", candidate_work_id(payload))
+        self.assertEqual("毎月第３月曜日更新", payload["scheduleLabel"])
+        self.assertEqual("2026.04.27", payload["nextUpdateLabel"])
+        self.assertEqual(
+            "https://www.alphapolis.co.jp/manga/official/208000499/11676",
+            candidate_latest_key(payload),
+        )
+        self.assertEqual(11676, payload["inlinePayload"]["episodes"][-1]["episodeNo"])
+        self.assertEqual("2026.04.06更新", payload["inlinePayload"]["episodes"][-1]["upTime"])
+
+    def test_prepublication_title_page_is_normalizable_but_has_no_latest_key_yet(self):
+        payload = load_fixture("920000640")
+
+        self.assertEqual(payload["inputUrl"], payload["canonicalUrl"])
+        self.assertEqual("alphapolis:920000640", candidate_work_id(payload))
+        self.assertEqual("毎月第2金曜日更新", payload["scheduleLabel"])
+        self.assertEqual("2026.04.10公開予定", payload["prepublicationLabel"])
+        self.assertTrue(payload["firstEpisodeButtonDisabled"])
+        self.assertEqual([], payload["inlinePayload"]["episodes"])
+        self.assertIsNone(candidate_latest_key(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue
- Closes #199

## What Changed
- capture the observed Alphapolis public title/work contract in a dedicated investigation note
- add two representative fixtures for an active title page and a pre-publication title page
- add an executable contract test that fixes the current canonical seed / work_id / latest_key rules

## Verification
- `python3 -m unittest tests.test_alphapolis_contract`

## Residual Risk
- this branch documents the current public contract but does not add a source adapter yet
- live HTML may drift, so the follow-up implementation should promote these fixtures into adapter/canary coverage once the host is accepted