### PR TITLE
Add GitHub Actions workflow to auto-close stale issues and PRs

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,38 @@
+name: Close stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close stale issues and PRs
+        uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because there
+            has not been recent activity. It will be closed in 7 days if no
+            further activity occurs.
+          close-issue-message: >-
+            This issue was closed automatically due to inactivity. If this is
+            still needed, please reopen it and share the latest context.
+          stale-pr-message: >-
+            This pull request has been automatically marked as stale because
+            there has not been recent activity. It will be closed in 7 days if
+            no further activity occurs.
+          close-pr-message: >-
+            This pull request was closed automatically due to inactivity.
+            Please reopen it if work should continue.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,priority:high
+          exempt-pr-labels: pinned,security,work-in-progress


### PR DESCRIPTION
### Motivation
- Reduce repository noise by automatically marking and closing issues and pull requests that have been inactive for an extended period.

### Description
- Add `.github/workflows/close-stale.yml` which uses `actions/stale@v9` to mark and close stale issues and PRs.
- Configure the workflow to run on a daily schedule (`cron: "30 3 * * *"`) and via manual `workflow_dispatch`.
- Mark items stale after `30` days and close them after `7` more days, with custom stale/close messages, `stale` labels, and exempt labels for issues and PRs.
- Grant the workflow `permissions` `issues: write` and `pull-requests: write` so it can modify and close issues/PRs.

### Testing
- Validated the workflow YAML structure by inspection, which succeeded.
- Committed the new file and verified the repository state with `git status` and `git show`, which succeeded.
- No workflow run was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8a7901cc88332b73447e4ef7fc6fb)