### PR TITLE
Refactor adapter-owned watch canonicalization for feed-backed sources

### DIFF
--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -27,43 +27,7 @@ from manga_watch.sources.comic_action import (
     extract_comic_action_series_id,
     extract_comic_action_series_id_from_seed_url,
 )
-from manga_watch.sources.comic_earthstar import (
-    canonical_comic_earthstar_series_feed_url,
-    extract_comic_earthstar_series_feed_url,
-    extract_comic_earthstar_series_id,
-    extract_comic_earthstar_series_id_from_seed_url,
-)
-from manga_watch.sources.comicborder import (
-    canonical_comicborder_series_feed_url,
-    extract_comicborder_series_feed_url,
-    extract_comicborder_series_id,
-    extract_comicborder_series_id_from_seed_url,
-)
-from manga_watch.sources.comic_trail import (
-    canonical_comic_trail_series_feed_url,
-    extract_comic_trail_series_feed_url,
-    extract_comic_trail_series_id,
-    extract_comic_trail_series_id_from_seed_url,
-)
 from manga_watch.sources.firecross import extract_firecross_series_id
-from manga_watch.sources.kuragebunch import (
-    canonical_kuragebunch_series_feed_url,
-    extract_kuragebunch_series_feed_url,
-    extract_kuragebunch_series_id,
-    extract_kuragebunch_series_id_from_seed_url,
-)
-from manga_watch.sources.shonenjumpplus import (
-    canonical_shonenjumpplus_series_feed_url,
-    extract_shonenjumpplus_series_feed_url,
-    extract_shonenjumpplus_series_id,
-    extract_shonenjumpplus_series_id_from_seed_url,
-)
-from manga_watch.sources.sunday_webry import (
-    canonical_sunday_webry_series_feed_url,
-    extract_sunday_webry_series_feed_url,
-    extract_sunday_webry_series_id,
-    extract_sunday_webry_series_id_from_seed_url,
-)
 from manga_watch.storage import (
     NOTIFICATION_POLICY_MODE_ALL,
     evaluate_notification_policy,
@@ -611,126 +575,6 @@ def stable_work_id_for_item(
             raise RuntimeError("champion-cross: series hash not found")
         return f"champion-cross:{series_hash}"
 
-    if source == "comic-earthstar":
-        stable_series = str(item.get("series") or "")
-        if stable_series.startswith("comic-earthstar:"):
-            return stable_series
-
-        seed_url = str(item.get("seedUrl") or "")
-        if not seed_url:
-            raise RuntimeError("comic-earthstar: seedUrl is required to derive work_id")
-
-        series_id = str(item.get("seriesId") or "") or extract_comic_earthstar_series_id_from_seed_url(seed_url)
-        if series_id:
-            return f"comic-earthstar:{series_id}"
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        series_id = extract_comic_earthstar_series_id(html)
-        if not series_id:
-            raise RuntimeError("comic-earthstar: series id not found")
-        return f"comic-earthstar:{series_id}"
-
-    if source == "comicborder":
-        stable_series = str(item.get("series") or "")
-        if stable_series.startswith("comicborder:"):
-            return stable_series
-
-        seed_url = str(item.get("seedUrl") or "")
-        if not seed_url:
-            raise RuntimeError("comicborder: seedUrl is required to derive work_id")
-
-        series_id = str(item.get("seriesId") or "") or extract_comicborder_series_id_from_seed_url(seed_url)
-        if series_id:
-            return f"comicborder:{series_id}"
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        series_id = extract_comicborder_series_id(html)
-        if not series_id:
-            raise RuntimeError("comicborder: series id not found")
-        return f"comicborder:{series_id}"
-
-    if source == "comic-trail":
-        stable_series = str(item.get("series") or "")
-        if stable_series.startswith("comic-trail:"):
-            return stable_series
-
-        seed_url = str(item.get("seedUrl") or "")
-        if not seed_url:
-            raise RuntimeError("comic-trail: seedUrl is required to derive work_id")
-
-        series_id = str(item.get("seriesId") or "") or extract_comic_trail_series_id_from_seed_url(seed_url)
-        if series_id:
-            return f"comic-trail:{series_id}"
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        series_id = extract_comic_trail_series_id(html)
-        if not series_id:
-            raise RuntimeError("comic-trail: series id not found")
-        return f"comic-trail:{series_id}"
-
-    if source == "kuragebunch":
-        stable_series = str(item.get("series") or "")
-        if stable_series.startswith("kuragebunch:"):
-            return stable_series
-
-        seed_url = str(item.get("seedUrl") or "")
-        if not seed_url:
-            raise RuntimeError("kuragebunch: seedUrl is required to derive work_id")
-
-        series_id = str(item.get("seriesId") or "") or extract_kuragebunch_series_id_from_seed_url(seed_url)
-        if series_id:
-            return f"kuragebunch:{series_id}"
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        series_id = extract_kuragebunch_series_id(html)
-        if not series_id:
-            raise RuntimeError("kuragebunch: series id not found")
-        return f"kuragebunch:{series_id}"
-
-    if source == "shonenjumpplus":
-        stable_series = str(item.get("series") or "")
-        if stable_series.startswith("shonenjumpplus:"):
-            return stable_series
-
-        seed_url = str(item.get("seedUrl") or "")
-        if not seed_url:
-            raise RuntimeError("shonenjumpplus: seedUrl is required to derive work_id")
-
-        series_id = str(item.get("seriesId") or "") or extract_shonenjumpplus_series_id_from_seed_url(seed_url)
-        if series_id:
-            return f"shonenjumpplus:{series_id}"
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        series_id = extract_shonenjumpplus_series_id(html)
-        if not series_id:
-            raise RuntimeError("shonenjumpplus: series id not found")
-        return f"shonenjumpplus:{series_id}"
-
-    if source == "sunday-webry":
-        stable_series = str(item.get("series") or "")
-        if stable_series.startswith("sunday-webry:"):
-            return stable_series
-
-        seed_url = str(item.get("seedUrl") or "")
-        if not seed_url:
-            raise RuntimeError("sunday-webry: seedUrl is required to derive work_id")
-
-        series_id = str(item.get("seriesId") or "") or extract_sunday_webry_series_id_from_seed_url(seed_url)
-        if series_id:
-            return f"sunday-webry:{series_id}"
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        series_id = extract_sunday_webry_series_id(html)
-        if not series_id:
-            raise RuntimeError("sunday-webry: series id not found")
-        return f"sunday-webry:{series_id}"
-
     if source != "comic-action":
         return item_id_for_state(item)
 
@@ -754,110 +598,32 @@ def stable_work_id_for_item(
     return f"comic-action:{series_id}"
 
 
-def canonical_seed_url_for_item(
+def _adapter_for_source(
+    source: str,
+    adapters: Optional[Sequence[SourceAdapter]] = None,
+) -> Optional[SourceAdapter]:
+    for adapter in _selected_adapters(adapters):
+        if adapter.source == source:
+            return adapter
+    return None
+
+
+def canonical_descriptor_for_item(
     item: Mapping[str, object],
     *,
+    adapters: Optional[Sequence[SourceAdapter]] = None,
     http_client: Optional[HttpClient] = None,
-) -> str:
+) -> WorkDescriptor:
     source = str(item.get("source") or "")
-    seed_url = str(item.get("seedUrl") or "")
-    if source == "comic-earthstar":
-        series_id = str(item.get("seriesId") or "") or extract_comic_earthstar_series_id_from_seed_url(seed_url)
-        if series_id:
-            return canonical_comic_earthstar_series_feed_url(series_id)
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        feed_url = extract_comic_earthstar_series_feed_url(html)
-        if feed_url:
-            return feed_url
-
-        series_id = extract_comic_earthstar_series_id(html)
-        if not series_id:
-            raise RuntimeError("comic-earthstar: series id not found")
-        return canonical_comic_earthstar_series_feed_url(series_id)
-
-    if source == "comicborder":
-        series_id = str(item.get("seriesId") or "") or extract_comicborder_series_id_from_seed_url(seed_url)
-        if series_id:
-            return canonical_comicborder_series_feed_url(series_id)
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        feed_url = extract_comicborder_series_feed_url(html)
-        if feed_url:
-            return feed_url
-
-        series_id = extract_comicborder_series_id(html)
-        if not series_id:
-            raise RuntimeError("comicborder: series id not found")
-        return canonical_comicborder_series_feed_url(series_id)
-
-    if source == "comic-trail":
-        series_id = str(item.get("seriesId") or "") or extract_comic_trail_series_id_from_seed_url(seed_url)
-        if series_id:
-            return canonical_comic_trail_series_feed_url(series_id)
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        feed_url = extract_comic_trail_series_feed_url(html)
-        if feed_url:
-            return feed_url
-
-        series_id = extract_comic_trail_series_id(html)
-        if not series_id:
-            raise RuntimeError("comic-trail: series id not found")
-        return canonical_comic_trail_series_feed_url(series_id)
-
-    if source == "sunday-webry":
-        series_id = str(item.get("seriesId") or "") or extract_sunday_webry_series_id_from_seed_url(seed_url)
-        if series_id:
-            return canonical_sunday_webry_series_feed_url(series_id)
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        feed_url = extract_sunday_webry_series_feed_url(html)
-        if feed_url:
-            return feed_url
-
-        series_id = extract_sunday_webry_series_id(html)
-        if not series_id:
-            raise RuntimeError("sunday-webry: series id not found")
-        return canonical_sunday_webry_series_feed_url(series_id)
-
-    if source == "kuragebunch":
-        series_id = str(item.get("seriesId") or "") or extract_kuragebunch_series_id_from_seed_url(seed_url)
-        if series_id:
-            return canonical_kuragebunch_series_feed_url(series_id)
-
-        client = http_client or RequestsHttpClient()
-        html = client.get_text(seed_url)
-        feed_url = extract_kuragebunch_series_feed_url(html)
-        if feed_url:
-            return feed_url
-
-        series_id = extract_kuragebunch_series_id(html)
-        if not series_id:
-            raise RuntimeError("kuragebunch: series id not found")
-        return canonical_kuragebunch_series_feed_url(series_id)
-
-    if source != "shonenjumpplus":
-        return seed_url
-
-    series_id = str(item.get("seriesId") or "") or extract_shonenjumpplus_series_id_from_seed_url(seed_url)
-    if series_id:
-        return canonical_shonenjumpplus_series_feed_url(series_id)
-
+    adapter = _adapter_for_source(source, adapters=adapters)
     client = http_client or RequestsHttpClient()
-    html = client.get_text(seed_url)
-    feed_url = extract_shonenjumpplus_series_feed_url(html)
-    if feed_url:
-        return feed_url
 
-    series_id = extract_shonenjumpplus_series_id(html)
-    if not series_id:
-        raise RuntimeError("shonenjumpplus: series id not found")
-    return canonical_shonenjumpplus_series_feed_url(series_id)
+    if adapter is not None and type(adapter).canonicalize_item is not SourceAdapter.canonicalize_item:
+        return adapter.canonicalize_item(item, client)
+
+    canonical_item = dict(item)
+    canonical_item["workId"] = stable_work_id_for_item(canonical_item, http_client=client)
+    return WorkDescriptor.from_dict(canonical_item)
 
 
 def build_watchlist_entry(
@@ -866,12 +632,11 @@ def build_watchlist_entry(
     http_client: Optional[HttpClient] = None,
 ) -> Dict[str, object]:
     item = dict(normalize_item(url, adapters=adapters))
-    canonical_seed_url = canonical_seed_url_for_item(item, http_client=http_client)
-    item["seedUrl"] = canonical_seed_url
+    work = canonical_descriptor_for_item(item, adapters=adapters, http_client=http_client)
     return {
-        "id": stable_work_id_for_item(item, http_client=http_client),
-        "source": str(item["source"]),
-        "seed_url": canonical_seed_url,
+        "id": work.work_id,
+        "source": work.source,
+        "seed_url": work.seed_url,
         "enabled": True,
         "notification_policy": {
             "mode": "all",

--- a/manga_watch/sources/base.py
+++ b/manga_watch/sources/base.py
@@ -260,3 +260,10 @@ class SourceAdapter(ABC):
     @abstractmethod
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         raise NotImplementedError
+
+    def canonicalize_item(
+        self,
+        item: Mapping[str, object],
+        http_client: HttpClient,
+    ) -> WorkDescriptor:
+        return WorkDescriptor.from_dict(item)

--- a/manga_watch/sources/comic_earthstar.py
+++ b/manga_watch/sources/comic_earthstar.py
@@ -178,6 +178,30 @@ class ComicEarthstarAdapter(SourceAdapter):
             },
         )
 
+    def canonicalize_item(
+        self,
+        item,
+        http_client: HttpClient,
+    ) -> WorkDescriptor:
+        seed_url = str(item.get("seedUrl") or "")
+        series_id = str(item.get("seriesId") or "") or extract_comic_earthstar_series_id_from_seed_url(seed_url)
+        if series_id:
+            return self.normalize(canonical_comic_earthstar_series_feed_url(series_id))
+
+        episode_url = parse_comic_earthstar_episode_url(seed_url)
+        if not episode_url:
+            raise RuntimeError("comic-earthstar: unsupported seed URL")
+
+        episode_html = http_client.get_text(episode_url)
+        feed_url = extract_comic_earthstar_series_feed_url(episode_html)
+        if feed_url:
+            return self.normalize(feed_url)
+
+        series_id = extract_comic_earthstar_series_id(episode_html)
+        if not series_id:
+            raise RuntimeError("comic-earthstar: series id not found")
+        return self.normalize(canonical_comic_earthstar_series_feed_url(series_id))
+
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         series = str(work.metadata.get("series") or work.work_id)
         series_id = str(work.metadata.get("seriesId") or "")

--- a/manga_watch/sources/comic_trail.py
+++ b/manga_watch/sources/comic_trail.py
@@ -185,6 +185,30 @@ class ComicTrailAdapter(SourceAdapter):
             },
         )
 
+    def canonicalize_item(
+        self,
+        item,
+        http_client: HttpClient,
+    ) -> WorkDescriptor:
+        seed_url = str(item.get("seedUrl") or "")
+        series_id = str(item.get("seriesId") or "") or extract_comic_trail_series_id_from_seed_url(seed_url)
+        if series_id:
+            return self.normalize(canonical_comic_trail_series_feed_url(series_id))
+
+        episode_url = parse_comic_trail_episode_url(seed_url)
+        if not episode_url:
+            raise RuntimeError("comic-trail: unsupported seed URL")
+
+        episode_html = http_client.get_text(episode_url)
+        feed_url = extract_comic_trail_series_feed_url(episode_html)
+        if feed_url:
+            return self.normalize(feed_url)
+
+        series_id = extract_comic_trail_series_id(episode_html)
+        if not series_id:
+            raise RuntimeError("comic-trail: series id not found")
+        return self.normalize(canonical_comic_trail_series_feed_url(series_id))
+
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         series = str(work.metadata.get("series") or work.work_id)
         series_id = str(work.metadata.get("seriesId") or "") or extract_comic_trail_series_id_from_seed_url(work.seed_url)

--- a/manga_watch/sources/comicborder.py
+++ b/manga_watch/sources/comicborder.py
@@ -170,6 +170,30 @@ class ComicBorderAdapter(SourceAdapter):
             },
         )
 
+    def canonicalize_item(
+        self,
+        item,
+        http_client: HttpClient,
+    ) -> WorkDescriptor:
+        seed_url = str(item.get("seedUrl") or "")
+        series_id = str(item.get("seriesId") or "") or extract_comicborder_series_id_from_seed_url(seed_url)
+        if series_id:
+            return self.normalize(canonical_comicborder_series_feed_url(series_id))
+
+        episode_url = parse_comicborder_episode_url(seed_url)
+        if not episode_url:
+            raise RuntimeError("comicborder: unsupported seed URL")
+
+        episode_html = http_client.get_text(episode_url)
+        feed_url = extract_comicborder_series_feed_url(episode_html)
+        if feed_url:
+            return self.normalize(feed_url)
+
+        series_id = extract_comicborder_series_id(episode_html)
+        if not series_id:
+            raise RuntimeError("comicborder: series id not found")
+        return self.normalize(canonical_comicborder_series_feed_url(series_id))
+
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         series = str(work.metadata.get("series") or work.work_id)
         series_id = str(work.metadata.get("seriesId") or "")

--- a/manga_watch/sources/kuragebunch.py
+++ b/manga_watch/sources/kuragebunch.py
@@ -168,6 +168,30 @@ class KuragebunchAdapter(SourceAdapter):
             },
         )
 
+    def canonicalize_item(
+        self,
+        item,
+        http_client: HttpClient,
+    ) -> WorkDescriptor:
+        seed_url = str(item.get("seedUrl") or "")
+        series_id = str(item.get("seriesId") or "") or extract_kuragebunch_series_id_from_seed_url(seed_url)
+        if series_id:
+            return self.normalize(canonical_kuragebunch_series_feed_url(series_id))
+
+        episode_url = parse_kuragebunch_episode_url(seed_url)
+        if not episode_url:
+            raise RuntimeError("kuragebunch: unsupported seed URL")
+
+        episode_html = http_client.get_text(episode_url)
+        feed_url = extract_kuragebunch_series_feed_url(episode_html)
+        if feed_url:
+            return self.normalize(feed_url)
+
+        series_id = extract_kuragebunch_series_id(episode_html)
+        if not series_id:
+            raise RuntimeError("kuragebunch: series id not found")
+        return self.normalize(canonical_kuragebunch_series_feed_url(series_id))
+
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         series = str(work.metadata.get("series") or work.work_id)
         series_id = str(work.metadata.get("seriesId") or "")

--- a/manga_watch/sources/shonenjumpplus.py
+++ b/manga_watch/sources/shonenjumpplus.py
@@ -175,6 +175,30 @@ class ShonenJumpPlusAdapter(SourceAdapter):
             },
         )
 
+    def canonicalize_item(
+        self,
+        item,
+        http_client: HttpClient,
+    ) -> WorkDescriptor:
+        seed_url = str(item.get("seedUrl") or "")
+        series_id = str(item.get("seriesId") or "") or extract_shonenjumpplus_series_id_from_seed_url(seed_url)
+        if series_id:
+            return self.normalize(canonical_shonenjumpplus_series_feed_url(series_id))
+
+        episode_url = parse_shonenjumpplus_episode_url(seed_url)
+        if not episode_url:
+            raise RuntimeError("shonenjumpplus: unsupported seed URL")
+
+        episode_html = http_client.get_text(episode_url)
+        feed_url = extract_shonenjumpplus_series_feed_url(episode_html)
+        if feed_url:
+            return self.normalize(feed_url)
+
+        series_id = extract_shonenjumpplus_series_id(episode_html)
+        if not series_id:
+            raise RuntimeError("shonenjumpplus: series id not found")
+        return self.normalize(canonical_shonenjumpplus_series_feed_url(series_id))
+
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         series = str(work.metadata.get("series") or work.work_id)
         series_id = str(work.metadata.get("seriesId") or "")

--- a/manga_watch/sources/sunday_webry.py
+++ b/manga_watch/sources/sunday_webry.py
@@ -173,6 +173,30 @@ class SundayWebryAdapter(SourceAdapter):
             },
         )
 
+    def canonicalize_item(
+        self,
+        item,
+        http_client: HttpClient,
+    ) -> WorkDescriptor:
+        seed_url = str(item.get("seedUrl") or "")
+        series_id = str(item.get("seriesId") or "") or extract_sunday_webry_series_id_from_seed_url(seed_url)
+        if series_id:
+            return self.normalize(canonical_sunday_webry_series_feed_url(series_id))
+
+        episode_url = parse_sunday_webry_episode_url(seed_url)
+        if not episode_url:
+            raise RuntimeError("sunday-webry: unsupported seed URL")
+
+        episode_html = http_client.get_text(episode_url)
+        feed_url = extract_sunday_webry_series_feed_url(episode_html)
+        if feed_url:
+            return self.normalize(feed_url)
+
+        series_id = extract_sunday_webry_series_id(episode_html)
+        if not series_id:
+            raise RuntimeError("sunday-webry: series id not found")
+        return self.normalize(canonical_sunday_webry_series_feed_url(series_id))
+
     def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
         series = str(work.metadata.get("series") or work.work_id)
         series_id = str(work.metadata.get("seriesId") or "")

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -53,6 +53,26 @@ class FakeAdapter(SourceAdapter):
         )
 
 
+class CanonicalizingFakeAdapter(FakeAdapter):
+    def can_handle(self, seed_url: str) -> bool:
+        return seed_url == "https://example.com/canonicalize"
+
+    def normalize(self, seed_url: str) -> WorkDescriptor:
+        return WorkDescriptor(
+            source=self.source,
+            work_id="https://example.com/canonicalize",
+            seed_url=seed_url,
+        )
+
+    def canonicalize_item(self, item, http_client) -> WorkDescriptor:
+        return WorkDescriptor(
+            source=self.source,
+            work_id="fake:series-1",
+            seed_url="https://example.com/series/1",
+            metadata={"series": "fake:series-1"},
+        )
+
+
 def watchlist_entry(
     *,
     work_id="work-1",
@@ -283,6 +303,16 @@ class CheckTests(unittest.TestCase):
 
         self.assertEqual("kakuyomu:123", entry["id"])
         self.assertEqual("https://kakuyomu.jp/works/123/", entry["seed_url"])
+
+    def test_build_watchlist_entry_prefers_adapter_canonicalization_contract(self):
+        entry = check.build_watchlist_entry(
+            "https://example.com/canonicalize",
+            adapters=[CanonicalizingFakeAdapter([])],
+        )
+
+        self.assertEqual("fake:series-1", entry["id"])
+        self.assertEqual("fake", entry["source"])
+        self.assertEqual("https://example.com/series/1", entry["seed_url"])
 
     def test_build_watchlist_entry_uses_stable_comic_action_work_id(self):
         fake_client = mock.Mock()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -329,6 +329,126 @@ class SourceAdapterTests(unittest.TestCase):
             work.to_dict(),
         )
 
+    def test_feed_family_canonicalize_item_promotes_episode_seed_to_stable_series_descriptor(self):
+        cases = (
+            (
+                "comic-earthstar",
+                normalize_seed_url(
+                    "https://comic-earthstar.com/episode/12207421983526541742?from=share"
+                ).to_dict(),
+                {
+                    "https://comic-earthstar.com/episode/12207421983526541742": """
+                    <html>
+                      <head>
+                        <link rel="alternate" type="application/rss+xml" href="https://comic-earthstar.com/rss/series/12207421983526538413">
+                      </head>
+                    </html>
+                    """,
+                },
+                normalize_seed_url(
+                    "https://comic-earthstar.com/rss/series/12207421983526538413"
+                ).to_dict(),
+            ),
+            (
+                "comicborder",
+                normalize_seed_url(
+                    "https://comicborder.com/episode/12207421983437812169?from=share"
+                ).to_dict(),
+                {
+                    "https://comicborder.com/episode/12207421983437812169": """
+                    <html>
+                      <head>
+                        <link rel="alternate" type="application/rss+xml" href="https://comicborder.com/rss/series/12207421983437805229">
+                      </head>
+                    </html>
+                    """,
+                },
+                normalize_seed_url(
+                    "https://comicborder.com/rss/series/12207421983437805229"
+                ).to_dict(),
+            ),
+            (
+                "comic-trail",
+                normalize_seed_url(
+                    "https://comic-trail.com/episode/2550689798402927313?from=share"
+                ).to_dict(),
+                {
+                    "https://comic-trail.com/episode/2550689798402927313": """
+                    <html>
+                      <head>
+                        <link rel="alternate" type="application/rss+xml" href="https://comic-trail.com/rss/series/14079602755560047206">
+                      </head>
+                    </html>
+                    """,
+                },
+                normalize_seed_url(
+                    "https://comic-trail.com/rss/series/14079602755560047206"
+                ).to_dict(),
+            ),
+            (
+                "kuragebunch",
+                normalize_seed_url(
+                    "https://kuragebunch.com/episode/2550912964856491139?from=share"
+                ).to_dict(),
+                {
+                    "https://kuragebunch.com/episode/2550912964856491139": """
+                    <html>
+                      <head>
+                        <link rel="alternate" type="application/rss+xml" href="https://kuragebunch.com/rss/series/2550912964856487532">
+                      </head>
+                    </html>
+                    """,
+                },
+                normalize_seed_url(
+                    "https://kuragebunch.com/rss/series/2550912964856487532"
+                ).to_dict(),
+            ),
+            (
+                "shonenjumpplus",
+                normalize_seed_url(
+                    "https://shonenjumpplus.com/episode/17107419589191805801?from=episode"
+                ).to_dict(),
+                {
+                    "https://shonenjumpplus.com/episode/17107419589191805801": """
+                    <html>
+                      <head>
+                        <link rel="alternate" type="application/rss+xml" href="https://shonenjumpplus.com/rss/series/3269754496881854342">
+                      </head>
+                    </html>
+                    """,
+                },
+                normalize_seed_url(
+                    "https://shonenjumpplus.com/rss/series/3269754496881854342"
+                ).to_dict(),
+            ),
+            (
+                "sunday-webry",
+                normalize_seed_url(
+                    "https://www.sunday-webry.com/episode/12207421983581042977?from=episode"
+                ).to_dict(),
+                {
+                    "https://www.sunday-webry.com/episode/12207421983581042977": """
+                    <html>
+                      <head>
+                        <link rel="alternate" type="application/rss+xml" href="https://www.sunday-webry.com/rss/series/12207421983580960894">
+                      </head>
+                    </html>
+                    """,
+                },
+                normalize_seed_url(
+                    "https://www.sunday-webry.com/rss/series/12207421983580960894"
+                ).to_dict(),
+            ),
+        )
+
+        for source, item, responses, expected in cases:
+            with self.subTest(source=source):
+                client = StaticHttpClient(responses)
+                descriptor = ADAPTERS[source]().canonicalize_item(item, client).to_dict()
+
+                self.assertEqual(expected, descriptor)
+                self.assertEqual([item["seedUrl"]], client.calls)
+
     def test_magapoke_fetch_latest_reads_series_rss_from_title_page(self):
         adapter = MagapokeAdapter()
         work = adapter.normalize("https://pocket.shonenmagazine.com/title/03021/episode/427856")


### PR DESCRIPTION
## Summary
- move watchlist canonicalization for the feed-backed source family into the adapter contract via `SourceAdapter.canonicalize_item`
- update `build_watchlist_entry` to prefer adapter-owned canonical descriptors and leave `check.py` with only the legacy fallback sources for this slice
- add regression coverage for the new adapter contract and for episode-seed promotion into stable series descriptors

## Issue
- Closes #236

## Verification
- `.venv/bin/python -m pytest tests/test_check.py tests/test_sources.py tests/test_source_drift.py`

## Residual Risks
- `firecross`, `champion-cross`, and `comic-action` still rely on the legacy fallback path in `check.py`; this PR establishes the adapter seam and migrates the feed-backed family first