### PR TITLE
Refactor storage normalization boundaries

### DIFF
--- a/manga_watch/discord_outbound.py
+++ b/manga_watch/discord_outbound.py
@@ -10,6 +10,7 @@ import requests
 
 from manga_watch.secret_redaction import redact_secret_text
 from manga_watch.secret_resolver import resolve_env_value
+from manga_watch.storage import state_daily_notification_delivery
 from manga_watch.discord_text import (
     episode_label_for_snapshot,
     series_label_for_snapshot,
@@ -194,25 +195,7 @@ class DiscordChannelClient:
 
 
 def _daily_notification_state(state: Dict[str, object]) -> Dict[str, object]:
-    discord_delivery = state.setdefault(DISCORD_DELIVERY_STATE_KEY, {})
-    if not isinstance(discord_delivery, dict):
-        discord_delivery = {}
-        state[DISCORD_DELIVERY_STATE_KEY] = discord_delivery
-
-    daily_notification = discord_delivery.setdefault(
-        DAILY_NOTIFICATION_STATE_KEY,
-        {
-            "delivered_latest_keys": {},
-            "pending_messages": [],
-        },
-    )
-    if not isinstance(daily_notification, dict):
-        daily_notification = {
-            "delivered_latest_keys": {},
-            "pending_messages": [],
-        }
-        discord_delivery[DAILY_NOTIFICATION_STATE_KEY] = daily_notification
-    return daily_notification
+    return state_daily_notification_delivery(state)
 
 
 def daily_notification_key(update: Mapping[str, object]) -> Optional[Tuple[str, str]]:
@@ -227,26 +210,14 @@ def daily_notification_key(update: Mapping[str, object]) -> Optional[Tuple[str, 
 
 
 def _pending_daily_notification_keys(state: Mapping[str, object]) -> set[Tuple[str, str]]:
-    discord_delivery = state.get(DISCORD_DELIVERY_STATE_KEY, {})
-    if not isinstance(discord_delivery, Mapping):
+    if not isinstance(state, dict):
         return set()
-    daily_notification = discord_delivery.get(DAILY_NOTIFICATION_STATE_KEY, {})
-    if not isinstance(daily_notification, Mapping):
-        return set()
-    pending_messages = daily_notification.get("pending_messages", [])
-    if not isinstance(pending_messages, list):
-        return set()
+    pending_messages = _daily_notification_state(state).get("pending_messages", [])
 
     keys: set[Tuple[str, str]] = set()
     for entry in pending_messages:
-        if not isinstance(entry, Mapping):
-            continue
         message_keys = entry.get("message_keys", [])
-        if not isinstance(message_keys, list):
-            continue
         for message_key in message_keys:
-            if not isinstance(message_key, Mapping):
-                continue
             work_id = _coerce_text(message_key.get("work_id"))
             latest_key = _coerce_text(message_key.get("latest_key"))
             if work_id and latest_key:
@@ -255,34 +226,19 @@ def _pending_daily_notification_keys(state: Mapping[str, object]) -> set[Tuple[s
 
 
 def pending_daily_notification_count(state: Mapping[str, object]) -> int:
-    discord_delivery = state.get(DISCORD_DELIVERY_STATE_KEY, {})
-    if not isinstance(discord_delivery, Mapping):
+    if not isinstance(state, dict):
         return 0
-    daily_notification = discord_delivery.get(DAILY_NOTIFICATION_STATE_KEY, {})
-    if not isinstance(daily_notification, Mapping):
-        return 0
-    pending_messages = daily_notification.get("pending_messages", [])
-    return len(pending_messages) if isinstance(pending_messages, list) else 0
+    return len(_daily_notification_state(state).get("pending_messages", []))
 
 
 def _delivered_latest_keys(state: Mapping[str, object]) -> Dict[str, str]:
-    discord_delivery = state.get(DISCORD_DELIVERY_STATE_KEY, {})
-    if not isinstance(discord_delivery, Mapping):
+    if not isinstance(state, dict):
         return {}
-    daily_notification = discord_delivery.get(DAILY_NOTIFICATION_STATE_KEY, {})
-    if not isinstance(daily_notification, Mapping):
-        return {}
-    delivered = daily_notification.get("delivered_latest_keys", {})
-    if not isinstance(delivered, Mapping):
-        return {}
+    delivered = _daily_notification_state(state).get("delivered_latest_keys", {})
 
     normalized: Dict[str, str] = {}
     for work_id, entry in delivered.items():
-        latest_key = None
-        if isinstance(entry, Mapping):
-            latest_key = _coerce_text(entry.get("latest_key"))
-        else:
-            latest_key = _coerce_text(entry)
+        latest_key = _coerce_text(entry.get("latest_key")) if isinstance(entry, Mapping) else _coerce_text(entry)
         if latest_key:
             normalized[str(work_id)] = latest_key
     return normalized

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -36,6 +36,7 @@ from manga_watch.storage import (
     load_state,
     record_run_summary,
     save_state,
+    state_notification_outbox,
 )
 from manga_watch.update_classification import DEFAULT_NOTIFY_UPDATE_TYPES
 
@@ -152,47 +153,28 @@ def resolve_named_notifiers(
 
 
 def load_notification_outbox(state: Dict[str, object]) -> List[Dict[str, object]]:
-    outbox = state.get(NOTIFICATION_OUTBOX_KEY, [])
-    if outbox is None:
-        return []
-    if not isinstance(outbox, list):
-        raise RuntimeError("state.notification_outbox must be a list")
+    try:
+        outbox = state_notification_outbox(state)
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
 
     normalized_entries: List[Dict[str, object]] = []
     for index, entry in enumerate(outbox):
-        if not isinstance(entry, dict):
-            raise RuntimeError(f"state.notification_outbox[{index}] must be an object")
         try:
             event = event_from_payload(entry.get("event") or {})
         except ValueError as exc:
             raise RuntimeError(f"state.notification_outbox[{index}] is invalid: {exc}") from exc
 
-        pending_backends = entry.get("pending_backends", entry.get("pendingBackends", []))
-        if pending_backends is None:
-            pending_backends = []
-        if not isinstance(pending_backends, list):
-            raise RuntimeError(f"state.notification_outbox[{index}].pending_backends must be a list")
-
-        normalized_pending_backends: List[str] = []
-        seen_backends = set()
-        for backend in pending_backends:
-            normalized_backend = str(backend).strip()
-            if not normalized_backend or normalized_backend in seen_backends:
-                continue
-            seen_backends.add(normalized_backend)
-            normalized_pending_backends.append(normalized_backend)
-
-        if not normalized_pending_backends:
+        if not entry["pending_backends"]:
             continue
 
         normalized_entries.append(
             {
                 "event": event.as_payload(),
-                "pending_backends": normalized_pending_backends,
-                "attempt_count": max(0, int(entry.get("attempt_count", entry.get("attemptCount", 0)) or 0)),
-                "last_attempted_at": str(entry.get("last_attempted_at", entry.get("lastAttemptedAt")) or "").strip()
-                or None,
-                "last_error": str(entry.get("last_error", entry.get("lastError")) or "").strip() or None,
+                "pending_backends": list(entry["pending_backends"]),
+                "attempt_count": int(entry["attempt_count"]),
+                "last_attempted_at": entry["last_attempted_at"],
+                "last_error": entry["last_error"],
             }
         )
     return normalized_entries

--- a/manga_watch/storage.py
+++ b/manga_watch/storage.py
@@ -89,6 +89,25 @@ def default_state() -> Dict[str, object]:
     }
 
 
+def state_notification_outbox(state: Dict[str, object]) -> List[Dict[str, object]]:
+    normalized_outbox = normalize_notification_outbox(state.get("notification_outbox"))
+    state["notification_outbox"] = normalized_outbox
+    return normalized_outbox
+
+
+def state_discord_delivery(state: Dict[str, object]) -> Dict[str, object]:
+    normalized_discord_delivery = normalize_discord_delivery(
+        state.get("discord_delivery", state.get("discordDelivery"))
+    )
+    state.pop("discordDelivery", None)
+    state["discord_delivery"] = normalized_discord_delivery
+    return normalized_discord_delivery
+
+
+def state_daily_notification_delivery(state: Dict[str, object]) -> Dict[str, object]:
+    return state_discord_delivery(state)["daily_notification"]
+
+
 def load_watchlist(
     path: Optional[str] = None,
     *,

--- a/tests/test_discord_outbound.py
+++ b/tests/test_discord_outbound.py
@@ -163,6 +163,38 @@ class DiscordOutboundTests(unittest.TestCase):
         self.assertEqual({"queued": False, "candidateUpdateCount": 0}, result)
         self.assertEqual([], state["discord_delivery"]["daily_notification"]["pending_messages"])
 
+    def test_enqueue_daily_notification_dedupes_against_legacy_camel_case_delivery_state(self):
+        state = {
+            "discordDelivery": {
+                "dailyNotification": {
+                    "deliveredLatestKeys": {
+                        "work-1": {
+                            "latestKey": "episode-2",
+                            "deliveredAt": "2023-11-14T22:13:20Z",
+                        }
+                    },
+                    "pendingMessages": [],
+                }
+            }
+        }
+
+        result = enqueue_daily_notification(
+            state,
+            updates=[
+                self.make_update(
+                    episode_title="第2話 改題",
+                    previous="第2話",
+                )
+            ],
+            channel_id="main-channel",
+            now_ts=1_700_000_300,
+            timezone_name="Asia/Tokyo",
+            created_at="2023-11-14T22:18:20Z",
+        )
+
+        self.assertEqual({"queued": False, "candidateUpdateCount": 0}, result)
+        self.assertEqual([], state["discord_delivery"]["daily_notification"]["pending_messages"])
+
     def test_discord_channel_client_posts_bot_message(self):
         session = FakeSession(responses=[FakeResponse(200)])
         client = DiscordChannelClient(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,7 +6,12 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
 
-from manga_watch.storage import load_state, save_state
+from manga_watch.storage import (
+    load_state,
+    save_state,
+    state_daily_notification_delivery,
+    state_notification_outbox,
+)
 
 
 def make_state(*, latest_key: str, last_run_at: int) -> dict:
@@ -43,6 +48,92 @@ def make_state(*, latest_key: str, last_run_at: int) -> dict:
 
 
 class StorageTests(unittest.TestCase):
+    def test_state_notification_outbox_normalizes_entries_in_place(self):
+        state = {
+            "notification_outbox": [
+                {
+                    "event": {"event_id": "event-1"},
+                    "pendingBackends": ["stdout", "stdout", " webhook "],
+                    "attemptCount": "2",
+                    "lastAttemptedAt": "2023-11-14T22:13:20Z",
+                    "lastError": "timed out",
+                    "extraField": "kept",
+                }
+            ]
+        }
+
+        outbox = state_notification_outbox(state)
+
+        self.assertEqual(
+            [
+                {
+                    "event": {"event_id": "event-1"},
+                    "pending_backends": ["stdout", "webhook"],
+                    "attempt_count": 2,
+                    "last_attempted_at": "2023-11-14T22:13:20Z",
+                    "last_error": "timed out",
+                    "extra_field": "kept",
+                }
+            ],
+            outbox,
+        )
+        self.assertEqual(outbox, state["notification_outbox"])
+
+    def test_state_daily_notification_delivery_normalizes_legacy_shape_in_place(self):
+        state = {
+            "discordDelivery": {
+                "dailyNotification": {
+                    "deliveredLatestKeys": {
+                        "work-1": {
+                            "latestKey": "episode-2",
+                            "deliveredAt": "2023-11-14T22:13:20Z",
+                        }
+                    },
+                    "pendingMessages": [
+                        {
+                            "channelId": "main-channel",
+                            "content": "pending daily message",
+                            "messageKeys": [
+                                {"workId": "work-1", "latestKey": "episode-2"},
+                                {"workId": "work-1", "latestKey": "episode-2"},
+                            ],
+                            "createdAt": "2023-11-14T22:13:20Z",
+                            "attemptCount": "1",
+                            "lastAttemptedAt": "2023-11-14T22:14:00Z",
+                            "lastError": "discord delivery failed",
+                        }
+                    ],
+                }
+            }
+        }
+
+        daily_notification = state_daily_notification_delivery(state)
+
+        self.assertEqual(
+            {
+                "delivered_latest_keys": {
+                    "work-1": {
+                        "latest_key": "episode-2",
+                        "delivered_at": "2023-11-14T22:13:20Z",
+                    }
+                },
+                "pending_messages": [
+                    {
+                        "channel_id": "main-channel",
+                        "content": "pending daily message",
+                        "message_keys": [{"work_id": "work-1", "latest_key": "episode-2"}],
+                        "created_at": "2023-11-14T22:13:20Z",
+                        "attempt_count": 1,
+                        "last_attempted_at": "2023-11-14T22:14:00Z",
+                        "last_error": "discord delivery failed",
+                    }
+                ],
+            },
+            daily_notification,
+        )
+        self.assertEqual(daily_notification, state["discord_delivery"]["daily_notification"])
+        self.assertNotIn("discordDelivery", state)
+
     def test_save_state_keeps_previous_json_when_write_fails_before_replace(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             state_path = Path(tmpdir) / "state.json"


### PR DESCRIPTION
## Summary
- move canonical notification/daily-delivery state access into `manga_watch.storage`
- make `runner` and `discord_outbound` consume those storage helpers instead of re-implementing shape normalization
- add regression coverage for legacy camelCase state so queue dedupe still works after normalization

## Issue
- Closes #235

## Verification
- `.venv/bin/python -m pytest tests/test_storage.py tests/test_runner.py tests/test_discord_outbound.py tests/test_discord_remove.py`

## Residual Risk
- this lane intentionally keeps event semantic validation in `runner`; it centralizes shape normalization first and leaves any deeper notifier/storage split to a follow-up if needed