### PR TITLE
Document comic-valkyrie to comic-brise source triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ runner が backend に送る update event は次の schema です。
 
 Phase 1 では source ごとの capability 差を隠しません。作品追加で受け付ける URL 種別は上の表だけです。内部の source capability / normalize 契約もこの表を source of truth とします。
 
+`Supported sources` にまだ入っていない host/domain の legacy/current 判定や successor mapping は、runtime contract を直接広げる前に `doc/` 配下の triage note へ残します。`comic-valkyrie.com -> comic-brise.com` の判定根拠は [`doc/source-triage-comic-valkyrie-comic-brise.md`](doc/source-triage-comic-valkyrie-comic-brise.md) を参照してください。
+
 ## Discord `/add`
 
 作品追加の正式導線は Discord slash command `/add url:<作品URL>` です。内部では shared add logic が URL を normalize し、duplicate / unsupported 判定を行ってから watchlist を更新します。

--- a/doc/source-triage-comic-valkyrie-comic-brise.md
+++ b/doc/source-triage-comic-valkyrie-comic-brise.md
@@ -1,0 +1,67 @@
+# Source Triage: comic-valkyrie.com -> comic-brise.com
+
+- Issue: `#213`
+- Observed on: `2026-04-08 JST`
+- Scope: public / non-login surface only
+- Non-goal: adapter 実装や supported source 追加
+
+## Decision
+
+| Item | Decision |
+| --- | --- |
+| `comic-valkyrie.com` | current reading contract ではなく、legacy / discovery surface として扱う |
+| `comic-brise.com` | successor ではなく、独立した current support candidate として扱う |
+| `comic-valkyrie.com -> comic-brise.com` | title-level successor mapping は成立するが、host 全体を単純置換する public contract とはみなさない |
+| inventory update (`#195`) | `comic-valkyrie.com` は legacy / inventory-only 側、`comic-brise.com` は current candidate 側として別建てで扱う |
+| follow-up | `comic-brise.com` の独立 investigation / implementation issue は必要 |
+
+## Public evidence
+
+### 1. `comic-valkyrie.com` は現役トップだが、`comic-brise.com` 作品を guest / discovery 導線として混在させている
+
+- `https://www.comic-valkyrie.com/` には `連載作品一覧` と別に `コミックブリーゼ出張掲載` セクションがある
+- 同一トップ内で `コミックヴァルキリー` と `コミックブリーゼ` を並べて告知しており、`comic-brise.com` を自サイト内の current reading contract として吸収していない
+
+Observed snippet on `2026-04-08`:
+
+```text
+<h2 class="info"><img src="img/icon_new.png" alt=""> 連載作品一覧</h2>
+<h2 class="info"><img src="img/icon_brise.png" alt=""> コミックブリーゼ出張掲載</h2>
+```
+
+### 2. `comic-brise.com` は独立した current surface を持つ
+
+- `https://www.comic-brise.com/` の title は `女性向け漫画(マンガ)読むならコミックブリーゼ` で、独立ブランドのトップとして動いている
+- 同タイトル中に `無料で第1話と最新話が読めます` とあり、current reading / latest discovery contract を自ドメインで持っている
+
+Observed snippet on `2026-04-08`:
+
+```text
+<title>コミックブリーゼ | 女性向け漫画(マンガ)読むならコミックブリーゼ。話題の悪役令嬢や、日常ほんわり系、ちょっとダークなファンタジーなどの漫画がたくさん！無料で第1話と最新話が読めます！新刊・発売日情報もたくさん！</title>
+```
+
+### 3. representative work page の latest/backnumber contract も `comic-brise.com` 側にある
+
+- representative page: `https://www.comic-brise.com/contents/oujisamanante/`
+- 同ページに `バックナンバー`、`第35話`、`第36話`、`FREE`、`TRIAL` が並んでおり、作品ページ単位の public navigation が `comic-brise.com` 側で完結している
+
+Observed snippet on `2026-04-08`:
+
+```text
+<title>王子様なんて、こっちから願い下げですわ！～追放された元悪役令嬢、魔法の力で見返します～ | コミックブリーゼ</title>
+<h2 class="common-title"><span>バックナンバー</span></h2>
+<div class="number-chapter">第35話</div>
+<div class="number-chapter">第36話</div>
+```
+
+## Conclusion for issue #213
+
+- `comic-valkyrie.com` は今も public top page として生きているが、`comic-brise.com` 作品の current/latest contract を代表する host とは言い切れない
+- `comic-brise.com` は独立したブランド top と作品ページ群を持つため、current support candidate として個別に扱う方が自然
+- したがって `comic-valkyrie.com -> comic-brise.com` は「old/current host の単純置換」ではなく、「一部タイトルで successor mapping が必要な legacy-to-current relationship」として扱う
+- `#195` の分類更新では、`comic-valkyrie.com` を current/live target として残すより、legacy / inventory-only 側へ寄せたうえで `comic-brise.com` を別 candidate として管理するのが妥当
+
+## Follow-up recommendation
+
+- `comic-brise.com` には独立 issue を切って、accepted input URL、canonical seed、latest/backnumber discovery の public contract を詰める
+- この note 自体は evidence 固定だけに責任を持ち、supported source 追加や parser 実装は別 issue で進める


### PR DESCRIPTION
## Issue
- Closes #213

## What changed
- added a source triage note that records the current/historical relationship between `comic-valkyrie.com` and `comic-brise.com`
- linked the note from README so successor-mapping evidence can live in-repo without expanding the supported-source table yet
- documented the inventory conclusion: treat `comic-valkyrie.com` as legacy/discovery for successor-mapped titles and track `comic-brise.com` separately as a current support candidate

## Verification
- `git diff --check`
- manually verified the public pages on 2026-04-08:
  - `https://www.comic-valkyrie.com/` still exposes `連載作品一覧` and a separate `コミックブリーゼ出張掲載` section
  - `https://www.comic-brise.com/` brands itself as a standalone current reading surface
  - `https://www.comic-brise.com/contents/oujisamanante/` exposes a `バックナンバー` section with chapter labels such as `第35話` and `第36話`

## Residual risk
- this PR records evidence only and does not create a `comic-brise.com` adapter yet
- site structure may drift over time, so a future implementation issue should re-check the public contract before coding