### PR TITLE
Add kuragebunch source adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ runner が backend に送る update event は次の schema です。
 | ComicWalker | canonical series URL, episode URL | `https://comic-walker.com/detail/<series>` | `KC_XXXXXX_S` | `episodeCode` |
 | webアクション | episode URL, RSS/Atom series feed URL | canonical episode URL または canonical series feed URL | `comic-action:<series_id>` | 最終到達 episode URL |
 | コミックボーダー | episode URL, RSS/Atom series feed URL | `https://comicborder.com/rss/series/<series_id>` | `comicborder:<series_id>` | 最新 episode URL |
+| くらげバンチ | episode URL, RSS/Atom series feed URL | `https://kuragebunch.com/rss/series/<series_id>` | `kuragebunch:<series_id>` | 最新 episode URL |
 | 少年ジャンプ＋ | episode URL, RSS/Atom series feed URL | `https://shonenjumpplus.com/rss/series/<series_id>` | `shonenjumpplus:<series_id>` | 最新 episode URL |
 | Champion Cross | episode URL, series URL, series RSS URL | canonical episode URL / canonical series URL / canonical series RSS URL | `champion-cross:<series_hash>` | 最新 episode URL |
 | マガポケ | title URL, episode URL | `https://pocket.shonenmagazine.com/title/<title_id>` | `magapoke:<title_id>` | 最新 episode URL |
@@ -461,6 +462,7 @@ fixture regression だけでは拾えない upstream HTML / embedded JSON drift 
 | ComicWalker | `https://comic-walker.com/detail/KC_003913_S` | canonical series page の `__NEXT_DATA__`、同一 series の最新 `episodeCode`、最新 episode page title parse | `tests/fixtures/comic-walker/normal` |
 | webアクション | `https://comic-action.com/episode/2550689798784879524` | seed episode page の `series_id`、`nextReadableProductUri`、最終到達 episode page title parse | `tests/fixtures/comic-action/normal` |
 | コミックボーダー | `https://comicborder.com/episode/12207421983437812169` | seed episode page 由来の stable `series_id`、series RSS の最新 episode URL、最新 episode page title parse | `tests/fixtures/comicborder/normal` |
+| くらげバンチ | `https://kuragebunch.com/episode/2550912964856491139` | seed episode page 由来の stable `series_id`、series RSS の最新 episode URL、最新 episode page title parse | `tests/fixtures/kuragebunch/normal` |
 | 少年ジャンプ＋ | `https://shonenjumpplus.com/episode/17107419589191805801` | seed episode page 由来の stable `series_id`、series RSS の最新 episode URL、最新 episode page title parse | `tests/fixtures/shonenjumpplus/normal` |
 | マガポケ | `https://pocket.shonenmagazine.com/title/03021` | title page の RSS feed URL、title page の次回更新ラベル、series RSS の最新 episode URL/title | `tests/fixtures/magapoke/normal` |
 | Kakuyomu | `https://kakuyomu.jp/works/16818093092974667738/episodes/822139844009936710` | work page の `__NEXT_DATA__`、最新 episode id/title、最新 episode page title | `tests/fixtures/kakuyomu/normal` |

--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -34,6 +34,12 @@ from manga_watch.sources.comicborder import (
     extract_comicborder_series_id_from_seed_url,
 )
 from manga_watch.sources.firecross import extract_firecross_series_id
+from manga_watch.sources.kuragebunch import (
+    canonical_kuragebunch_series_feed_url,
+    extract_kuragebunch_series_feed_url,
+    extract_kuragebunch_series_id,
+    extract_kuragebunch_series_id_from_seed_url,
+)
 from manga_watch.sources.shonenjumpplus import (
     canonical_shonenjumpplus_series_feed_url,
     extract_shonenjumpplus_series_feed_url,
@@ -607,6 +613,26 @@ def stable_work_id_for_item(
             raise RuntimeError("comicborder: series id not found")
         return f"comicborder:{series_id}"
 
+    if source == "kuragebunch":
+        stable_series = str(item.get("series") or "")
+        if stable_series.startswith("kuragebunch:"):
+            return stable_series
+
+        seed_url = str(item.get("seedUrl") or "")
+        if not seed_url:
+            raise RuntimeError("kuragebunch: seedUrl is required to derive work_id")
+
+        series_id = str(item.get("seriesId") or "") or extract_kuragebunch_series_id_from_seed_url(seed_url)
+        if series_id:
+            return f"kuragebunch:{series_id}"
+
+        client = http_client or RequestsHttpClient()
+        html = client.get_text(seed_url)
+        series_id = extract_kuragebunch_series_id(html)
+        if not series_id:
+            raise RuntimeError("kuragebunch: series id not found")
+        return f"kuragebunch:{series_id}"
+
     if source == "shonenjumpplus":
         stable_series = str(item.get("series") or "")
         if stable_series.startswith("shonenjumpplus:"):
@@ -672,6 +698,22 @@ def canonical_seed_url_for_item(
         if not series_id:
             raise RuntimeError("comicborder: series id not found")
         return canonical_comicborder_series_feed_url(series_id)
+
+    if source == "kuragebunch":
+        series_id = str(item.get("seriesId") or "") or extract_kuragebunch_series_id_from_seed_url(seed_url)
+        if series_id:
+            return canonical_kuragebunch_series_feed_url(series_id)
+
+        client = http_client or RequestsHttpClient()
+        html = client.get_text(seed_url)
+        feed_url = extract_kuragebunch_series_feed_url(html)
+        if feed_url:
+            return feed_url
+
+        series_id = extract_kuragebunch_series_id(html)
+        if not series_id:
+            raise RuntimeError("kuragebunch: series id not found")
+        return canonical_kuragebunch_series_feed_url(series_id)
 
     if source != "shonenjumpplus":
         return seed_url

--- a/manga_watch/source_drift.py
+++ b/manga_watch/source_drift.py
@@ -30,6 +30,12 @@ from .sources.firecross import (
     parse_firecross_reader_title,
 )
 from .sources.kakuyomu import KakuyomuAdapter
+from .sources.kuragebunch import (
+    KuragebunchAdapter,
+    extract_kuragebunch_series_id,
+    parse_kuragebunch_feed_latest,
+    parse_kuragebunch_title,
+)
 from .sources.magapoke import (
     MagapokeAdapter,
     canonical_magapoke_rss_url,
@@ -129,6 +135,16 @@ DEFAULT_SOURCE_CANARY_CONTRACTS: Dict[str, SourceCanaryContract] = {
         source="comicborder",
         seed_url="https://comicborder.com/episode/12207421983437812169",
         fixture_bundle="tests/fixtures/comicborder/normal",
+        monitored_signals=(
+            "seed episode page exposes a stable series id",
+            "series RSS feed keeps the latest episode URL",
+            "latest episode page title still parses into series / episode labels",
+        ),
+    ),
+    "kuragebunch": SourceCanaryContract(
+        source="kuragebunch",
+        seed_url="https://kuragebunch.com/episode/2550912964856491139",
+        fixture_bundle="tests/fixtures/kuragebunch/normal",
         monitored_signals=(
             "seed episode page exposes a stable series id",
             "series RSS feed keeps the latest episode URL",
@@ -397,6 +413,57 @@ def _comicborder_canary(
     )
 
 
+def _kuragebunch_canary(
+    contract: SourceCanaryContract,
+    http_client: HttpClient,
+) -> Tuple[Tuple[str, ...], Tuple[CanaryObservation, ...]]:
+    adapter = KuragebunchAdapter()
+    work = adapter.normalize(contract.seed_url)
+
+    checked_urls = []
+    if work.seed_url.endswith("/rss") or "/rss/series/" in work.seed_url:
+        rss_url = work.seed_url
+        series_id = str(work.metadata.get("seriesId") or "") or rss_url.rstrip("/").rsplit("/", 1)[-1]
+        feed_text = http_client.get_text(rss_url)
+        checked_urls.append(rss_url)
+        latest_url, latest_title, _ = parse_kuragebunch_feed_latest(feed_text)
+        latest_html = http_client.get_text(latest_url)
+        checked_urls.append(latest_url)
+    else:
+        episode_html = http_client.get_text(work.seed_url)
+        checked_urls.append(work.seed_url)
+        series_id = extract_kuragebunch_series_id(episode_html)
+        if not series_id:
+            raise SourceParseError("kuragebunch: series id not found")
+        rss_url = f"https://kuragebunch.com/rss/series/{series_id}"
+        feed_text = http_client.get_text(rss_url)
+        checked_urls.append(rss_url)
+        latest_url, latest_title, _ = parse_kuragebunch_feed_latest(feed_text)
+        latest_html = http_client.get_text(latest_url)
+        checked_urls.append(latest_url)
+
+    page_title = html_title(latest_html) or ""
+    if not latest_title:
+        raise SourceParseError("kuragebunch: latest episode title not found")
+    if not page_title:
+        raise SourceParseError("kuragebunch: latest episode page title not found")
+    parsed_episode_title, parsed_series_title = parse_kuragebunch_title(page_title)
+    if not parsed_episode_title:
+        raise SourceParseError("kuragebunch: latest episode title could not be parsed from page title")
+    if not parsed_series_title:
+        raise SourceParseError("kuragebunch: series title could not be parsed from page title")
+
+    return (
+        tuple(checked_urls),
+        (
+            CanaryObservation("series_id", series_id),
+            CanaryObservation("latest_episode_url", latest_url),
+            CanaryObservation("latest_episode_title", parsed_episode_title),
+            CanaryObservation("series_title", parsed_series_title),
+        ),
+    )
+
+
 def _kakuyomu_canary(contract: SourceCanaryContract, http_client: HttpClient) -> Tuple[Tuple[str, ...], Tuple[CanaryObservation, ...]]:
     adapter = KakuyomuAdapter()
     work = adapter.normalize(contract.seed_url)
@@ -581,6 +648,7 @@ CANARY_RUNNERS = {
     "comic-walker": _comic_walker_canary,
     "comic-action": _comic_action_canary,
     "comicborder": _comicborder_canary,
+    "kuragebunch": _kuragebunch_canary,
     "shonenjumpplus": _shonenjumpplus_canary,
     "champion-cross": _champion_cross_canary,
     "magapoke": _magapoke_canary,

--- a/manga_watch/sources/kuragebunch.py
+++ b/manga_watch/sources/kuragebunch.py
@@ -1,0 +1,210 @@
+import html
+import re
+import xml.etree.ElementTree as ET
+from typing import Optional, Tuple
+
+from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
+from .util import html_title
+
+
+_HOST = "kuragebunch.com"
+_EPISODE_URL = re.compile(rf"^https?://(?:www\.)?{_HOST}/episode/(\d+)(?:/)?(?:\?.*)?$")
+_SERIES_FEED_URL = re.compile(
+    rf"^https?://(?:www\.)?{_HOST}/(rss|atom)/series/(\d+)(?:/)?(?:\?.*)?$"
+)
+_RSS_LINK = re.compile(
+    rf'<link[^>]+rel="alternate"[^>]+type="application/rss\+xml"[^>]+href="(https?://(?:www\.)?{_HOST}/rss/series/\d+(?:\?[^"]*)?)"',
+    re.I,
+)
+_SERIES_ID_PATTERNS = (
+    re.compile(r'"series_id"\s*:\s*"(\d+)"'),
+    re.compile(r'&quot;series_id&quot;\s*:\s*&quot;(\d+)&quot;'),
+    re.compile(rf"https?://(?:www\.)?{_HOST}/(?:rss|atom)/series/(\d+)"),
+)
+
+
+def canonical_kuragebunch_episode_url(episode_id: str) -> str:
+    return f"https://{_HOST}/episode/{episode_id}"
+
+
+def canonical_kuragebunch_series_feed_url(series_id: str, feed_kind: str = "rss") -> str:
+    return f"https://{_HOST}/{feed_kind}/series/{series_id}"
+
+
+def parse_kuragebunch_episode_url(seed_url: str) -> Optional[str]:
+    match = _EPISODE_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_kuragebunch_episode_url(match.group(1))
+
+
+def parse_kuragebunch_series_feed_url(seed_url: str) -> Optional[Tuple[str, str]]:
+    match = _SERIES_FEED_URL.match(seed_url)
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def extract_kuragebunch_series_id_from_seed_url(seed_url: str) -> Optional[str]:
+    parsed = parse_kuragebunch_series_feed_url(seed_url)
+    if parsed:
+        return parsed[1]
+    return None
+
+
+def extract_kuragebunch_series_id(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    normalized = html.unescape(html_text).replace("\\/", "/")
+    for pattern in _SERIES_ID_PATTERNS:
+        match = pattern.search(normalized)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_kuragebunch_series_feed_url(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    normalized = html.unescape(html_text).replace("\\/", "/")
+    match = _RSS_LINK.search(normalized)
+    if match:
+        return canonical_kuragebunch_series_feed_url(match.group(1).rsplit("/", 1)[-1].split("?", 1)[0])
+    series_id = extract_kuragebunch_series_id(normalized)
+    if not series_id:
+        return None
+    return canonical_kuragebunch_series_feed_url(series_id)
+
+
+def parse_kuragebunch_feed_latest(feed_text: str) -> Tuple[str, Optional[str], Optional[str]]:
+    if not feed_text or not feed_text.strip():
+        raise SourceParseError("kuragebunch: empty feed")
+
+    try:
+        root = ET.fromstring(feed_text)
+    except ET.ParseError as exc:
+        raise SourceParseError(f"kuragebunch: invalid feed: {exc}") from exc
+
+    channel = root.find("channel")
+    if channel is not None:
+        series_title = _series_title_from_channel_title((channel.findtext("title") or "").strip())
+        for item in channel.findall("item"):
+            latest_url = parse_kuragebunch_episode_url((item.findtext("link") or "").strip())
+            if not latest_url:
+                continue
+            episode_title = (item.findtext("title") or "").strip() or None
+            item_series_title = (item.findtext("description") or "").strip() or None
+            return latest_url, episode_title, item_series_title or series_title
+        raise SourceParseError("kuragebunch: latest episode not found in RSS feed")
+
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    title_text = (root.findtext("atom:title", default="", namespaces=ns) or "").strip()
+    series_title = _series_title_from_channel_title(title_text)
+    for entry in root.findall("atom:entry", ns):
+        for link in entry.findall("atom:link", ns):
+            latest_url = parse_kuragebunch_episode_url((link.get("href") or "").strip())
+            if latest_url:
+                episode_title = (entry.findtext("atom:title", default="", namespaces=ns) or "").strip() or None
+                content = (entry.findtext("atom:content", default="", namespaces=ns) or "").strip() or None
+                return latest_url, episode_title, content or series_title
+    raise SourceParseError("kuragebunch: latest episode not found in Atom feed")
+
+
+def parse_kuragebunch_title(page_title: str) -> Tuple[Optional[str], Optional[str]]:
+    title = str(page_title or "").strip()
+    if not title:
+        return None, None
+    main = title.split("|", 1)[0].strip()
+    left, separator, right = main.rpartition(" / ")
+    if not separator:
+        return None, None
+    episode_title = right.strip() or None
+    series_part = left.strip()
+    series_title = series_part.split(" - ", 1)[0].strip() or None
+    return episode_title, series_title
+
+
+def _series_title_from_channel_title(channel_title: str) -> Optional[str]:
+    if not channel_title:
+        return None
+    match = re.search(r"くらげバンチ（(.+?)）", channel_title)
+    if match:
+        return match.group(1).strip() or None
+    return channel_title or None
+
+
+class KuragebunchAdapter(SourceAdapter):
+    source = "kuragebunch"
+
+    def can_handle(self, seed_url: str) -> bool:
+        return bool(
+            parse_kuragebunch_episode_url(seed_url)
+            or parse_kuragebunch_series_feed_url(seed_url)
+        )
+
+    def normalize(self, seed_url: str) -> WorkDescriptor:
+        normalized_episode_url = parse_kuragebunch_episode_url(seed_url)
+        if normalized_episode_url:
+            return WorkDescriptor(
+                source=self.source,
+                work_id=normalized_episode_url,
+                seed_url=normalized_episode_url,
+            )
+
+        feed_match = parse_kuragebunch_series_feed_url(seed_url)
+        if not feed_match:
+            raise RuntimeError(f"kuragebunch: unsupported seed URL: {seed_url}")
+
+        _, series_id = feed_match
+        stable_work_id = f"{self.source}:{series_id}"
+        return WorkDescriptor(
+            source=self.source,
+            work_id=stable_work_id,
+            seed_url=canonical_kuragebunch_series_feed_url(series_id),
+            metadata={
+                "series": stable_work_id,
+                "seriesId": series_id,
+                "feedKind": "rss",
+            },
+        )
+
+    def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
+        series = str(work.metadata.get("series") or work.work_id)
+        series_id = str(work.metadata.get("seriesId") or "")
+
+        feed_match = parse_kuragebunch_series_feed_url(work.seed_url)
+        if feed_match:
+            feed_url = canonical_kuragebunch_series_feed_url(feed_match[1])
+            series_id = series_id or feed_match[1]
+        else:
+            episode_url = parse_kuragebunch_episode_url(work.seed_url)
+            if not episode_url:
+                raise RuntimeError("kuragebunch: unsupported seed URL")
+            episode_html = http_client.get_text(episode_url)
+            feed_url = extract_kuragebunch_series_feed_url(episode_html)
+            series_id = series_id or extract_kuragebunch_series_id(episode_html) or ""
+            if not series_id:
+                raise SourceParseError("kuragebunch: series id not found")
+            if not feed_url:
+                raise SourceParseError("kuragebunch: series feed URL not found")
+            series = f"{self.source}:{series_id}"
+
+        feed_text = http_client.get_text(feed_url)
+        latest_url, episode_title, series_title = parse_kuragebunch_feed_latest(feed_text)
+        page_title = html_title(http_client.get_text(latest_url))
+        parsed_episode_title, parsed_series_title = parse_kuragebunch_title(page_title or "")
+        if not episode_title:
+            episode_title = parsed_episode_title
+        if not series_title:
+            series_title = parsed_series_title
+
+        return LatestEpisode(
+            source=self.source,
+            work_id=work.work_id if work.work_id.startswith(f"{self.source}:") else series,
+            latest_key=latest_url,
+            url=latest_url,
+            series=series,
+            series_title=series_title,
+            episode_title=episode_title,
+            page_title=page_title,
+        )

--- a/manga_watch/sources/registry.py
+++ b/manga_watch/sources/registry.py
@@ -7,6 +7,7 @@ from .comicborder import ComicBorderAdapter
 from .comic_walker import ComicWalkerAdapter
 from .firecross import FirecrossAdapter
 from .kakuyomu import KakuyomuAdapter
+from .kuragebunch import KuragebunchAdapter
 from .magapoke import MagapokeAdapter
 from .nicovideo_manga import NicovideoMangaAdapter
 from .shonenjumpplus import ShonenJumpPlusAdapter
@@ -17,6 +18,7 @@ REGISTERED_ADAPTERS = (
     ComicWalkerAdapter(),
     ComicActionAdapter(),
     ComicBorderAdapter(),
+    KuragebunchAdapter(),
     ShonenJumpPlusAdapter(),
     ChampionCrossAdapter(),
     MagapokeAdapter(),

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -47,6 +47,16 @@ SOURCE_CAPABILITIES = (
         ),
     ),
     SourceCapability(
+        source="kuragebunch",
+        domains=("kuragebunch.com",),
+        input_labels=("episode URL", "series RSS URL", "series Atom URL"),
+        examples=(
+            "https://kuragebunch.com/episode/2550912964856491139",
+            "https://kuragebunch.com/rss/series/2550912964856487532",
+            "https://kuragebunch.com/atom/series/2550912964856487532",
+        ),
+    ),
+    SourceCapability(
         source="shonenjumpplus",
         domains=("shonenjumpplus.com",),
         input_labels=("episode URL", "series RSS URL", "series Atom URL"),

--- a/tests/fixtures/kuragebunch/broken_missing_series_id/01-episode.html
+++ b/tests/fixtures/kuragebunch/broken_missing_series_id/01-episode.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>赤と青のガウン - 彬子女王/池辺葵 / 第1話 | くらげバンチ</title>
+  </head>
+  <body>
+    <script id='episode-json' type='text/json' data-value='{&quot;readableProduct&quot;:{&quot;nextReadableProductUri&quot;:&quot;https://kuragebunch.com/episode/2550912965213403651&quot;}}'></script>
+  </body>
+</html>

--- a/tests/fixtures/kuragebunch/broken_missing_series_id/manifest.json
+++ b/tests/fixtures/kuragebunch/broken_missing_series_id/manifest.json
@@ -1,0 +1,19 @@
+{
+  "seedUrl": "https://kuragebunch.com/episode/2550912964856491139",
+  "expectedWork": {
+    "source": "kuragebunch",
+    "kind": "kuragebunch",
+    "workId": "https://kuragebunch.com/episode/2550912964856491139",
+    "seedUrl": "https://kuragebunch.com/episode/2550912964856491139"
+  },
+  "expectedError": {
+    "type": "SourceParseError",
+    "message": "kuragebunch: series id not found"
+  },
+  "steps": [
+    {
+      "url": "https://kuragebunch.com/episode/2550912964856491139",
+      "response": "01-episode.html"
+    }
+  ]
+}

--- a/tests/fixtures/kuragebunch/normal/01-rss.xml
+++ b/tests/fixtures/kuragebunch/normal/01-rss.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rss version="2.0" xmlns:giga="https://gigaviewer.com">
+  <channel>
+    <title>くらげバンチ（赤と青のガウン）</title>
+    <item>
+      <title>第15話</title>
+      <link>https://kuragebunch.com/episode/12207421983430264919</link>
+      <description>赤と青のガウン</description>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/kuragebunch/normal/02-latest.html
+++ b/tests/fixtures/kuragebunch/normal/02-latest.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>赤と青のガウン - 彬子女王/池辺葵 / 第15話 | くらげバンチ</title>
+  </head>
+  <body>
+    <div data-gtm-data-layer="{&quot;episode&quot;:{&quot;series_id&quot;:&quot;2550912964856487532&quot;,&quot;episode_id&quot;:&quot;12207421983430264919&quot;,&quot;episode_title&quot;:&quot;第15話&quot;,&quot;series_title&quot;:&quot;赤と青のガウン&quot;}}"></div>
+    <link rel="alternate" type="application/rss+xml" href="https://kuragebunch.com/rss/series/2550912964856487532">
+    <script id='episode-json' type='text/json' data-value='{&quot;readableProduct&quot;:{&quot;nextReadableProductUri&quot;:null}}'></script>
+  </body>
+</html>

--- a/tests/fixtures/kuragebunch/normal/manifest.json
+++ b/tests/fixtures/kuragebunch/normal/manifest.json
@@ -1,0 +1,34 @@
+{
+  "seedUrl": "https://kuragebunch.com/rss/series/2550912964856487532",
+  "expectedWork": {
+    "source": "kuragebunch",
+    "kind": "kuragebunch",
+    "workId": "kuragebunch:2550912964856487532",
+    "seedUrl": "https://kuragebunch.com/rss/series/2550912964856487532",
+    "series": "kuragebunch:2550912964856487532",
+    "seriesId": "2550912964856487532",
+    "feedKind": "rss"
+  },
+  "expectedLatest": {
+    "workId": "kuragebunch:2550912964856487532",
+    "latestKey": "https://kuragebunch.com/episode/12207421983430264919",
+    "url": "https://kuragebunch.com/episode/12207421983430264919",
+    "series": "kuragebunch:2550912964856487532",
+    "seriesTitle": "赤と青のガウン",
+    "episodeTitle": "第15話",
+    "pageTitle": "赤と青のガウン - 彬子女王/池辺葵 / 第15話 | くらげバンチ"
+  },
+  "missingLatestKeys": [
+    "nextUpdateLabel"
+  ],
+  "steps": [
+    {
+      "url": "https://kuragebunch.com/rss/series/2550912964856487532",
+      "response": "01-rss.xml"
+    },
+    {
+      "url": "https://kuragebunch.com/episode/12207421983430264919",
+      "response": "02-latest.html"
+    }
+  ]
+}

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -334,6 +334,35 @@ class CheckTests(unittest.TestCase):
         self.assertEqual("https://comicborder.com/rss/series/12207421983437805229", entry["seed_url"])
         self.assertEqual("comicborder", entry["source"])
 
+    def test_build_watchlist_entry_canonicalizes_kuragebunch_episode_seed_to_rss(self):
+        fake_client = mock.Mock()
+        fake_client.get_text.return_value = """
+        <html>
+          <head>
+            <link rel="alternate" type="application/rss+xml" href="https://kuragebunch.com/rss/series/2550912964856487532">
+          </head>
+          <body>
+            <div data-gtm-data-layer="{&quot;episode&quot;:{&quot;series_id&quot;:&quot;2550912964856487532&quot;}}"></div>
+          </body>
+        </html>
+        """
+        with mock.patch(
+            "manga_watch.check.normalize_item",
+            return_value={
+                "source": "kuragebunch",
+                "workId": "https://kuragebunch.com/episode/2550912964856491139",
+                "seedUrl": "https://kuragebunch.com/episode/2550912964856491139",
+            },
+        ):
+            entry = check.build_watchlist_entry(
+                "https://kuragebunch.com/episode/2550912964856491139",
+                http_client=fake_client,
+            )
+
+        self.assertEqual("kuragebunch:2550912964856487532", entry["id"])
+        self.assertEqual("https://kuragebunch.com/rss/series/2550912964856487532", entry["seed_url"])
+        self.assertEqual("kuragebunch", entry["source"])
+
     def test_build_watchlist_entry_uses_stable_champion_cross_work_id(self):
         fake_client = mock.Mock()
         fake_client.get_text.return_value = """

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -50,6 +50,10 @@ SOURCE_CASES = {
         "normal",
         "broken_missing_series_id",
     ),
+    "kuragebunch": (
+        "normal",
+        "broken_missing_series_id",
+    ),
     "shonenjumpplus": (
         "broken_missing_series_id",
         "normal",
@@ -97,6 +101,9 @@ EXPECTED_LATEST_CLASSIFICATIONS = {
         "broken_loop": "main_story",
     },
     "comicborder": {
+        "normal": "main_story",
+    },
+    "kuragebunch": {
         "normal": "main_story",
     },
     "shonenjumpplus": {
@@ -212,6 +219,7 @@ class SourceAdapterTests(unittest.TestCase):
                 "comic-walker",
                 "comic-action",
                 "comicborder",
+                "kuragebunch",
                 "shonenjumpplus",
                 "champion-cross",
                 "magapoke",
@@ -246,6 +254,9 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_comicborder_fixtures(self):
         self._assert_fixture_matrix("comicborder")
+
+    def test_kuragebunch_fixtures(self):
+        self._assert_fixture_matrix("kuragebunch")
 
     def test_kakuyomu_fixtures(self):
         self._assert_fixture_matrix("kakuyomu")
@@ -985,6 +996,83 @@ class SourceAdapterTests(unittest.TestCase):
             [
                 "https://comicborder.com/rss/series/12207421983437805229",
                 "https://comicborder.com/episode/12207421983437812169",
+            ],
+            client.calls,
+        )
+
+    def test_kuragebunch_normalize_accepts_episode_and_feed_urls(self):
+        episode_work = normalize_seed_url("https://kuragebunch.com/episode/2550912964856491139?from=share").to_dict()
+        rss_work = normalize_seed_url("https://kuragebunch.com/rss/series/2550912964856487532?from=share").to_dict()
+        atom_work = normalize_seed_url("https://kuragebunch.com/atom/series/2550912964856487532").to_dict()
+
+        self.assertEqual(
+            {
+                "source": "kuragebunch",
+                "kind": "kuragebunch",
+                "workId": "https://kuragebunch.com/episode/2550912964856491139",
+                "seedUrl": "https://kuragebunch.com/episode/2550912964856491139",
+            },
+            episode_work,
+        )
+
+        expected_feed = {
+            "source": "kuragebunch",
+            "kind": "kuragebunch",
+            "workId": "kuragebunch:2550912964856487532",
+            "seedUrl": "https://kuragebunch.com/rss/series/2550912964856487532",
+            "series": "kuragebunch:2550912964856487532",
+            "seriesId": "2550912964856487532",
+            "feedKind": "rss",
+        }
+        self.assertEqual(expected_feed, rss_work)
+        self.assertEqual(expected_feed, atom_work)
+
+    def test_kuragebunch_fetch_latest_accepts_canonical_feed_seed(self):
+        work = WorkDescriptor(
+            source="kuragebunch",
+            work_id="kuragebunch:2550912964856487532",
+            seed_url="https://kuragebunch.com/rss/series/2550912964856487532",
+            metadata={
+                "series": "kuragebunch:2550912964856487532",
+                "seriesId": "2550912964856487532",
+                "feedKind": "rss",
+            },
+        )
+        client = StaticHttpClient(
+            {
+                "https://kuragebunch.com/rss/series/2550912964856487532": """
+                <rss version="2.0">
+                  <channel>
+                    <title>くらげバンチ（赤と青のガウン）</title>
+                    <item>
+                      <title>第15話</title>
+                      <link>https://kuragebunch.com/episode/12207421983430264919</link>
+                      <description>赤と青のガウン</description>
+                    </item>
+                  </channel>
+                </rss>
+                """,
+                "https://kuragebunch.com/episode/12207421983430264919": """
+                <html>
+                  <head>
+                    <title>赤と青のガウン - 彬子女王/池辺葵 / 第15話 | くらげバンチ</title>
+                  </head>
+                </html>
+                """,
+            }
+        )
+
+        latest = fetch_latest_for_work(work, http_client=client).to_dict()
+
+        self.assertEqual("kuragebunch:2550912964856487532", latest["workId"])
+        self.assertEqual("kuragebunch:2550912964856487532", latest["series"])
+        self.assertEqual("https://kuragebunch.com/episode/12207421983430264919", latest["latestKey"])
+        self.assertEqual("赤と青のガウン", latest["seriesTitle"])
+        self.assertEqual("第15話", latest["episodeTitle"])
+        self.assertEqual(
+            [
+                "https://kuragebunch.com/rss/series/2550912964856487532",
+                "https://kuragebunch.com/episode/12207421983430264919",
             ],
             client.calls,
         )

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -265,6 +265,42 @@ class WatchlistAddLogicTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
+    def test_add_watchlist_url_accepts_kuragebunch_episode_url_and_canonicalizes_to_rss(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            payload = add_watchlist_url(
+                "https://kuragebunch.com/episode/2550912964856491139?from=share",
+                watchlist_path=str(watchlist_path),
+                http_client=StaticHttpClient(
+                    {
+                        "https://kuragebunch.com/episode/2550912964856491139": """
+                        <html>
+                          <head>
+                            <title>赤と青のガウン - 彬子女王/池辺葵 / 第1話 | くらげバンチ</title>
+                            <link rel="alternate" type="application/rss+xml" href="https://kuragebunch.com/rss/series/2550912964856487532">
+                          </head>
+                          <body>
+                            <div data-gtm-data-layer="{&quot;episode&quot;:{&quot;series_id&quot;:&quot;2550912964856487532&quot;}}"></div>
+                          </body>
+                        </html>
+                        """
+                    }
+                ),
+            )
+            saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("added", payload["action"])
+        self.assertEqual("kuragebunch:2550912964856487532", payload["entry"]["id"])
+        self.assertEqual(
+            "https://kuragebunch.com/rss/series/2550912964856487532",
+            payload["entry"]["seed_url"],
+        )
+        self.assertEqual("kuragebunch", payload["entry"]["source"])
+        self.assertEqual(1, payload["work_count"])
+        self.assertEqual(1, len(saved["works"]))
+
     def test_add_watchlist_url_accepts_firecross_reader_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"


### PR DESCRIPTION
## Issue
- Closes #197
- Parent: #189

## What Changed
- add `kuragebunch.com` Family A source support for episode and RSS/Atom series feed URLs
- canonicalize episode seeds to RSS series feeds in add/check flows
- add kuragebunch fixtures, watchlist/check coverage, and source drift canary/docs updates

## Verification
- `../../.venv/bin/python -m unittest tests.test_sources tests.test_watchlist tests.test_check tests.test_source_drift`

## Residual Risk
- title parsing and series-id extraction still rely on the current public HTML/feed contract for kuragebunch