### PR TITLE
Document zerosumonline public title contract

### DIFF
--- a/doc/zerosumonline_public_title_contract.md
+++ b/doc/zerosumonline_public_title_contract.md
@@ -1,0 +1,106 @@
+# zerosumonline.com public title/work contract
+
+Issue: #202
+Observed: 2026-04-08 JST
+
+## Summary
+
+`online.ichijinsha.co.jp/zerosum` now fronts the `zerosumonline.com` experience, but the current public work listing surface is not the previously assumed bare `/works` URL.
+
+Observed current public contract:
+
+- legacy landing entry: `https://online.ichijinsha.co.jp/zerosum/`
+- current active listing page: `https://zerosumonline.com/works/series`
+- current title detail page: `https://zerosumonline.com/detail/<tag>`
+- current public chapter route shape: `https://zerosumonline.com/episode/<tag>/chapter/<latestChapterId>`
+
+This issue remains investigation-only. Adapter implementation is a non-goal here.
+
+## Accepted input URL
+
+- Accepted now:
+  - current title detail URL such as `https://zerosumonline.com/detail/shinryu`
+  - current active listing URL `https://zerosumonline.com/works/series`
+  - legacy landing entry `https://online.ichijinsha.co.jp/zerosum/` as a source-family clue
+- Not accepted yet in this issue:
+  - direct adapter support for every category page
+  - chapter ingestion or protobuf decoding implementation
+
+## Route blocker recorded in this lane
+
+The issue body's earlier assumption that `https://zerosumonline.com/works` is the public works listing is no longer correct as observed on 2026-04-08:
+
+- requesting `https://zerosumonline.com/works` returns a page whose `og:url` is `https://zerosumonline.com`
+- the active works listing lives at `https://zerosumonline.com/works/series`
+- the active listing page title is `連載作品 | ゼロサムオンライン`
+
+This means follow-up work must treat `/works/series` as the public series listing seed instead of bare `/works`.
+
+## Canonical seed
+
+- Canonical public title seed: `https://zerosumonline.com/detail/<tag>`
+- Representative observed title seed: `https://zerosumonline.com/detail/shinryu`
+
+The detail page exposes stable public metadata:
+
+- `og:url = https://zerosumonline.com/detail/shinryu`
+- `og:image = https://contents.zerosumonline.com/title_thumbnail/197.webp`
+
+## Stable identifier
+
+- Candidate `work_id` rule: `zerosumonline:<tag>`
+- Representative evidence: the public detail route is keyed by `tag`, and both listing and detail bundles route users by that same `tag`
+
+## Listing contract
+
+The works category bundle calls:
+
+- API base: `https://api.zerosumonline.com/api/v1`
+- list endpoint: `GET /list`
+- observed query shape for active series page: `category=series&sort=date`
+
+The works category page links each title to:
+
+- `/detail/<tag>`
+
+So a follow-up adapter can treat `/works/series` as the public discovery/list seed for active titles.
+
+## Latest detection contract
+
+The public detail bundle calls:
+
+- title endpoint: `GET /title?tag=<tag>`
+
+The shipped protobuf schema and detail-page bundle expose these signals:
+
+- `Title.latestChapterId`
+- `TitleView.chapters`
+- public chapter route template `/episode/<tag>/chapter/<chapterId>`
+
+Bounded rule established in this issue:
+
+1. Normalize the title to `https://zerosumonline.com/detail/<tag>`.
+2. Fetch the public title payload from `/title?tag=<tag>`.
+3. Read the latest chapter identifier from the public title payload.
+4. Materialize `latest_key` as:
+   - `https://zerosumonline.com/episode/<tag>/chapter/<latestChapterId>`
+
+This lane proves the route contract and the payload fields required for latest detection. It does not implement protobuf decoding.
+
+## Implementation-ready outcome
+
+Zerosum Online is implementation-ready for a Family B follow-up if that adapter:
+
+- accepts current detail URLs under `/detail/<tag>`
+- uses `/works/series` as the active public listing seed
+- derives `work_id = zerosumonline:<tag>`
+- decodes the public `/title?tag=<tag>` payload
+- derives `latest_key = https://zerosumonline.com/episode/<tag>/chapter/<latestChapterId>`
+- treats bare `/works` as a blocked or obsolete listing seed, not the canonical public listing page
+
+## Evidence captured in this branch
+
+- `tests/fixtures/zerosumonline/contract/detail_shinryu.json`
+- `tests/fixtures/zerosumonline/contract/works_series.json`
+- `tests/fixtures/zerosumonline/contract/works_root_blocked.json`
+- `tests/test_zerosumonline_contract.py`

--- a/tests/fixtures/zerosumonline/contract/detail_shinryu.json
+++ b/tests/fixtures/zerosumonline/contract/detail_shinryu.json
@@ -1,0 +1,19 @@
+{
+  "inputUrl": "https://zerosumonline.com/detail/shinryu",
+  "canonicalUrl": "https://zerosumonline.com/detail/shinryu",
+  "tag": "shinryu",
+  "pageTitle": "神竜の後継者 出来損ないと二人の守護竜|ゼロサムオンライン",
+  "ogImage": "https://contents.zerosumonline.com/title_thumbnail/197.webp",
+  "api": {
+    "baseUrl": "https://api.zerosumonline.com/api/v1",
+    "titlePath": "/title",
+    "titleQuery": {
+      "tag": "shinryu"
+    }
+  },
+  "publicSignals": {
+    "titleField": "latestChapterId",
+    "titleViewField": "chapters",
+    "episodePathTemplate": "/episode/<tag>/chapter/<latestChapterId>"
+  }
+}

--- a/tests/fixtures/zerosumonline/contract/works_root_blocked.json
+++ b/tests/fixtures/zerosumonline/contract/works_root_blocked.json
@@ -1,0 +1,7 @@
+{
+  "inputUrl": "https://zerosumonline.com/works",
+  "observedOgUrl": "https://zerosumonline.com",
+  "pageTitle": "ゼロサムオンライン",
+  "acceptedAsSeriesListing": false,
+  "blocker": "bare /works no longer behaves as the active works listing; use /works/series instead"
+}

--- a/tests/fixtures/zerosumonline/contract/works_series.json
+++ b/tests/fixtures/zerosumonline/contract/works_series.json
@@ -1,0 +1,16 @@
+{
+  "inputUrl": "https://zerosumonline.com/works/series",
+  "canonicalUrl": "https://zerosumonline.com/works/series",
+  "pageTitle": "連載作品 | ゼロサムオンライン",
+  "api": {
+    "baseUrl": "https://api.zerosumonline.com/api/v1",
+    "listPath": "/list",
+    "listQuery": {
+      "category": "series",
+      "sort": "date"
+    }
+  },
+  "routing": {
+    "titlePathTemplate": "/detail/<tag>"
+  }
+}

--- a/tests/test_zerosumonline_contract.py
+++ b/tests/test_zerosumonline_contract.py
@@ -1,0 +1,71 @@
+import json
+import unittest
+from pathlib import Path
+
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures" / "zerosumonline" / "contract"
+ORIGIN = "https://zerosumonline.com"
+
+
+def load_fixture(name: str):
+    return json.loads((FIXTURES_ROOT / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def candidate_work_id(payload):
+    return f"zerosumonline:{payload['tag']}"
+
+
+def candidate_latest_key_template(payload):
+    return f"{ORIGIN}/episode/{payload['tag']}/chapter/<latestChapterId>"
+
+
+class ZerosumonlineContractTests(unittest.TestCase):
+    maxDiff = None
+
+    def test_current_series_listing_seed_uses_works_series(self):
+        payload = load_fixture("works_series")
+
+        self.assertEqual(payload["inputUrl"], payload["canonicalUrl"])
+        self.assertEqual("連載作品 | ゼロサムオンライン", payload["pageTitle"])
+        self.assertEqual("https://api.zerosumonline.com/api/v1", payload["api"]["baseUrl"])
+        self.assertEqual("/list", payload["api"]["listPath"])
+        self.assertEqual(
+            {"category": "series", "sort": "date"},
+            payload["api"]["listQuery"],
+        )
+        self.assertEqual("/detail/<tag>", payload["routing"]["titlePathTemplate"])
+
+    def test_detail_page_contract_supports_tag_work_id_and_latest_key_template(self):
+        payload = load_fixture("detail_shinryu")
+
+        self.assertEqual(payload["inputUrl"], payload["canonicalUrl"])
+        self.assertEqual("zerosumonline:shinryu", candidate_work_id(payload))
+        self.assertEqual(
+            "神竜の後継者 出来損ないと二人の守護竜|ゼロサムオンライン",
+            payload["pageTitle"],
+        )
+        self.assertEqual(
+            "https://contents.zerosumonline.com/title_thumbnail/197.webp",
+            payload["ogImage"],
+        )
+        self.assertEqual("/title", payload["api"]["titlePath"])
+        self.assertEqual({"tag": "shinryu"}, payload["api"]["titleQuery"])
+        self.assertEqual("latestChapterId", payload["publicSignals"]["titleField"])
+        self.assertEqual("chapters", payload["publicSignals"]["titleViewField"])
+        self.assertEqual(
+            "https://zerosumonline.com/episode/shinryu/chapter/<latestChapterId>",
+            candidate_latest_key_template(payload),
+        )
+
+    def test_bare_works_route_is_a_blocked_seed_not_the_active_listing_page(self):
+        payload = load_fixture("works_root_blocked")
+
+        self.assertEqual("https://zerosumonline.com/works", payload["inputUrl"])
+        self.assertEqual("https://zerosumonline.com", payload["observedOgUrl"])
+        self.assertEqual("ゼロサムオンライン", payload["pageTitle"])
+        self.assertFalse(payload["acceptedAsSeriesListing"])
+        self.assertIn("/works/series", payload["blocker"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the current zerosumonline public title and listing route contract for issue #202
- record the  blocker and the current  listing seed
- add focused fixtures and a unittest for the bounded contract evidence

## Testing
- /Users/kentokumatsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_zerosumonline_contract

Closes #202