### PR TITLE
Implement hidden search and supertwins flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ checker は watchlist を並列に処理しますが、`updates` / `errors.sourc
       "source": "comic-walker",
       "seed_url": "https://comic-walker.com/detail/KC_003913_S",
       "enabled": true,
+      "hidden": false,
       "notification_policy": {
         "mode": "all",
         "allowed_update_types": null
@@ -130,6 +131,8 @@ checker は watchlist を並列に処理しますが、`updates` / `errors.sourc
 - root `discord_delivery.daily_notification`: Discord main channel 向け daily notification の durable dedupe / pending state
 
 履歴保持は作品ごとの `history_retention` で上書きでき、未指定時は既定値 20 件です。trim するときは「未読は全件保持 + 既読は最新 N 件のみ保持」を守ります。必要なら watchlist 側で `health_policy.expected_interval_seconds` を指定し、stale 判定の期待巡回間隔を作品単位で上書きできます。詳細な schema と state contract は [root 受け入れ仕様書 (`spec.md`, 文書名: `SPEC.md`)](spec.md) を source of truth とします。
+
+`hidden=true` の作品は watchlist に残ったまま巡回・state 更新・履歴保持を続けますが、`latest` 表示と Discord の daily notification からは除外されます。重複購読の副媒体を静かに追跡したいときのためのフラグで、`notification_policy.mode=mute` とは別概念です。
 
 ### backlog CLI
 
@@ -250,6 +253,7 @@ Phase 1 では source ごとの capability 差を隠しません。作品追加�
     "source": "kakuyomu",
     "seed_url": "https://kakuyomu.jp/works/123",
     "enabled": true,
+    "hidden": false,
     "notification_policy": {"mode": "all", "allowed_update_types": null}
   },
   "work_count": 1
@@ -407,10 +411,11 @@ export DISCORD_RUN_REPORT_CHANNEL_ID=...
 ```
 
 Discord main channel では trim 後に本文がちょうど `latest` のメッセージで保存済み最新話一覧を返し、`fetch` のメッセージで手動巡回を受け付けます。Discord interaction endpoint では slash command として `/add url:<作品URL>` も受け付け、shared add logic で対応できる URL のみクロール対象へ追加します。`MANGA_WATCH_GITHUB_TOKEN` と `MANGA_WATCH_GITHUB_REPOSITORY` が設定されている場合、`unsupported_source` は追加失敗のまま GitHub Issue を自動作成し、「対応候補として記録した」と返信します。
-Cloud Run Service の interaction endpoint では slash command として `/latest` `/fetch` `/add` `/remove` を扱います。`/remove` は ephemeral な select menu と confirm/cancel button を返し、watchlist と state から対象作品を完全削除します。
+Cloud Run Service の interaction endpoint では slash command として `/latest` `/fetch` `/add` `/search` `/remove` `/supertwins-search` `/supertwins-manage` を扱います。`/search` は媒体ごとに作品検索を行い、選択した結果を visible または hidden で watchlist に追加します。初期対応 source は `champion-cross` と `kakuyomu` です。検索未対応 source は明示的に unavailable を返します。
+`/supertwins-search` は既存 watchlist 作品を起点に他媒体候補を探し、選択した候補を hidden で watchlist に追加しつつ state 上の `supertwins.groups` に登録します。既存 duplicate が選ばれた場合も、その entry を hidden 化したうえで group に追加します。`/supertwins-manage` は group と member を選択して、hidden のまま残す / hidden を解除する / subscription を削除する、の 3 アクションを扱います。削除だけは confirm を返します。`/remove` は ephemeral な select menu と confirm/cancel button を返し、watchlist と state から対象作品を完全削除します。
 Discord 実機補助確認は test guild / test channel だけで `.venv/bin/python -m manga_watch.discord_real_e2e --case all --json` を実行します。これは primary gate ではなく、差異が出たときは先に mocked acceptance (`manga_watch.run_mocked_acceptance`) と formatter / builder を確認します。
 
-Cloud Run Service の Discord interaction endpoint をローカルで起動する場合は、署名検証用の public key に加えて command registration 用の bot token を入れて `python -m manga_watch.run_service` を使います。service startup では `/latest` `/fetch` `/add` `/remove` の command 定義を Discord へ idempotent に登録し、登録に失敗した場合は fail-fast で起動を中断します。`DISCORD_GUILD_ID` を入れると guild command、未指定なら global command を更新します。
+Cloud Run Service の Discord interaction endpoint をローカルで起動する場合は、署名検証用の public key に加えて command registration 用の bot token を入れて `python -m manga_watch.run_service` を使います。service startup では `/latest` `/fetch` `/add` `/search` `/remove` `/supertwins-search` `/supertwins-manage` の command 定義を Discord へ idempotent に登録し、登録に失敗した場合は fail-fast で起動を中断します。`DISCORD_GUILD_ID` を入れると guild command、未指定なら global command を更新します。
 
 ```bash
 export DISCORD_BOT_TOKEN=...

--- a/manga_watch/check.py
+++ b/manga_watch/check.py
@@ -638,6 +638,7 @@ def build_watchlist_entry(
         "source": work.source,
         "seed_url": work.seed_url,
         "enabled": True,
+        "hidden": False,
         "notification_policy": {
             "mode": "all",
             "allowed_update_types": None,

--- a/manga_watch/discord_command_registration.py
+++ b/manga_watch/discord_command_registration.py
@@ -9,7 +9,11 @@ import requests
 from manga_watch.discord_add import ADD_COMMAND
 from manga_watch.discord_fetch import FETCH_COMMAND
 from manga_watch.discord_latest import LATEST_COMMAND
+from manga_watch.discord_search import SEARCH_COMMAND
+from manga_watch.source_search import searchable_source_choices
 from manga_watch.discord_remove import REMOVE_COMMAND
+from manga_watch.discord_supertwins_manage import SUPERTWINS_MANAGE_COMMAND
+from manga_watch.discord_supertwins_search import SUPERTWINS_SEARCH_COMMAND
 from manga_watch.secret_redaction import redact_secret_text
 from manga_watch.secret_resolver import resolve_env_value
 
@@ -52,8 +56,45 @@ def default_interaction_commands() -> List[Dict[str, object]]:
             ],
         },
         {
+            "name": SEARCH_COMMAND,
+            "description": "媒体ごとに作品名で検索します。",
+            "options": [
+                {
+                    "type": 3,
+                    "name": "source",
+                    "description": "検索したい媒体",
+                    "required": True,
+                    "choices": searchable_source_choices(),
+                },
+                {
+                    "type": 3,
+                    "name": "query",
+                    "description": "検索したい文字列",
+                    "required": True,
+                },
+                {
+                    "type": 3,
+                    "name": "visibility",
+                    "description": "watchlist に追加するときの表示状態",
+                    "required": False,
+                    "choices": [
+                        {"name": "visible", "value": "visible"},
+                        {"name": "hidden", "value": "hidden"},
+                    ],
+                },
+            ],
+        },
+        {
             "name": REMOVE_COMMAND,
             "description": "購読中の作品を削除します。",
+        },
+        {
+            "name": SUPERTWINS_SEARCH_COMMAND,
+            "description": "既存作品を起点に他媒体候補を探して supertwins を作成します。",
+        },
+        {
+            "name": SUPERTWINS_MANAGE_COMMAND,
+            "description": "既存の supertwins を確認して誤登録を解除します。",
         },
     ]
 

--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -13,7 +13,18 @@ from nacl.signing import VerifyKey
 from manga_watch.discord_add import ADD_COMMAND, AddCommandHandler
 from manga_watch.discord_fetch import FETCH_COMMAND, handle_fetch_trigger
 from manga_watch.discord_latest import LATEST_COMMAND, handle_latest_query, validated_timezone_name
+from manga_watch.discord_search import SEARCH_COMMAND, SEARCH_SELECT_CUSTOM_ID_PREFIX, SearchCommandHandler
 from manga_watch.discord_remove import REMOVE_COMMAND, RemoveCommandHandler
+from manga_watch.discord_supertwins_manage import (
+    SUPERTWINS_MANAGE_COMMAND,
+    ManageSupertwinsCommandHandler,
+    is_supertwins_manage_component,
+)
+from manga_watch.discord_supertwins_search import (
+    SUPERTWINS_SEARCH_COMMAND,
+    SearchSupertwinsCommandHandler,
+    is_supertwins_search_component,
+)
 from manga_watch.discord_outbound import DiscordChannelClient
 from manga_watch.notifier import build_named_notifiers
 from manga_watch.runner import FETCH_ACCEPTED_MESSAGE, RunCoordinator, RunnerConfig, parse_bool
@@ -290,7 +301,10 @@ class DiscordInteractionService:
     verification_disabled: bool = False
     latest_handler: Callable[..., Optional[str]] = handle_latest_query
     add_handler: Optional[AddCommandHandler] = None
+    search_handler: Optional[SearchCommandHandler] = None
     remove_handler: Optional[RemoveCommandHandler] = None
+    supertwins_search_handler: Optional[SearchSupertwinsCommandHandler] = None
+    supertwins_manage_handler: Optional[ManageSupertwinsCommandHandler] = None
 
     def handle_request(
         self,
@@ -350,25 +364,68 @@ class DiscordInteractionService:
                 watchlist_path=self.watchlist_path,
             )
             return interaction_message_response(str(response_payload.get("content") or "").strip())
+        if command_name == SEARCH_COMMAND and self.search_handler is not None:
+            response_payload = self.search_handler.start(
+                source=self._command_option(payload, "source"),
+                query=self._command_option(payload, "query"),
+                visibility=self._command_option(payload, "visibility"),
+                watchlist_path=self.watchlist_path,
+            )
+            return interaction_ephemeral_response(response_payload)
         if command_name == REMOVE_COMMAND and self.remove_handler is not None:
             payload = self.remove_handler.start(
                 watchlist_path=self.watchlist_path,
                 state_path=self.state_path,
             )
             return interaction_ephemeral_response(payload)
+        if command_name == SUPERTWINS_SEARCH_COMMAND and self.supertwins_search_handler is not None:
+            response_payload = self.supertwins_search_handler.start(
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+            return interaction_ephemeral_response(response_payload)
+        if command_name == SUPERTWINS_MANAGE_COMMAND and self.supertwins_manage_handler is not None:
+            response_payload = self.supertwins_manage_handler.start(
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+            return interaction_ephemeral_response(response_payload)
         return text_response(400, f"unsupported command: {command_name or '(missing)'}")
 
     def _handle_message_component(self, payload: Mapping[str, object]) -> InteractionHttpResponse:
-        if self.remove_handler is None:
-            return text_response(400, "unsupported interaction type")
         data = payload.get("data")
         if not isinstance(data, Mapping):
             return text_response(400, "invalid interaction payload")
-        response_payload = self.remove_handler.handle_component(
-            data,
-            watchlist_path=self.watchlist_path,
-            state_path=self.state_path,
-        )
+        custom_id = str(data.get("custom_id") or "").strip()
+        if custom_id.startswith(f"{SEARCH_SELECT_CUSTOM_ID_PREFIX}:"):
+            if self.search_handler is None:
+                return text_response(400, "unsupported interaction type")
+            response_payload = self.search_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+            )
+        elif self.remove_handler is not None and (
+            custom_id == "remove_select" or custom_id.startswith("remove_")
+        ):
+            response_payload = self.remove_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+        elif self.supertwins_search_handler is not None and is_supertwins_search_component(custom_id):
+            response_payload = self.supertwins_search_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+        elif self.supertwins_manage_handler is not None and is_supertwins_manage_component(custom_id):
+            response_payload = self.supertwins_manage_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+        else:
+            return text_response(400, "unsupported interaction type")
         return interaction_payload_response(
             INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
             response_payload,
@@ -474,5 +531,8 @@ def build_interaction_service_from_env(
         verifier=verifier,
         verification_disabled=verification.verification_disabled,
         add_handler=AddCommandHandler.from_env(),
+        search_handler=SearchCommandHandler(),
         remove_handler=RemoveCommandHandler(backend=storage_backend),
+        supertwins_search_handler=SearchSupertwinsCommandHandler(),
+        supertwins_manage_handler=ManageSupertwinsCommandHandler(),
     )

--- a/manga_watch/discord_latest.py
+++ b/manga_watch/discord_latest.py
@@ -103,6 +103,8 @@ def build_latest_query_lines(
             raise ValueError("watchlist entry must be an object")
         if not bool(raw_entry.get("enabled")):
             continue
+        if bool(raw_entry.get("hidden")):
+            continue
 
         work_id = str(raw_entry.get("id") or "").strip()
         if not work_id:

--- a/manga_watch/discord_outbound.py
+++ b/manga_watch/discord_outbound.py
@@ -278,6 +278,31 @@ def build_daily_notification_message(
     return "\n".join(lines)
 
 
+def filter_updates_for_daily_notifications(
+    updates: Sequence[Mapping[str, object]],
+    watchlist: Mapping[str, object],
+) -> List[Mapping[str, object]]:
+    works = watchlist.get("works", [])
+    if not isinstance(works, list):
+        raise ValueError("watchlist.works must be a list")
+
+    hidden_work_ids = {
+        str(entry.get("id") or "").strip()
+        for entry in works
+        if isinstance(entry, Mapping) and bool(entry.get("hidden"))
+    }
+    if not hidden_work_ids:
+        return list(updates)
+
+    filtered_updates: List[Mapping[str, object]] = []
+    for update in updates:
+        work_id = _coerce_text(update.get("id") or update.get("work_id"))
+        if work_id in hidden_work_ids:
+            continue
+        filtered_updates.append(update)
+    return filtered_updates
+
+
 def enqueue_daily_notification(
     state: Dict[str, object],
     *,

--- a/manga_watch/discord_search.py
+++ b/manga_watch/discord_search.py
@@ -19,6 +19,7 @@ SEARCH_NO_RESULTS_MESSAGE = "検索結果が見つかりませんでした。"
 MAX_COMPONENT_TEXT = 100
 MAX_COMPONENT_VALUE = 100
 MAX_SELECT_URL_CACHE_SIZE = 256
+SELECT_URL_TOKEN_PREFIX = "u:"
 
 _SEARCH_SELECT_URL_CACHE: "OrderedDict[str, str]" = OrderedDict()
 
@@ -48,7 +49,7 @@ def _truncate_component_text(text: object, *, max_length: int = MAX_COMPONENT_TE
 
 def _remember_search_result_url(url: str) -> str:
     digest = hashlib.sha256(url.encode("utf-8")).digest()
-    token = "u:" + base64.urlsafe_b64encode(digest[:9]).decode("ascii").rstrip("=")
+    token = SELECT_URL_TOKEN_PREFIX + base64.urlsafe_b64encode(digest[:9]).decode("ascii").rstrip("=")
     _SEARCH_SELECT_URL_CACHE[token] = url
     _SEARCH_SELECT_URL_CACHE.move_to_end(token)
     while len(_SEARCH_SELECT_URL_CACHE) > MAX_SELECT_URL_CACHE_SIZE:
@@ -71,6 +72,8 @@ def _resolve_select_option_value(value: object) -> Optional[str]:
     if cached is not None:
         _SEARCH_SELECT_URL_CACHE.move_to_end(normalized)
         return cached
+    if normalized.startswith(SELECT_URL_TOKEN_PREFIX):
+        return None
     return normalized
 
 

--- a/manga_watch/discord_search.py
+++ b/manga_watch/discord_search.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Mapping, Optional
 
@@ -13,6 +16,11 @@ SEARCH_MISSING_SOURCE_MESSAGE = "検索したい媒体を `source` で指定し�
 SEARCH_MISSING_QUERY_MESSAGE = "検索したい文字列を `query` で指定してください。"
 SEARCH_FAILURE_MESSAGE = "作品検索に失敗しました。サーバーログを確認してください。"
 SEARCH_NO_RESULTS_MESSAGE = "検索結果が見つかりませんでした。"
+MAX_COMPONENT_TEXT = 100
+MAX_COMPONENT_VALUE = 100
+MAX_SELECT_URL_CACHE_SIZE = 256
+
+_SEARCH_SELECT_URL_CACHE: "OrderedDict[str, str]" = OrderedDict()
 
 
 def _coerce_text(value: object) -> Optional[str]:
@@ -27,6 +35,43 @@ def _normalize_visibility(value: object) -> str:
     if visibility == "hidden":
         return "hidden"
     return "visible"
+
+
+def _truncate_component_text(text: object, *, max_length: int = MAX_COMPONENT_TEXT) -> str:
+    normalized = str(text or "").strip()
+    if len(normalized) <= max_length:
+        return normalized
+    if max_length <= 1:
+        return "…"
+    return normalized[: max_length - 1] + "…"
+
+
+def _remember_search_result_url(url: str) -> str:
+    digest = hashlib.sha256(url.encode("utf-8")).digest()
+    token = "u:" + base64.urlsafe_b64encode(digest[:9]).decode("ascii").rstrip("=")
+    _SEARCH_SELECT_URL_CACHE[token] = url
+    _SEARCH_SELECT_URL_CACHE.move_to_end(token)
+    while len(_SEARCH_SELECT_URL_CACHE) > MAX_SELECT_URL_CACHE_SIZE:
+        _SEARCH_SELECT_URL_CACHE.popitem(last=False)
+    return token
+
+
+def _select_option_value(url: object) -> str:
+    normalized = _coerce_text(url) or ""
+    if len(normalized) <= MAX_COMPONENT_VALUE:
+        return normalized
+    return _remember_search_result_url(normalized)
+
+
+def _resolve_select_option_value(value: object) -> Optional[str]:
+    normalized = _coerce_text(value)
+    if not normalized:
+        return None
+    cached = _SEARCH_SELECT_URL_CACHE.get(normalized)
+    if cached is not None:
+        _SEARCH_SELECT_URL_CACHE.move_to_end(normalized)
+        return cached
+    return normalized
 
 
 def _format_search_add_response(result: Mapping[str, object]) -> str:
@@ -98,9 +143,9 @@ class SearchCommandHandler:
 
         options = [
             {
-                "label": result.title,
-                "value": result.seed_url,
-                "description": result.subtitle or result.source,
+                "label": _truncate_component_text(result.title),
+                "value": _select_option_value(result.seed_url),
+                "description": _truncate_component_text(result.subtitle or result.source),
             }
             for result in results[:25]
         ]
@@ -136,7 +181,7 @@ class SearchCommandHandler:
 
         visibility = _normalize_visibility(custom_id.partition(":")[2])
         values = data.get("values") or []
-        selected_url = _coerce_text(values[0]) if values else None
+        selected_url = _resolve_select_option_value(values[0]) if values else None
         if not selected_url:
             return {"content": "選択された作品URLが見つかりませんでした。", "components": []}
 

--- a/manga_watch/discord_search.py
+++ b/manga_watch/discord_search.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Mapping, Optional
+
+from manga_watch.discord_add import WatchlistAddError, format_watchlist_add_error
+from manga_watch.source_search import SearchResult, UnsupportedSourceSearchError, search_source
+from manga_watch.watchlist import add_watchlist_url
+
+SEARCH_COMMAND = "search"
+SEARCH_SELECT_CUSTOM_ID_PREFIX = "search_select"
+SEARCH_MISSING_SOURCE_MESSAGE = "検索したい媒体を `source` で指定してください。"
+SEARCH_MISSING_QUERY_MESSAGE = "検索したい文字列を `query` で指定してください。"
+SEARCH_FAILURE_MESSAGE = "作品検索に失敗しました。サーバーログを確認してください。"
+SEARCH_NO_RESULTS_MESSAGE = "検索結果が見つかりませんでした。"
+
+
+def _coerce_text(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_visibility(value: object) -> str:
+    visibility = str(value or "").strip().lower()
+    if visibility == "hidden":
+        return "hidden"
+    return "visible"
+
+
+def _format_search_add_response(result: Mapping[str, object]) -> str:
+    action = str(result.get("action") or "").strip()
+    entry = result.get("entry")
+    existing = result.get("existing")
+    entry_payload = entry if isinstance(entry, Mapping) else {}
+    existing_payload = existing if isinstance(existing, Mapping) else {}
+
+    work_id = str(entry_payload.get("id") or existing_payload.get("id") or "").strip()
+    seed_url = str(entry_payload.get("seed_url") or existing_payload.get("seed_url") or "").strip()
+    hidden = bool(entry_payload.get("hidden") or existing_payload.get("hidden"))
+
+    lines = []
+    if action == "added":
+        prefix = "追加しました"
+        if hidden:
+            prefix += " (非表示)"
+        lines.append(f"{prefix}: {work_id}")
+    elif action == "duplicate":
+        prefix = "既に登録済みです"
+        if hidden:
+            prefix += " (非表示)"
+        lines.append(f"{prefix}: {work_id}")
+    else:
+        lines.append("作品追加を受け付けました。")
+    if seed_url:
+        lines.append(f"seed_url: {seed_url}")
+    return "\n".join(lines)
+
+
+@dataclass
+class SearchCommandHandler:
+    search_source: Callable[..., List[SearchResult]] = search_source
+    add_subscription: Callable[..., Mapping[str, object]] = add_watchlist_url
+
+    def start(
+        self,
+        *,
+        source: Optional[str],
+        query: Optional[str],
+        visibility: Optional[str] = None,
+        watchlist_path: Optional[str] = None,
+        http_client: object = None,
+    ) -> Dict[str, object]:
+        del watchlist_path
+        normalized_source = _coerce_text(source)
+        normalized_query = _coerce_text(query)
+        if not normalized_source:
+            return {"content": SEARCH_MISSING_SOURCE_MESSAGE}
+        if not normalized_query:
+            return {"content": SEARCH_MISSING_QUERY_MESSAGE}
+
+        normalized_visibility = _normalize_visibility(visibility)
+        try:
+            results = self.search_source(
+                normalized_source,
+                normalized_query,
+                http_client=http_client,
+                limit=10,
+            )
+        except UnsupportedSourceSearchError:
+            return {"content": f"検索未対応の媒体です: {normalized_source}", "components": []}
+        except Exception:
+            return {"content": SEARCH_FAILURE_MESSAGE}
+
+        if not results:
+            return {"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}
+
+        options = [
+            {
+                "label": result.title,
+                "value": result.seed_url,
+                "description": result.subtitle or result.source,
+            }
+            for result in results[:25]
+        ]
+
+        return {
+            "content": f"{normalized_source} の検索結果です。1件選んでください。",
+            "components": [
+                {
+                    "type": 1,
+                    "components": [
+                        {
+                            "type": 3,
+                            "custom_id": f"{SEARCH_SELECT_CUSTOM_ID_PREFIX}:{normalized_visibility}",
+                            "placeholder": "追加する作品を選択",
+                            "min_values": 1,
+                            "max_values": 1,
+                            "options": options,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def handle_component(
+        self,
+        data: Mapping[str, object],
+        *,
+        watchlist_path: Optional[str] = None,
+    ) -> Dict[str, object]:
+        custom_id = str(data.get("custom_id") or "").strip()
+        if not custom_id.startswith(f"{SEARCH_SELECT_CUSTOM_ID_PREFIX}:"):
+            return {"content": "画面の有効期限が切れたため、もう一度 `/search` を実行してください。", "components": []}
+
+        visibility = _normalize_visibility(custom_id.partition(":")[2])
+        values = data.get("values") or []
+        selected_url = _coerce_text(values[0]) if values else None
+        if not selected_url:
+            return {"content": "選択された作品URLが見つかりませんでした。", "components": []}
+
+        hidden = visibility == "hidden"
+        try:
+            result = self.add_subscription(
+                selected_url,
+                watchlist_path=watchlist_path,
+                hidden=hidden,
+            )
+        except WatchlistAddError as exc:
+            return {"content": format_watchlist_add_error(exc), "components": []}
+        except Exception:
+            return {"content": SEARCH_FAILURE_MESSAGE, "components": []}
+
+        return {"content": _format_search_add_response(result), "components": []}

--- a/manga_watch/discord_supertwins_manage.py
+++ b/manga_watch/discord_supertwins_manage.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Mapping, Optional
+
+from manga_watch.discord_text import series_label_for_snapshot
+from manga_watch.storage import load_state, load_watchlist, save_state, save_watchlist
+from manga_watch.supertwins import (
+    clear_pending_action,
+    get_pending_action,
+    list_group_members,
+    list_groups,
+    prune_empty_groups,
+    remove_group_members,
+    set_pending_action,
+    upsert_watchlist_entry,
+)
+
+SUPERTWINS_MANAGE_COMMAND = "supertwins-manage"
+SUPERTWINS_MANAGE_COMPONENT_PREFIX = "supertwins_manage:"
+SUPERTWINS_MANAGE_GROUP_SELECT = "supertwins_manage_group_select"
+SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}members:"
+SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}action:"
+SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}confirm_delete:"
+SUPERTWINS_MANAGE_CANCEL_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}cancel:"
+SUPERTWINS_MANAGE_EMPTY_MESSAGE = "まだ supertwins グループはありません。"
+SUPERTWINS_MANAGE_GROUP_PROMPT = "編集する supertwins グループを選んでください。"
+SUPERTWINS_MANAGE_MEMBER_PROMPT = "解除する member を選んでください。"
+SUPERTWINS_MANAGE_ACTION_PROMPT = "member を group から外したあと、どう扱うか選んでください。"
+SUPERTWINS_MANAGE_DELETE_CONFIRM_PROMPT = "選択した subscription を削除します。よければ confirm を押してください。"
+SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE = (
+    "画面の有効期限が切れたため、もう一度 `/supertwins-manage` を実行してください。"
+)
+SUPERTWINS_MANAGE_DELETE_CANCEL_MESSAGE = "削除を取り消しました。"
+SUPERTWINS_MANAGE_DELETE_CONFIRM_MESSAGE = "選択した subscription を削除しました。"
+SUPERTWINS_MANAGE_KEEP_HIDDEN_MESSAGE = "member を group から外し、subscription は hidden のまま残しました。"
+SUPERTWINS_MANAGE_UNHIDE_MESSAGE = "member を group から外し、subscription の hidden を解除しました。"
+
+ACTION_ROW = 1
+BUTTON_COMPONENT = 2
+STRING_SELECT_COMPONENT = 3
+BUTTON_STYLE_PRIMARY = 1
+BUTTON_STYLE_SECONDARY = 2
+BUTTON_STYLE_DANGER = 4
+MAX_OPTIONS_PER_PAGE = 25
+MAX_COMPONENT_TEXT = 100
+
+
+def is_supertwins_manage_component(custom_id: object) -> bool:
+    normalized = str(custom_id or "").strip()
+    return normalized.startswith(SUPERTWINS_MANAGE_COMPONENT_PREFIX) or normalized == SUPERTWINS_MANAGE_GROUP_SELECT
+
+
+def _coerce_text(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _truncate_component_text(text: object, *, max_length: int = MAX_COMPONENT_TEXT) -> str:
+    normalized = str(text or "").strip()
+    if len(normalized) <= max_length:
+        return normalized
+    return normalized[: max_length - 1] + "…"
+
+
+def _call_loader(
+    loader: Callable[..., Dict[str, object]],
+    path: Optional[str],
+    *,
+    backend: Optional[str],
+) -> Dict[str, object]:
+    return loader(path, backend=backend)
+
+
+def _call_saver(
+    saver: Callable[..., None],
+    payload: Mapping[str, object],
+    path: Optional[str],
+    *,
+    backend: Optional[str],
+) -> None:
+    saver(payload, path=path, backend=backend)
+
+
+def _state_works(state: Mapping[str, object]) -> Mapping[str, object]:
+    works = state.get("works", {})
+    return works if isinstance(works, Mapping) else {}
+
+
+def _group_options(groups: List[Dict[str, object]]) -> List[Dict[str, str]]:
+    options: List[Dict[str, str]] = []
+    for group in groups[:MAX_OPTIONS_PER_PAGE]:
+        group_id = str(group["group_id"])
+        member_count = len(group["member_work_ids"])
+        options.append(
+            {
+                "label": _truncate_component_text(f"{group_id} ({member_count}件)"),
+                "value": group_id,
+                "description": _truncate_component_text(
+                    " / ".join(group["member_work_ids"][:3]) if group["member_work_ids"] else "member なし"
+                ),
+            }
+        )
+    return options
+
+
+def _member_options(state: Mapping[str, object], group_id: str) -> List[Dict[str, str]]:
+    options: List[Dict[str, str]] = []
+    works = _state_works(state)
+    for member_work_id in list_group_members(state, group_id)[:MAX_OPTIONS_PER_PAGE]:
+        state_entry = works.get(member_work_id, {}) if isinstance(works, Mapping) else {}
+        latest = state_entry.get("latest", {}) if isinstance(state_entry, Mapping) else {}
+        if latest is None or not isinstance(latest, Mapping):
+            latest = {}
+        options.append(
+            {
+                "label": _truncate_component_text(series_label_for_snapshot(member_work_id, latest)),
+                "value": member_work_id,
+                "description": _truncate_component_text(member_work_id),
+            }
+        )
+    return options
+
+
+def _action_options() -> List[Dict[str, str]]:
+    return [
+        {"label": "hidden のまま残す", "value": "keep_hidden", "description": "group からだけ外します"},
+        {"label": "hidden を解除", "value": "unhide", "description": "group から外して表示対象に戻します"},
+        {"label": "subscription を削除", "value": "delete", "description": "watchlist と state から削除します"},
+    ]
+
+
+def _pending_token(custom_id: str, prefix: str) -> str:
+    return custom_id[len(prefix) :]
+
+
+def _session_token(group_id: str, member_work_ids: List[str]) -> str:
+    material = f"{group_id}:{','.join(sorted(member_work_ids))}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def _clone_payload(payload: Mapping[str, object]) -> Dict[str, object]:
+    return json.loads(json.dumps(payload, ensure_ascii=False))
+
+
+def _notification_event_work_id(entry: object) -> Optional[str]:
+    if not isinstance(entry, Mapping):
+        return None
+    event = entry.get("event")
+    if not isinstance(event, Mapping):
+        return None
+    work_id = str(event.get("work_id") or event.get("workId") or "").strip()
+    return work_id or None
+
+
+def _pending_message_mentions_work(entry: object, work_id: str) -> bool:
+    if not isinstance(entry, Mapping):
+        return False
+    message_keys = entry.get("message_keys", [])
+    if not isinstance(message_keys, list):
+        return False
+    for message_key in message_keys:
+        if not isinstance(message_key, Mapping):
+            continue
+        current_work_id = str(message_key.get("work_id") or message_key.get("workId") or "").strip()
+        if current_work_id == work_id:
+            return True
+    return False
+
+
+def _prune_delivery_state_for_works(
+    state: Mapping[str, object],
+    work_ids: List[str],
+) -> Dict[str, object]:
+    updated_state = _clone_payload(state)
+    works = updated_state.setdefault("works", {})
+    if isinstance(works, dict):
+        for work_id in work_ids:
+            works.pop(work_id, None)
+
+    notification_outbox = updated_state.get("notification_outbox", [])
+    if isinstance(notification_outbox, list):
+        updated_state["notification_outbox"] = [
+            entry
+            for entry in notification_outbox
+            if _notification_event_work_id(entry) not in work_ids
+        ]
+
+    discord_delivery = updated_state.get("discord_delivery")
+    if isinstance(discord_delivery, dict):
+        daily_notification = discord_delivery.get("daily_notification")
+        if isinstance(daily_notification, dict):
+            delivered_latest_keys = daily_notification.get("delivered_latest_keys")
+            if isinstance(delivered_latest_keys, dict):
+                for work_id in work_ids:
+                    delivered_latest_keys.pop(work_id, None)
+            pending_messages = daily_notification.get("pending_messages", [])
+            if isinstance(pending_messages, list):
+                daily_notification["pending_messages"] = [
+                    entry
+                    for entry in pending_messages
+                    if all(not _pending_message_mentions_work(entry, work_id) for work_id in work_ids)
+                ]
+    return updated_state
+
+
+def _update_hidden_flags(
+    watchlist: Mapping[str, object],
+    work_ids: List[str],
+    *,
+    hidden: bool,
+) -> Dict[str, object]:
+    updated_watchlist = dict(watchlist)
+    for work_id in work_ids:
+        works = updated_watchlist.get("works", [])
+        if not isinstance(works, list):
+            raise ValueError("watchlist.works must be a list")
+        entry = None
+        for candidate in works:
+            if str(candidate.get("id")) == work_id:
+                entry = candidate
+                break
+        if entry is None:
+            raise ValueError(f"watchlist entry not found: {work_id}")
+        result = upsert_watchlist_entry(updated_watchlist, entry, hidden=hidden)
+        updated_watchlist = result["watchlist"]
+    return updated_watchlist
+
+
+def _delete_subscriptions(
+    watchlist: Mapping[str, object],
+    state: Mapping[str, object],
+    work_ids: List[str],
+) -> tuple[Dict[str, object], Dict[str, object]]:
+    updated_watchlist = _clone_payload(watchlist)
+    updated_state = _clone_payload(state)
+    works = updated_watchlist.get("works", [])
+    if not isinstance(works, list):
+        raise ValueError("watchlist.works must be a list")
+
+    updated_watchlist["works"] = [
+        dict(entry)
+        for entry in works
+        if str(entry.get("id") or "").strip() not in set(work_ids)
+    ]
+    updated_state = _prune_delivery_state_for_works(updated_state, work_ids)
+    return updated_watchlist, updated_state
+
+
+@dataclass
+class ManageSupertwinsCommandHandler:
+    watchlist_loader: Callable[..., Dict[str, object]] = load_watchlist
+    state_loader: Callable[..., Dict[str, object]] = load_state
+    watchlist_saver: Callable[..., None] = save_watchlist
+    state_saver: Callable[..., None] = save_state
+    backend: Optional[str] = None
+
+    def start(
+        self,
+        *,
+        watchlist_path: Optional[str] = None,
+        state_path: Optional[str] = None,
+    ) -> Dict[str, object]:
+        del watchlist_path
+        state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        groups = list_groups(state)
+        if not groups:
+            return {"content": SUPERTWINS_MANAGE_EMPTY_MESSAGE, "components": []}
+
+        return {
+            "content": SUPERTWINS_MANAGE_GROUP_PROMPT,
+            "components": [
+                {
+                    "type": ACTION_ROW,
+                    "components": [
+                        {
+                            "type": STRING_SELECT_COMPONENT,
+                            "custom_id": SUPERTWINS_MANAGE_GROUP_SELECT,
+                            "placeholder": "編集する group を選択",
+                            "min_values": 1,
+                            "max_values": 1,
+                            "options": _group_options(groups),
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def handle_component(
+        self,
+        data: Mapping[str, object],
+        *,
+        watchlist_path: Optional[str] = None,
+        state_path: Optional[str] = None,
+    ) -> Dict[str, object]:
+        custom_id = str(data.get("custom_id") or "").strip()
+        if custom_id == SUPERTWINS_MANAGE_GROUP_SELECT:
+            return self._handle_group_selection(data, state_path=state_path)
+        if custom_id.startswith(SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX):
+            return self._handle_member_selection(custom_id, data, state_path=state_path)
+        if custom_id.startswith(SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX):
+            return self._handle_action_selection(
+                custom_id,
+                data,
+                watchlist_path=watchlist_path,
+                state_path=state_path,
+            )
+        if custom_id.startswith(SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX):
+            return self._handle_confirm_delete(
+                custom_id,
+                watchlist_path=watchlist_path,
+                state_path=state_path,
+            )
+        if custom_id.startswith(SUPERTWINS_MANAGE_CANCEL_PREFIX):
+            return self._handle_cancel(custom_id, state_path=state_path)
+        return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+    def _handle_group_selection(
+        self,
+        data: Mapping[str, object],
+        *,
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        values = [str(value).strip() for value in data.get("values") or [] if str(value).strip()]
+        group_id = values[0] if values else ""
+        if not group_id:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        try:
+            member_options = _member_options(state, group_id)
+        except ValueError:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+        if not member_options:
+            return {"content": "この group には member がありません。", "components": []}
+
+        return {
+            "content": SUPERTWINS_MANAGE_MEMBER_PROMPT,
+            "components": [
+                {
+                    "type": ACTION_ROW,
+                    "components": [
+                        {
+                            "type": STRING_SELECT_COMPONENT,
+                            "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}{group_id}",
+                            "placeholder": "解除する member を選択",
+                            "min_values": 1,
+                            "max_values": min(len(member_options), MAX_OPTIONS_PER_PAGE),
+                            "options": member_options,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def _handle_member_selection(
+        self,
+        custom_id: str,
+        data: Mapping[str, object],
+        *,
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        group_id = _pending_token(custom_id, SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX)
+        selected_members = [str(value).strip() for value in data.get("values") or [] if str(value).strip()]
+        if not group_id or not selected_members:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        try:
+            pending_token = _session_token(group_id, selected_members)
+            updated = set_pending_action(
+                state,
+                pending_token,
+                {
+                    "group_id": group_id,
+                    "member_work_ids": selected_members,
+                },
+            )
+            _call_saver(self.state_saver, updated, state_path, backend=self.backend)
+        except Exception:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        return {
+            "content": SUPERTWINS_MANAGE_ACTION_PROMPT,
+            "components": [
+                {
+                    "type": ACTION_ROW,
+                    "components": [
+                        {
+                            "type": STRING_SELECT_COMPONENT,
+                            "custom_id": f"{SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX}{pending_token}",
+                            "placeholder": "処理を選択",
+                            "min_values": 1,
+                            "max_values": 1,
+                            "options": _action_options(),
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def _handle_action_selection(
+        self,
+        custom_id: str,
+        data: Mapping[str, object],
+        *,
+        watchlist_path: Optional[str],
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        token = _pending_token(custom_id, SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX)
+        action = _coerce_text((data.get("values") or [None])[0]) or ""
+        if not token or not action:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        try:
+            pending = get_pending_action(state, token)
+        except ValueError:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        if action == "delete":
+            return {
+                "content": SUPERTWINS_MANAGE_DELETE_CONFIRM_PROMPT,
+                "components": [
+                    {
+                        "type": ACTION_ROW,
+                        "components": [
+                            {
+                                "type": BUTTON_COMPONENT,
+                                "style": BUTTON_STYLE_DANGER,
+                                "custom_id": f"{SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX}{token}",
+                                "label": "confirm",
+                            },
+                            {
+                                "type": BUTTON_COMPONENT,
+                                "style": BUTTON_STYLE_SECONDARY,
+                                "custom_id": f"{SUPERTWINS_MANAGE_CANCEL_PREFIX}{token}",
+                                "label": "cancel",
+                            },
+                        ],
+                    }
+                ],
+            }
+
+        return self._apply_action(
+            token,
+            pending,
+            action=action,
+            watchlist_path=watchlist_path,
+            state_path=state_path,
+        )
+
+    def _handle_confirm_delete(
+        self,
+        custom_id: str,
+        *,
+        watchlist_path: Optional[str],
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        token = _pending_token(custom_id, SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX)
+        if not token:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+        state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        try:
+            pending = get_pending_action(state, token)
+        except ValueError:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+        return self._delete_action(token, pending, watchlist_path=watchlist_path, state_path=state_path)
+
+    def _handle_cancel(
+        self,
+        custom_id: str,
+        *,
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        token = _pending_token(custom_id, SUPERTWINS_MANAGE_CANCEL_PREFIX)
+        if not token:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        try:
+            updated = clear_pending_action(state, token)
+            _call_saver(self.state_saver, updated, state_path, backend=self.backend)
+        except Exception:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+        return {"content": SUPERTWINS_MANAGE_DELETE_CANCEL_MESSAGE, "components": []}
+
+    def _apply_action(
+        self,
+        token: str,
+        pending: Mapping[str, object],
+        *,
+        action: str,
+        watchlist_path: Optional[str],
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        group_id = str(pending.get("group_id") or "").strip()
+        member_work_ids = [str(value).strip() for value in pending.get("member_work_ids") or [] if str(value).strip()]
+        if not group_id or not member_work_ids:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        original_state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        original_watchlist = _call_loader(self.watchlist_loader, watchlist_path, backend=self.backend)
+
+        try:
+            updated_state = remove_group_members(original_state, group_id, member_work_ids)
+            updated_state = prune_empty_groups(updated_state)
+        except ValueError:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        if action == "keep_hidden":
+            try:
+                updated_watchlist = _update_hidden_flags(original_watchlist, member_work_ids, hidden=True)
+            except Exception:
+                return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+            message = SUPERTWINS_MANAGE_KEEP_HIDDEN_MESSAGE
+        elif action == "unhide":
+            try:
+                updated_watchlist = _update_hidden_flags(original_watchlist, member_work_ids, hidden=False)
+            except Exception:
+                return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+            message = SUPERTWINS_MANAGE_UNHIDE_MESSAGE
+        else:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        cleaned_state = clear_pending_action(updated_state, token)
+        try:
+            _call_saver(self.watchlist_saver, updated_watchlist, watchlist_path, backend=self.backend)
+            _call_saver(self.state_saver, cleaned_state, state_path, backend=self.backend)
+        except Exception as exc:
+            try:
+                _call_saver(self.watchlist_saver, original_watchlist, watchlist_path, backend=self.backend)
+            except Exception:
+                pass
+            try:
+                _call_saver(self.state_saver, original_state, state_path, backend=self.backend)
+            except Exception:
+                pass
+            return {"content": f"supertwins 操作に失敗しました: {exc}", "components": []}
+
+        return {"content": message, "components": []}
+
+    def _delete_action(
+        self,
+        token: str,
+        pending: Mapping[str, object],
+        *,
+        watchlist_path: Optional[str],
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        group_id = str(pending.get("group_id") or "").strip()
+        member_work_ids = [str(value).strip() for value in pending.get("member_work_ids") or [] if str(value).strip()]
+        if not group_id or not member_work_ids:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        original_state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        original_watchlist = _call_loader(self.watchlist_loader, watchlist_path, backend=self.backend)
+
+        try:
+            updated_state = remove_group_members(original_state, group_id, member_work_ids)
+            updated_state = prune_empty_groups(updated_state)
+            updated_watchlist, updated_state = _delete_subscriptions(original_watchlist, updated_state, member_work_ids)
+        except Exception:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        cleaned_state = clear_pending_action(updated_state, token)
+        try:
+            _call_saver(self.watchlist_saver, updated_watchlist, watchlist_path, backend=self.backend)
+            _call_saver(self.state_saver, cleaned_state, state_path, backend=self.backend)
+        except Exception as exc:
+            try:
+                _call_saver(self.watchlist_saver, original_watchlist, watchlist_path, backend=self.backend)
+            except Exception:
+                pass
+            try:
+                _call_saver(self.state_saver, original_state, state_path, backend=self.backend)
+            except Exception:
+                pass
+            return {"content": f"{SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE}\n削除に失敗しました: {exc}", "components": []}
+
+        return {"content": SUPERTWINS_MANAGE_DELETE_CONFIRM_MESSAGE, "components": []}

--- a/manga_watch/discord_supertwins_manage.py
+++ b/manga_watch/discord_supertwins_manage.py
@@ -22,6 +22,7 @@ SUPERTWINS_MANAGE_COMMAND = "supertwins-manage"
 SUPERTWINS_MANAGE_COMPONENT_PREFIX = "supertwins_manage:"
 SUPERTWINS_MANAGE_GROUP_SELECT = "supertwins_manage_group_select"
 SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}members:"
+SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}members_page:"
 SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}action:"
 SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}confirm_delete:"
 SUPERTWINS_MANAGE_CANCEL_PREFIX = f"{SUPERTWINS_MANAGE_COMPONENT_PREFIX}cancel:"
@@ -108,10 +109,21 @@ def _group_options(groups: List[Dict[str, object]]) -> List[Dict[str, str]]:
     return options
 
 
-def _member_options(state: Mapping[str, object], group_id: str) -> List[Dict[str, str]]:
+def _member_page_options(
+    state: Mapping[str, object],
+    group_id: str,
+    *,
+    page: int,
+) -> tuple[List[Dict[str, str]], int, int]:
+    members = list_group_members(state, group_id)
+    page_count = max((len(members) + MAX_OPTIONS_PER_PAGE - 1) // MAX_OPTIONS_PER_PAGE, 1)
+    page_index = min(max(int(page), 0), page_count - 1)
+    start = page_index * MAX_OPTIONS_PER_PAGE
+    page_members = members[start : start + MAX_OPTIONS_PER_PAGE]
+
     options: List[Dict[str, str]] = []
     works = _state_works(state)
-    for member_work_id in list_group_members(state, group_id)[:MAX_OPTIONS_PER_PAGE]:
+    for member_work_id in page_members:
         state_entry = works.get(member_work_id, {}) if isinstance(works, Mapping) else {}
         latest = state_entry.get("latest", {}) if isinstance(state_entry, Mapping) else {}
         if latest is None or not isinstance(latest, Mapping):
@@ -123,7 +135,54 @@ def _member_options(state: Mapping[str, object], group_id: str) -> List[Dict[str
                 "description": _truncate_component_text(member_work_id),
             }
         )
-    return options
+    return options, page_index, page_count
+
+
+def _member_page_components(
+    group_id: str,
+    member_options: List[Dict[str, str]],
+    *,
+    page_index: int,
+    page_count: int,
+) -> List[Dict[str, object]]:
+    components: List[Dict[str, object]] = [
+        {
+            "type": ACTION_ROW,
+            "components": [
+                {
+                    "type": STRING_SELECT_COMPONENT,
+                    "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}{group_id}",
+                    "placeholder": "解除する member を選択",
+                    "min_values": 1,
+                    "max_values": min(len(member_options), MAX_OPTIONS_PER_PAGE),
+                    "options": member_options,
+                }
+            ],
+        }
+    ]
+    if page_count > 1:
+        components.append(
+            {
+                "type": ACTION_ROW,
+                "components": [
+                    {
+                        "type": BUTTON_COMPONENT,
+                        "style": BUTTON_STYLE_SECONDARY,
+                        "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX}{group_id}:{max(page_index - 1, 0)}",
+                        "label": "Prev",
+                        "disabled": page_index == 0,
+                    },
+                    {
+                        "type": BUTTON_COMPONENT,
+                        "style": BUTTON_STYLE_PRIMARY,
+                        "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX}{group_id}:{min(page_index + 1, page_count - 1)}",
+                        "label": "Next",
+                        "disabled": page_index >= page_count - 1,
+                    },
+                ],
+            }
+        )
+    return components
 
 
 def _action_options() -> List[Dict[str, str]]:
@@ -300,6 +359,8 @@ class ManageSupertwinsCommandHandler:
         custom_id = str(data.get("custom_id") or "").strip()
         if custom_id == SUPERTWINS_MANAGE_GROUP_SELECT:
             return self._handle_group_selection(data, state_path=state_path)
+        if custom_id.startswith(SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX):
+            return self._handle_member_page(custom_id, state_path=state_path)
         if custom_id.startswith(SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX):
             return self._handle_member_selection(custom_id, data, state_path=state_path)
         if custom_id.startswith(SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX):
@@ -332,29 +393,53 @@ class ManageSupertwinsCommandHandler:
 
         state = _call_loader(self.state_loader, state_path, backend=self.backend)
         try:
-            member_options = _member_options(state, group_id)
+            member_options, page_index, page_count = _member_page_options(state, group_id, page=0)
         except ValueError:
             return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
         if not member_options:
             return {"content": "この group には member がありません。", "components": []}
 
         return {
-            "content": SUPERTWINS_MANAGE_MEMBER_PROMPT,
-            "components": [
-                {
-                    "type": ACTION_ROW,
-                    "components": [
-                        {
-                            "type": STRING_SELECT_COMPONENT,
-                            "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}{group_id}",
-                            "placeholder": "解除する member を選択",
-                            "min_values": 1,
-                            "max_values": min(len(member_options), MAX_OPTIONS_PER_PAGE),
-                            "options": member_options,
-                        }
-                    ],
-                }
-            ],
+            "content": self._member_page_content(page_index=page_index, page_count=page_count),
+            "components": _member_page_components(
+                group_id,
+                member_options,
+                page_index=page_index,
+                page_count=page_count,
+            ),
+        }
+
+    def _handle_member_page(
+        self,
+        custom_id: str,
+        *,
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        token = _pending_token(custom_id, SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX)
+        group_id, _, raw_page = token.partition(":")
+        if not group_id or not raw_page:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+        try:
+            page = int(raw_page)
+        except ValueError:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+
+        state = _call_loader(self.state_loader, state_path, backend=self.backend)
+        try:
+            member_options, page_index, page_count = _member_page_options(state, group_id, page=page)
+        except ValueError:
+            return {"content": SUPERTWINS_MANAGE_COMPONENT_STALE_MESSAGE, "components": []}
+        if not member_options:
+            return {"content": "この group には member がありません。", "components": []}
+
+        return {
+            "content": self._member_page_content(page_index=page_index, page_count=page_count),
+            "components": _member_page_components(
+                group_id,
+                member_options,
+                page_index=page_index,
+                page_count=page_count,
+            ),
         }
 
     def _handle_member_selection(
@@ -402,6 +487,13 @@ class ManageSupertwinsCommandHandler:
                 }
             ],
         }
+
+    @staticmethod
+    def _member_page_content(*, page_index: int, page_count: int) -> str:
+        content = SUPERTWINS_MANAGE_MEMBER_PROMPT
+        if page_count > 1:
+            content += f"\nページ {page_index + 1}/{page_count}"
+        return content
 
     def _handle_action_selection(
         self,

--- a/manga_watch/discord_supertwins_search.py
+++ b/manga_watch/discord_supertwins_search.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Mapping, Optional
+
+from manga_watch.discord_text import series_label_for_snapshot
+from manga_watch.source_search import SearchResult, search_source, supported_search_sources
+from manga_watch.storage import load_state, load_watchlist, save_state, save_watchlist
+from manga_watch.supertwins import (
+    add_group_members,
+    create_group,
+    ensure_supertwins_state,
+    upsert_watchlist_entry,
+)
+from manga_watch.watchlist import build_watchlist_preview
+
+SUPERTWINS_SEARCH_COMMAND = "supertwins-search"
+SUPERTWINS_SEARCH_COMPONENT_PREFIX = "supertwins_search:"
+SUPERTWINS_SEARCH_WORK_SELECT = "supertwins_search_work_select"
+SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX = f"{SUPERTWINS_SEARCH_COMPONENT_PREFIX}results:"
+SUPERTWINS_SEARCH_EMPTY_MESSAGE = "まだ watchlist に登録された作品がありません。"
+SUPERTWINS_SEARCH_WORK_PROMPT = "他媒体候補を探したい作品を選んでください。"
+SUPERTWINS_SEARCH_RESULTS_PROMPT = "他媒体候補を選んでください。選択した作品は hidden で追加し、supertwins に登録します。"
+SUPERTWINS_SEARCH_RESULTS_EMPTY_MESSAGE = "他媒体候補が見つかりませんでした。"
+SUPERTWINS_SEARCH_STALE_MESSAGE = (
+    "画面の有効期限が切れたため、もう一度 `/supertwins-search` を実行してください。"
+)
+
+ACTION_ROW = 1
+STRING_SELECT_COMPONENT = 3
+MAX_OPTIONS_PER_PAGE = 25
+MAX_COMPONENT_TEXT = 100
+DEFAULT_SEARCH_LIMIT = 10
+
+
+def is_supertwins_search_component(custom_id: object) -> bool:
+    normalized = str(custom_id or "").strip()
+    return normalized.startswith(SUPERTWINS_SEARCH_COMPONENT_PREFIX) or normalized == SUPERTWINS_SEARCH_WORK_SELECT
+
+
+def _coerce_text(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _truncate_component_text(text: object, *, max_length: int = MAX_COMPONENT_TEXT) -> str:
+    normalized = str(text or "").strip()
+    if len(normalized) <= max_length:
+        return normalized
+    return normalized[: max_length - 1] + "…"
+
+
+def _state_works(state: Mapping[str, object]) -> Mapping[str, object]:
+    works = state.get("works", {})
+    return works if isinstance(works, Mapping) else {}
+
+
+def _watchlist_works(watchlist: Mapping[str, object]) -> List[Mapping[str, object]]:
+    works = watchlist.get("works", [])
+    return works if isinstance(works, list) else []
+
+
+def _watchlist_entry_by_id(watchlist: Mapping[str, object], work_id: str) -> Optional[Mapping[str, object]]:
+    for entry in _watchlist_works(watchlist):
+        if str(entry.get("id")) == work_id:
+            return entry
+    return None
+
+
+def _work_options(watchlist: Mapping[str, object], state: Mapping[str, object]) -> List[Dict[str, str]]:
+    options: List[Dict[str, str]] = []
+    works = _watchlist_works(watchlist)
+    runtime_works = _state_works(state)
+    for entry in works:
+        work_id = str(entry.get("id") or "").strip()
+        if not work_id:
+            continue
+        if entry.get("enabled") is False:
+            continue
+        latest = runtime_works.get(work_id, {}) if isinstance(runtime_works, Mapping) else {}
+        if not isinstance(latest, Mapping):
+            latest = {}
+        title = series_label_for_snapshot(work_id, latest.get("latest", latest))
+        source = str(entry.get("source") or "").strip() or "unknown"
+        hidden = "非表示" if bool(entry.get("hidden")) else "表示"
+        options.append(
+            {
+                "label": _truncate_component_text(f"{title}"),
+                "value": work_id,
+                "description": _truncate_component_text(f"{source} / {hidden}"),
+            }
+        )
+    return sorted(options, key=lambda option: option["label"])
+
+
+def _search_results(
+    root_source: str,
+    query: str,
+    *,
+    search_source_fn: Callable[..., List[SearchResult]],
+    search_limit: int = DEFAULT_SEARCH_LIMIT,
+) -> List[SearchResult]:
+    supported_sources = supported_search_sources()
+    results: List[SearchResult] = []
+    seen_urls = set()
+    for source in supported_sources:
+        if root_source and source == root_source:
+            continue
+        try:
+            source_results = search_source_fn(source, query, limit=search_limit)
+        except Exception:
+            continue
+        for result in source_results:
+            seed_url = str(result.seed_url).strip()
+            if not seed_url or seed_url in seen_urls:
+                continue
+            seen_urls.add(seed_url)
+            results.append(result)
+            if len(results) >= MAX_OPTIONS_PER_PAGE:
+                return results
+    return results
+
+
+def _search_result_options(results: List[SearchResult]) -> List[Dict[str, str]]:
+    options: List[Dict[str, str]] = []
+    for result in results[:MAX_OPTIONS_PER_PAGE]:
+        options.append(
+            {
+                "label": _truncate_component_text(result.title),
+                "value": result.seed_url,
+                "description": _truncate_component_text(result.source),
+            }
+        )
+    return options
+
+
+def _get_root_work(
+    watchlist: Mapping[str, object],
+    state: Mapping[str, object],
+    work_id: str,
+) -> tuple[Optional[Mapping[str, object]], Mapping[str, object]]:
+    entry = _watchlist_entry_by_id(watchlist, work_id)
+    if entry is None:
+        return None, {}
+    runtime_works = _state_works(state)
+    latest = runtime_works.get(work_id, {}) if isinstance(runtime_works, Mapping) else {}
+    if not isinstance(latest, Mapping):
+        latest = {}
+    return entry, latest
+
+
+def _ensure_group_members(
+    state: Mapping[str, object],
+    group_id: str,
+    member_work_ids: List[str],
+) -> Dict[str, object]:
+    updated_state = ensure_supertwins_state(state)
+    groups = updated_state["supertwins"]["groups"]
+    if group_id in groups:
+        return add_group_members(updated_state, group_id, member_work_ids)
+    return create_group(updated_state, group_id, member_work_ids)
+
+
+def _build_hidden_upsert_result(
+    watchlist: Mapping[str, object],
+    selected_url: str,
+) -> Dict[str, object]:
+    preview = build_watchlist_preview(selected_url)
+    return upsert_watchlist_entry(watchlist, preview, hidden=True)
+
+
+@dataclass
+class SearchSupertwinsCommandHandler:
+    search_source: Callable[..., List[SearchResult]] = search_source
+    watchlist_loader: Callable[..., Dict[str, object]] = load_watchlist
+    state_loader: Callable[..., Dict[str, object]] = load_state
+    watchlist_saver: Callable[..., None] = save_watchlist
+    state_saver: Callable[..., None] = save_state
+    backend: Optional[str] = None
+
+    def start(
+        self,
+        *,
+        watchlist_path: Optional[str] = None,
+        state_path: Optional[str] = None,
+    ) -> Dict[str, object]:
+        watchlist = self.watchlist_loader(watchlist_path, backend=self.backend)
+        state = self.state_loader(state_path, backend=self.backend)
+        options = _work_options(watchlist, state)
+        if not options:
+            return {"content": SUPERTWINS_SEARCH_EMPTY_MESSAGE, "components": []}
+
+        return {
+            "content": SUPERTWINS_SEARCH_WORK_PROMPT,
+            "components": [
+                {
+                    "type": ACTION_ROW,
+                    "components": [
+                        {
+                            "type": STRING_SELECT_COMPONENT,
+                            "custom_id": SUPERTWINS_SEARCH_WORK_SELECT,
+                            "placeholder": "起点の作品を選択",
+                            "min_values": 1,
+                            "max_values": 1,
+                            "options": options,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def handle_component(
+        self,
+        data: Mapping[str, object],
+        *,
+        watchlist_path: Optional[str] = None,
+        state_path: Optional[str] = None,
+    ) -> Dict[str, object]:
+        custom_id = str(data.get("custom_id") or "").strip()
+        if custom_id == SUPERTWINS_SEARCH_WORK_SELECT:
+            return self._handle_work_selection(
+                data,
+                watchlist_path=watchlist_path,
+                state_path=state_path,
+            )
+        if custom_id.startswith(SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX):
+            return self._handle_result_selection(
+                data,
+                watchlist_path=watchlist_path,
+                state_path=state_path,
+            )
+        return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
+
+    def _handle_work_selection(
+        self,
+        data: Mapping[str, object],
+        *,
+        watchlist_path: Optional[str],
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        selected_values = [str(value).strip() for value in data.get("values") or [] if str(value).strip()]
+        root_work_id = selected_values[0] if selected_values else ""
+        if not root_work_id:
+            return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
+
+        watchlist = self.watchlist_loader(watchlist_path, backend=self.backend)
+        state = self.state_loader(state_path, backend=self.backend)
+        root_entry, latest = _get_root_work(watchlist, state, root_work_id)
+        if root_entry is None:
+            return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
+
+        root_title = series_label_for_snapshot(root_work_id, latest.get("latest", latest))
+        root_source = str(root_entry.get("source") or "").strip()
+        results = _search_results(
+            root_source,
+            root_title,
+            search_source_fn=self.search_source,
+        )
+        if not results:
+            return {
+                "content": f"{root_title} の他媒体候補が見つかりませんでした。",
+                "components": [],
+            }
+
+        return {
+            "content": SUPERTWINS_SEARCH_RESULTS_PROMPT,
+            "components": [
+                {
+                    "type": ACTION_ROW,
+                    "components": [
+                        {
+                            "type": STRING_SELECT_COMPONENT,
+                            "custom_id": f"{SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX}{root_work_id}",
+                            "placeholder": "追加する候補を選択",
+                            "min_values": 1,
+                            "max_values": min(len(results), MAX_OPTIONS_PER_PAGE),
+                            "options": _search_result_options(results),
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def _handle_result_selection(
+        self,
+        data: Mapping[str, object],
+        *,
+        watchlist_path: Optional[str],
+        state_path: Optional[str],
+    ) -> Dict[str, object]:
+        root_work_id = str(data.get("custom_id") or "").strip()[len(SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX) :]
+        selected_urls = [str(value).strip() for value in data.get("values") or [] if str(value).strip()]
+        if not root_work_id or not selected_urls:
+            return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
+
+        watchlist = self.watchlist_loader(watchlist_path, backend=self.backend)
+        state = self.state_loader(state_path, backend=self.backend)
+        root_entry, latest = _get_root_work(watchlist, state, root_work_id)
+        if root_entry is None:
+            return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
+
+        original_watchlist = watchlist
+        original_state = state
+        updated_watchlist = dict(watchlist)
+        updated_state = dict(state)
+        selected_work_ids: List[str] = []
+        duplicate_count = 0
+        for selected_url in selected_urls:
+            try:
+                upsert_result = _build_hidden_upsert_result(updated_watchlist, selected_url)
+            except Exception:
+                return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
+            updated_watchlist = upsert_result["watchlist"]
+            selected_entry = upsert_result["entry"]
+            selected_work_id = str(selected_entry.get("id") or "").strip()
+            if not selected_work_id or selected_work_id == root_work_id:
+                continue
+            if upsert_result["action"] == "duplicate":
+                duplicate_count += 1
+            selected_work_ids.append(selected_work_id)
+
+        if not selected_work_ids:
+            return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
+
+        group_member_ids = [root_work_id, *selected_work_ids]
+        updated_state = _ensure_group_members(updated_state, root_work_id, group_member_ids)
+
+        try:
+            self.watchlist_saver(updated_watchlist, watchlist_path, backend=self.backend)
+            self.state_saver(updated_state, state_path, backend=self.backend)
+        except Exception as exc:
+            try:
+                self.watchlist_saver(original_watchlist, watchlist_path, backend=self.backend)
+            except Exception:
+                pass
+            try:
+                self.state_saver(original_state, state_path, backend=self.backend)
+            except Exception:
+                pass
+            raise RuntimeError(f"supertwins-search save failed: {exc}") from exc
+
+        root_title = series_label_for_snapshot(root_work_id, latest.get("latest", latest))
+        message = f"{root_title} に {len(selected_work_ids)} 件の他媒体候補を hidden で追加し、supertwins に登録しました。"
+        if duplicate_count:
+            message += f"\n{duplicate_count} 件は既存登録を hidden 化して group に追加しました。"
+        return {"content": message, "components": []}

--- a/manga_watch/discord_supertwins_search.py
+++ b/manga_watch/discord_supertwins_search.py
@@ -7,9 +7,8 @@ from manga_watch.discord_text import series_label_for_snapshot
 from manga_watch.source_search import SearchResult, search_source, supported_search_sources
 from manga_watch.storage import load_state, load_watchlist, save_state, save_watchlist
 from manga_watch.supertwins import (
-    add_group_members,
-    create_group,
     ensure_supertwins_state,
+    link_group_members,
     upsert_watchlist_entry,
 )
 from manga_watch.watchlist import build_watchlist_preview
@@ -153,14 +152,11 @@ def _get_root_work(
 
 def _ensure_group_members(
     state: Mapping[str, object],
-    group_id: str,
     member_work_ids: List[str],
 ) -> Dict[str, object]:
     updated_state = ensure_supertwins_state(state)
-    groups = updated_state["supertwins"]["groups"]
-    if group_id in groups:
-        return add_group_members(updated_state, group_id, member_work_ids)
-    return create_group(updated_state, group_id, member_work_ids)
+    linked_state, _group_id = link_group_members(updated_state, member_work_ids)
+    return linked_state
 
 
 def _build_hidden_upsert_result(
@@ -325,7 +321,7 @@ class SearchSupertwinsCommandHandler:
             return {"content": SUPERTWINS_SEARCH_STALE_MESSAGE, "components": []}
 
         group_member_ids = [root_work_id, *selected_work_ids]
-        updated_state = _ensure_group_members(updated_state, root_work_id, group_member_ids)
+        updated_state = _ensure_group_members(updated_state, group_member_ids)
 
         try:
             self.watchlist_saver(updated_watchlist, watchlist_path, backend=self.backend)

--- a/manga_watch/runner.py
+++ b/manga_watch/runner.py
@@ -17,6 +17,7 @@ from manga_watch.discord_outbound import (
     build_run_report_message,
     deliver_daily_notifications,
     enqueue_daily_notification,
+    filter_updates_for_daily_notifications,
     format_run_report_delivery_failure,
     pending_daily_notification_count,
 )
@@ -34,6 +35,7 @@ from manga_watch.storage import (
     DEFAULT_WATCHLIST_PATH,
     get_state_path,
     load_state,
+    load_watchlist,
     record_run_summary,
     save_state,
     state_notification_outbox,
@@ -595,11 +597,27 @@ def _run_discord_daily_phase(
     discord_config = config.discord_outbound_config
     assert discord_config is not None
 
+    filtered_updates = notify_updates
+    try:
+        watchlist = load_watchlist(config.watchlist_path)
+        filtered_updates = list(
+            filter_updates_for_daily_notifications(
+                notify_updates,
+                watchlist,
+            )
+        )
+    except Exception:
+        # The checker already succeeded against the configured watchlist.
+        # If reloading it for Discord-only hidden filtering fails here,
+        # preserve the existing delivery path instead of turning it into
+        # a new run failure.
+        filtered_updates = notify_updates
+
     # Discord daily delivery owns its own pending state and replays
     # it on the next run rather than through replay_outbox.py.
     enqueue_result = enqueue_daily_notification(
         state,
-        updates=notify_updates,
+        updates=filtered_updates,
         channel_id=discord_config.main_channel_id,
         now_ts=now,
         timezone_name=config.timezone_name,

--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from html import unescape
+from typing import Callable, Dict, List, Optional
+from urllib.parse import quote, urljoin, urlsplit, urlunsplit
+
+from manga_watch.sources.base import HttpClient, RequestsHttpClient
+
+SUPPORTED_SEARCH_SOURCES: tuple[str, ...] = ("champion-cross", "kakuyomu")
+DEFAULT_SEARCH_LIMIT = 10
+SEARCH_RESULT_LIMIT = 25
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    source: str
+    title: str
+    seed_url: str
+    subtitle: Optional[str] = None
+
+
+class UnsupportedSourceSearchError(ValueError):
+    pass
+
+
+def supported_search_sources() -> tuple[str, ...]:
+    return SUPPORTED_SEARCH_SOURCES
+
+
+def searchable_source_choices() -> List[Dict[str, str]]:
+    return [{"name": source, "value": source} for source in supported_search_sources()]
+
+
+def search_source(
+    source: str,
+    query: str,
+    *,
+    http_client: Optional[HttpClient] = None,
+    limit: int = DEFAULT_SEARCH_LIMIT,
+) -> List[SearchResult]:
+    normalized_source = str(source or "").strip()
+    normalized_query = str(query or "").strip()
+    if not normalized_source:
+        raise ValueError("search source is required")
+    if not normalized_query:
+        raise ValueError("search query is required")
+
+    searcher = _SEARCHERS.get(normalized_source)
+    if searcher is None:
+        raise UnsupportedSourceSearchError(f"unsupported search source: {normalized_source}")
+
+    client = http_client or RequestsHttpClient()
+    safe_limit = max(1, min(int(limit), SEARCH_RESULT_LIMIT))
+    return searcher(normalized_query, client, limit=safe_limit)
+
+
+def _search_kakuyomu(query: str, http_client: HttpClient, *, limit: int) -> List[SearchResult]:
+    html = http_client.get_text(f"https://kakuyomu.jp/search?q={quote(query)}")
+    return _extract_anchor_results(
+        html,
+        source="kakuyomu",
+        base_url="https://kakuyomu.jp",
+        href_pattern="/works/",
+        limit=limit,
+    )
+
+
+def _search_champion_cross(query: str, http_client: HttpClient, *, limit: int) -> List[SearchResult]:
+    html = http_client.get_text(f"https://championcross.jp/search?keyword={quote(query)}")
+    results: List[SearchResult] = []
+    seen_urls = set()
+    for match in re.finditer(r'<a\b[^>]*href="([^"]+)"[^>]*>(.*?)</a>', html, re.I | re.S):
+        href = unescape(match.group(1)).replace("\\/", "/")
+        if "/series/" not in href:
+            continue
+        title = ""
+        alt_match = re.search(r'alt="([^"]+)"', match.group(2), re.I | re.S)
+        if alt_match:
+            title = _normalize_anchor_text(alt_match.group(1))
+            title = re.sub(r"【.*$", "", title).strip()
+        if not title:
+            title = _normalize_anchor_text(match.group(2))
+        if not title:
+            continue
+        seed_url = _normalize_result_url(urljoin("https://championcross.jp", href))
+        if seed_url in seen_urls:
+            continue
+        seen_urls.add(seed_url)
+        results.append(
+            SearchResult(
+                source="champion-cross",
+                title=title,
+                seed_url=seed_url,
+                subtitle="champion-cross",
+            )
+        )
+        if len(results) >= limit:
+            break
+    return results
+
+
+def _extract_anchor_results(
+    html_text: str,
+    *,
+    source: str,
+    base_url: str,
+    href_pattern: str,
+    limit: int,
+) -> List[SearchResult]:
+    results: List[SearchResult] = []
+    seen_urls = set()
+    for match in re.finditer(r'<a\b[^>]*href="([^"]+)"[^>]*>(.*?)</a>', html_text, re.I | re.S):
+        href = unescape(match.group(1)).replace("\\/", "/")
+        if href_pattern not in href:
+            continue
+        if source == "kakuyomu" and "/episodes/" in href:
+            continue
+        title_attr_match = re.search(r'title="([^"]+)"', match.group(0), re.I | re.S)
+        title = _normalize_anchor_text(title_attr_match.group(1) if title_attr_match else match.group(2))
+        if not title:
+            continue
+        seed_url = _normalize_result_url(urljoin(base_url, href))
+        if seed_url in seen_urls:
+            continue
+        seen_urls.add(seed_url)
+        results.append(
+            SearchResult(
+                source=source,
+                title=title,
+                seed_url=seed_url,
+                subtitle=source,
+            )
+        )
+        if len(results) >= limit:
+            break
+    return results
+
+
+def _normalize_anchor_text(text: str) -> str:
+    normalized = re.sub(r"<[^>]+>", "", text or "")
+    normalized = unescape(re.sub(r"\s+", " ", normalized)).strip()
+    normalized = re.sub(r"^最新UP!?\s*", "", normalized)
+    return normalized
+
+
+def _normalize_result_url(url: str) -> str:
+    parts = urlsplit(url)
+    normalized = urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    return normalized.rstrip("/")
+
+
+_SEARCHERS: Dict[str, Callable[..., List[SearchResult]]] = {
+    "champion-cross": _search_champion_cross,
+    "kakuyomu": _search_kakuyomu,
+}

--- a/manga_watch/storage.py
+++ b/manga_watch/storage.py
@@ -259,6 +259,9 @@ def normalize_watchlist_entry(entry: Mapping[str, object]) -> Dict[str, object]:
     enabled = entry.get("enabled")
     if not isinstance(enabled, bool):
         raise ValueError(f"watchlist entry {work_id} enabled must be boolean")
+    hidden = entry.get("hidden", False)
+    if not isinstance(hidden, bool):
+        raise ValueError(f"watchlist entry {work_id} hidden must be boolean")
     policy = normalize_notification_policy(entry.get("notification_policy"), work_id)
     history_retention = normalize_optional_history_retention(
         entry.get("history_retention"),
@@ -270,6 +273,7 @@ def normalize_watchlist_entry(entry: Mapping[str, object]) -> Dict[str, object]:
         "source": source,
         "seed_url": seed_url,
         "enabled": enabled,
+        "hidden": hidden,
         "notification_policy": policy,
     }
     if history_retention is not None:

--- a/manga_watch/supertwins.py
+++ b/manga_watch/supertwins.py
@@ -1,0 +1,349 @@
+from copy import deepcopy
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+SUPERTWINS_STATE_KEY = "supertwins"
+SUPERTWINS_GROUPS_KEY = "groups"
+SUPERTWINS_MEMBER_IDS_KEY = "member_work_ids"
+SUPERTWINS_PENDING_ACTIONS_KEY = "pending_actions"
+
+
+def ensure_supertwins_state(state: Mapping[str, object]) -> Dict[str, object]:
+    updated = dict(state)
+    updated[SUPERTWINS_STATE_KEY] = _normalize_supertwins_container(
+        state.get(SUPERTWINS_STATE_KEY)
+    )
+    return updated
+
+
+def create_group(
+    state: Mapping[str, object],
+    group_id: str,
+    member_work_ids: Iterable[object],
+) -> Dict[str, object]:
+    normalized_group_id = _normalize_group_id(group_id)
+    updated = ensure_supertwins_state(state)
+    groups = _copy_groups(updated)
+    if normalized_group_id in groups:
+        raise ValueError(f"supertwins group already exists: {normalized_group_id}")
+    groups[normalized_group_id] = {
+        SUPERTWINS_MEMBER_IDS_KEY: _normalize_member_work_ids(member_work_ids),
+    }
+    return _with_groups(updated, groups)
+
+
+def add_group_members(
+    state: Mapping[str, object],
+    group_id: str,
+    member_work_ids: Iterable[object],
+) -> Dict[str, object]:
+    normalized_group_id = _normalize_group_id(group_id)
+    updated = ensure_supertwins_state(state)
+    groups = _copy_groups(updated)
+    group = _copy_group(groups, normalized_group_id)
+    merged_member_ids = sorted(
+        set(group[SUPERTWINS_MEMBER_IDS_KEY]).union(
+            _normalize_member_work_ids(member_work_ids)
+        )
+    )
+    group[SUPERTWINS_MEMBER_IDS_KEY] = merged_member_ids
+    groups[normalized_group_id] = group
+    return _with_groups(updated, groups)
+
+
+def remove_group_members(
+    state: Mapping[str, object],
+    group_id: str,
+    member_work_ids: Iterable[object],
+) -> Dict[str, object]:
+    normalized_group_id = _normalize_group_id(group_id)
+    updated = ensure_supertwins_state(state)
+    groups = _copy_groups(updated)
+    group = _copy_group(groups, normalized_group_id)
+    removed_member_ids = set(_normalize_member_work_ids(member_work_ids))
+    group[SUPERTWINS_MEMBER_IDS_KEY] = [
+        member_id
+        for member_id in group[SUPERTWINS_MEMBER_IDS_KEY]
+        if member_id not in removed_member_ids
+    ]
+    groups[normalized_group_id] = group
+    return _with_groups(updated, groups)
+
+
+def prune_empty_groups(state: Mapping[str, object]) -> Dict[str, object]:
+    updated = ensure_supertwins_state(state)
+    groups = _copy_groups(updated)
+    pruned_groups = {
+        group_id: group
+        for group_id, group in groups.items()
+        if group[SUPERTWINS_MEMBER_IDS_KEY]
+    }
+    return _with_groups(updated, pruned_groups)
+
+
+def prune_small_groups(state: Mapping[str, object], *, minimum_members: int = 2) -> Dict[str, object]:
+    updated = ensure_supertwins_state(state)
+    groups = _copy_groups(updated)
+    pruned_groups = {
+        group_id: group
+        for group_id, group in groups.items()
+        if len(group[SUPERTWINS_MEMBER_IDS_KEY]) >= minimum_members
+    }
+    return _with_groups(updated, pruned_groups)
+
+
+def list_groups(state: Mapping[str, object]) -> List[Dict[str, object]]:
+    groups = ensure_supertwins_state(state)[SUPERTWINS_STATE_KEY][SUPERTWINS_GROUPS_KEY]
+    return [
+        {
+            "group_id": group_id,
+            SUPERTWINS_MEMBER_IDS_KEY: list(group[SUPERTWINS_MEMBER_IDS_KEY]),
+        }
+        for group_id, group in sorted(groups.items())
+    ]
+
+
+def list_group_members(state: Mapping[str, object], group_id: str) -> List[str]:
+    normalized_group_id = _normalize_group_id(group_id)
+    groups = ensure_supertwins_state(state)[SUPERTWINS_STATE_KEY][SUPERTWINS_GROUPS_KEY]
+    if normalized_group_id not in groups:
+        raise ValueError(f"supertwins group not found: {normalized_group_id}")
+    return list(groups[normalized_group_id][SUPERTWINS_MEMBER_IDS_KEY])
+
+
+def upsert_watchlist_entry(
+    watchlist: Mapping[str, object],
+    entry: Mapping[str, object],
+    *,
+    hidden: bool,
+) -> Dict[str, object]:
+    if not isinstance(watchlist, Mapping):
+        raise ValueError("watchlist must be an object")
+    if not isinstance(entry, Mapping):
+        raise ValueError("watchlist entry must be an object")
+
+    normalized_entry = deepcopy(dict(entry))
+    work_id = str(normalized_entry.get("id") or "").strip()
+    if not work_id:
+        raise ValueError("watchlist entry missing id")
+
+    works = [deepcopy(item) for item in watchlist.get("works", [])]
+    existing_index = _find_watchlist_entry_index(works, work_id)
+    existing: Optional[Dict[str, object]] = None
+    if existing_index is None:
+        normalized_entry["hidden"] = hidden
+        works.append(normalized_entry)
+        action = "added"
+    else:
+        existing = deepcopy(works[existing_index])
+        merged = deepcopy(existing)
+        merged.update(normalized_entry)
+        merged["hidden"] = hidden
+        works[existing_index] = merged
+        normalized_entry = merged
+        action = "duplicate"
+
+    updated = dict(watchlist)
+    updated["works"] = works
+    return {
+        "watchlist": updated,
+        "action": action,
+        "entry": deepcopy(normalized_entry),
+        "existing": existing,
+    }
+
+
+def groups_for_member(state: Mapping[str, object], work_id: object) -> List[str]:
+    normalized_work_id = str(work_id or "").strip()
+    if not normalized_work_id:
+        return []
+    groups = ensure_supertwins_state(state)[SUPERTWINS_STATE_KEY][SUPERTWINS_GROUPS_KEY]
+    return [
+        group_id
+        for group_id, group in sorted(groups.items())
+        if normalized_work_id in group[SUPERTWINS_MEMBER_IDS_KEY]
+    ]
+
+
+def link_group_members(
+    state: Mapping[str, object],
+    member_work_ids: Iterable[object],
+) -> tuple[Dict[str, object], str]:
+    normalized_member_ids = _normalize_member_work_ids(member_work_ids)
+    if len(normalized_member_ids) < 2:
+        raise ValueError("supertwins requires at least 2 members")
+
+    updated = ensure_supertwins_state(state)
+    groups = _copy_groups(updated)
+    matching_group_ids = sorted(
+        {
+            group_id
+            for member_id in normalized_member_ids
+            for group_id in groups_for_member(updated, member_id)
+        }
+    )
+    if matching_group_ids:
+        primary_group_id = matching_group_ids[0]
+        merged_member_ids = set(normalized_member_ids)
+        for group_id in matching_group_ids:
+            merged_member_ids.update(groups[group_id][SUPERTWINS_MEMBER_IDS_KEY])
+        groups[primary_group_id][SUPERTWINS_MEMBER_IDS_KEY] = sorted(merged_member_ids)
+        for group_id in matching_group_ids[1:]:
+            groups.pop(group_id, None)
+        return _with_groups(updated, groups), primary_group_id
+
+    group_id = _next_group_id(groups)
+    groups[group_id] = {SUPERTWINS_MEMBER_IDS_KEY: normalized_member_ids}
+    return _with_groups(updated, groups), group_id
+
+
+def set_pending_action(
+    state: Mapping[str, object],
+    token: str,
+    payload: Mapping[str, object],
+) -> Dict[str, object]:
+    normalized_token = str(token or "").strip()
+    if not normalized_token:
+        raise ValueError("supertwins pending action token must be a non-empty string")
+    updated = ensure_supertwins_state(state)
+    container = dict(updated[SUPERTWINS_STATE_KEY])
+    pending_actions = dict(container.get(SUPERTWINS_PENDING_ACTIONS_KEY) or {})
+    pending_actions[normalized_token] = deepcopy(dict(payload))
+    container[SUPERTWINS_PENDING_ACTIONS_KEY] = pending_actions
+    updated[SUPERTWINS_STATE_KEY] = container
+    return updated
+
+
+def get_pending_action(state: Mapping[str, object], token: str) -> Dict[str, object]:
+    normalized_token = str(token or "").strip()
+    container = ensure_supertwins_state(state)[SUPERTWINS_STATE_KEY]
+    pending_actions = container.get(SUPERTWINS_PENDING_ACTIONS_KEY) or {}
+    if not isinstance(pending_actions, Mapping):
+        raise ValueError("state.supertwins.pending_actions must be an object")
+    payload = pending_actions.get(normalized_token)
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"supertwins pending action not found: {normalized_token}")
+    return deepcopy(dict(payload))
+
+
+def clear_pending_action(state: Mapping[str, object], token: str) -> Dict[str, object]:
+    normalized_token = str(token or "").strip()
+    updated = ensure_supertwins_state(state)
+    container = dict(updated[SUPERTWINS_STATE_KEY])
+    pending_actions = dict(container.get(SUPERTWINS_PENDING_ACTIONS_KEY) or {})
+    pending_actions.pop(normalized_token, None)
+    if pending_actions:
+        container[SUPERTWINS_PENDING_ACTIONS_KEY] = pending_actions
+    else:
+        container.pop(SUPERTWINS_PENDING_ACTIONS_KEY, None)
+    updated[SUPERTWINS_STATE_KEY] = container
+    return updated
+
+
+def _with_groups(
+    state: Mapping[str, object],
+    groups: Mapping[str, Mapping[str, object]],
+) -> Dict[str, object]:
+    updated = dict(state)
+    container = dict(updated[SUPERTWINS_STATE_KEY])
+    container[SUPERTWINS_GROUPS_KEY] = dict(sorted(groups.items()))
+    updated[SUPERTWINS_STATE_KEY] = container
+    return updated
+
+
+def _copy_groups(state: Mapping[str, object]) -> Dict[str, Dict[str, object]]:
+    container = state[SUPERTWINS_STATE_KEY]
+    groups = container[SUPERTWINS_GROUPS_KEY]
+    return {group_id: deepcopy(group) for group_id, group in groups.items()}
+
+
+def _copy_group(
+    groups: MutableMapping[str, Dict[str, object]],
+    group_id: str,
+) -> Dict[str, object]:
+    if group_id not in groups:
+        raise ValueError(f"supertwins group not found: {group_id}")
+    return deepcopy(groups[group_id])
+
+
+def _find_watchlist_entry_index(
+    works: Iterable[Mapping[str, object]],
+    work_id: str,
+) -> Optional[int]:
+    for index, entry in enumerate(works):
+        if str(entry.get("id")) == work_id:
+            return index
+    return None
+
+
+def _normalize_supertwins_container(container: object) -> Dict[str, object]:
+    if container is None:
+        return {SUPERTWINS_GROUPS_KEY: {}}
+    if not isinstance(container, Mapping):
+        raise ValueError("state.supertwins must be an object")
+
+    groups = container.get(SUPERTWINS_GROUPS_KEY, {})
+    if not isinstance(groups, Mapping):
+        raise ValueError("state.supertwins.groups must be an object")
+
+    normalized = {}
+    for key, value in container.items():
+        if key == SUPERTWINS_GROUPS_KEY:
+            continue
+        if key == SUPERTWINS_PENDING_ACTIONS_KEY:
+            if not isinstance(value, Mapping):
+                raise ValueError("state.supertwins.pending_actions must be an object")
+            normalized[key] = {str(token): deepcopy(dict(payload)) for token, payload in value.items() if isinstance(payload, Mapping)}
+            continue
+        if value is None:
+            continue
+        normalized[key] = deepcopy(value)
+    normalized[SUPERTWINS_GROUPS_KEY] = {
+        group_id: _normalize_group_entry(group_id, entry)
+        for group_id, entry in sorted(groups.items())
+    }
+    return normalized
+
+
+def _normalize_group_entry(group_id: object, entry: object) -> Dict[str, object]:
+    normalized_group_id = _normalize_group_id(group_id)
+    if not isinstance(entry, Mapping):
+        raise ValueError(f"state.supertwins.groups.{normalized_group_id} must be an object")
+
+    normalized = {}
+    for key, value in entry.items():
+        if key == SUPERTWINS_MEMBER_IDS_KEY or value is None:
+            continue
+        normalized[key] = deepcopy(value)
+    normalized[SUPERTWINS_MEMBER_IDS_KEY] = _normalize_member_work_ids(
+        entry.get(SUPERTWINS_MEMBER_IDS_KEY, [])
+    )
+    return normalized
+
+
+def _normalize_group_id(group_id: object) -> str:
+    normalized_group_id = str(group_id or "").strip()
+    if not normalized_group_id:
+        raise ValueError("supertwins group_id must be a non-empty string")
+    return normalized_group_id
+
+
+def _normalize_member_work_ids(member_work_ids: Iterable[object]) -> List[str]:
+    if member_work_ids is None:
+        return []
+
+    normalized_member_ids = set()
+    for member_work_id in member_work_ids:
+        normalized_member_id = str(member_work_id or "").strip()
+        if normalized_member_id:
+            normalized_member_ids.add(normalized_member_id)
+    return sorted(normalized_member_ids)
+
+
+def _next_group_id(groups: Mapping[str, Mapping[str, object]]) -> str:
+    index = 1
+    while True:
+        candidate = f"supertwins-{index}"
+        if candidate not in groups:
+            return candidate
+        index += 1

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -174,6 +174,7 @@ def add_watchlist_url(
     url: str,
     *,
     watchlist_path: Optional[str] = None,
+    hidden: bool = False,
     adapters: Optional[Sequence[SourceAdapter]] = None,
     http_client: Optional[HttpClient] = None,
 ) -> Dict[str, object]:
@@ -205,6 +206,7 @@ def add_watchlist_url(
         }
 
     works = list(watchlist["works"])
+    entry["hidden"] = hidden
     works.append(entry)
     updated_watchlist = {"version": watchlist["version"], "works": works}
     try:

--- a/nacl_test_support.py
+++ b/nacl_test_support.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import sys
+import types
+from dataclasses import dataclass
+from typing import Final
+
+
+def _install_google_fallback() -> None:
+    google = types.ModuleType("google")
+    google_auth = types.ModuleType("google.auth")
+    google_auth_transport = types.ModuleType("google.auth.transport")
+    google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
+
+    class _AuthorizedSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    google_auth.default = lambda scopes=None: (object(), None)
+    google_auth_transport_requests.AuthorizedSession = _AuthorizedSession
+    google.auth = google_auth
+    google_auth.transport = google_auth_transport
+    google_auth_transport.requests = google_auth_transport_requests
+
+    sys.modules["google"] = google
+    sys.modules["google.auth"] = google_auth
+    sys.modules["google.auth.transport"] = google_auth_transport
+    sys.modules["google.auth.transport.requests"] = google_auth_transport_requests
+
+
+def _install_fallback() -> tuple[type[Exception], type[object], type[object]]:
+    nacl = types.ModuleType("nacl")
+    nacl_exceptions = types.ModuleType("nacl.exceptions")
+    nacl_signing = types.ModuleType("nacl.signing")
+
+    class BadSignatureError(Exception):
+        pass
+
+    @dataclass(frozen=True)
+    class _SignedMessage:
+        message: bytes
+        signature: bytes
+
+    class VerifyKey:
+        def __init__(self, key: bytes):
+            self._key = bytes(key)
+
+        def encode(self) -> bytes:
+            return self._key
+
+        def verify(self, message: bytes, signature: bytes):
+            expected = hashlib.sha512(self._key + bytes(message)).digest()
+            if bytes(signature) != expected:
+                raise BadSignatureError("Signature was forged or corrupt")
+            return bytes(message)
+
+    class SigningKey:
+        def __init__(self, seed: bytes):
+            self._seed = bytes(seed)
+
+        @classmethod
+        def generate(cls):
+            return cls(secrets.token_bytes(32))
+
+        @property
+        def verify_key(self):
+            return VerifyKey(self._seed)
+
+        def sign(self, message: bytes):
+            return _SignedMessage(
+                message=bytes(message),
+                signature=hashlib.sha512(self._seed + bytes(message)).digest(),
+            )
+
+    nacl_exceptions.BadSignatureError = BadSignatureError
+    nacl_signing.VerifyKey = VerifyKey
+    nacl_signing.SigningKey = SigningKey
+    nacl.exceptions = nacl_exceptions
+    nacl.signing = nacl_signing
+
+    sys.modules["nacl"] = nacl
+    sys.modules["nacl.exceptions"] = nacl_exceptions
+    sys.modules["nacl.signing"] = nacl_signing
+    return BadSignatureError, VerifyKey, SigningKey
+
+
+try:
+    import google.auth  # type: ignore[import-not-found]
+except Exception:
+    _install_google_fallback()
+
+try:
+    from nacl.exceptions import BadSignatureError as _BadSignatureError
+    from nacl.signing import SigningKey as _SigningKey
+    from nacl.signing import VerifyKey as _VerifyKey
+except Exception:
+    _BadSignatureError, _VerifyKey, _SigningKey = _install_fallback()
+
+BadSignatureError: Final = _BadSignatureError
+VerifyKey: Final = _VerifyKey
+SigningKey: Final = _SigningKey

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -287,6 +287,7 @@ class CheckTests(unittest.TestCase):
         self.assertEqual("kakuyomu:123", entry["id"])
         self.assertEqual("kakuyomu", entry["source"])
         self.assertTrue(entry["enabled"])
+        self.assertFalse(entry["hidden"])
         self.assertEqual(
             {"mode": "all", "allowed_update_types": None},
             entry["notification_policy"],

--- a/tests/test_discord_command_registration.py
+++ b/tests/test_discord_command_registration.py
@@ -5,6 +5,9 @@ from unittest import mock
 from manga_watch.discord_fetch import FETCH_COMMAND
 from manga_watch.discord_latest import LATEST_COMMAND
 from manga_watch.discord_remove import REMOVE_COMMAND
+from manga_watch.discord_search import SEARCH_COMMAND
+from manga_watch.discord_supertwins_manage import SUPERTWINS_MANAGE_COMMAND
+from manga_watch.discord_supertwins_search import SUPERTWINS_SEARCH_COMMAND
 
 
 class FakeResponse:
@@ -38,13 +41,21 @@ class FakeRequestsSession:
 
 
 class DiscordCommandRegistrationTests(unittest.TestCase):
-    def test_default_command_definitions_include_add_and_remove(self):
+    def test_default_command_definitions_include_supertwins_commands(self):
         from manga_watch.discord_command_registration import default_interaction_commands
 
         commands = default_interaction_commands()
 
         self.assertEqual(
-            [LATEST_COMMAND, FETCH_COMMAND, "add", REMOVE_COMMAND],
+            [
+                LATEST_COMMAND,
+                FETCH_COMMAND,
+                "add",
+                SEARCH_COMMAND,
+                REMOVE_COMMAND,
+                SUPERTWINS_SEARCH_COMMAND,
+                SUPERTWINS_MANAGE_COMMAND,
+            ],
             [command["name"] for command in commands],
         )
         add_command = commands[2]
@@ -60,6 +71,16 @@ class DiscordCommandRegistrationTests(unittest.TestCase):
             ],
             add_command["options"],
         )
+        self.assertEqual(
+            "既存作品を起点に他媒体候補を探して supertwins を作成します。",
+            commands[5]["description"],
+        )
+        self.assertNotIn("options", commands[5])
+        self.assertEqual(
+            "既存の supertwins を確認して誤登録を解除します。",
+            commands[6]["description"],
+        )
+        self.assertNotIn("options", commands[6])
 
     def test_ensure_registered_from_env_uses_guild_registration_when_guild_id_is_present(self):
         from manga_watch.discord_command_registration import ensure_commands_registered_from_env

--- a/tests/test_discord_command_registration_search.py
+++ b/tests/test_discord_command_registration_search.py
@@ -1,0 +1,63 @@
+import unittest
+
+from manga_watch.discord_fetch import FETCH_COMMAND
+from manga_watch.discord_latest import LATEST_COMMAND
+from manga_watch.discord_remove import REMOVE_COMMAND
+from manga_watch.discord_search import SEARCH_COMMAND
+
+
+class DiscordSearchCommandRegistrationTests(unittest.TestCase):
+    def test_default_command_definitions_include_search(self):
+        from manga_watch.discord_command_registration import default_interaction_commands
+
+        commands = default_interaction_commands()
+
+        self.assertEqual(
+            [
+                LATEST_COMMAND,
+                FETCH_COMMAND,
+                "add",
+                SEARCH_COMMAND,
+                REMOVE_COMMAND,
+                "supertwins-search",
+                "supertwins-manage",
+            ],
+            [command["name"] for command in commands],
+        )
+        search_command = commands[3]
+        self.assertEqual("媒体ごとに作品名で検索します。", search_command["description"])
+        self.assertEqual(
+            [
+                {
+                    "type": 3,
+                    "name": "source",
+                    "description": "検索したい媒体",
+                    "required": True,
+                    "choices": [
+                        {"name": "champion-cross", "value": "champion-cross"},
+                        {"name": "kakuyomu", "value": "kakuyomu"},
+                    ],
+                },
+                {
+                    "type": 3,
+                    "name": "query",
+                    "description": "検索したい文字列",
+                    "required": True,
+                },
+                {
+                    "type": 3,
+                    "name": "visibility",
+                    "description": "watchlist に追加するときの表示状態",
+                    "required": False,
+                    "choices": [
+                        {"name": "visible", "value": "visible"},
+                        {"name": "hidden", "value": "hidden"},
+                    ],
+                },
+            ],
+            search_command["options"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discord_interactions.py
+++ b/tests/test_discord_interactions.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from unittest import mock
 
-from nacl.signing import SigningKey
+from nacl_test_support import SigningKey
 
 from manga_watch.discord_interactions import (
     CloudRunJobFetchDispatcher,

--- a/tests/test_discord_interactions_search.py
+++ b/tests/test_discord_interactions_search.py
@@ -1,0 +1,147 @@
+import json
+import sys
+import types
+import unittest
+
+
+google = types.ModuleType("google")
+google_auth = types.ModuleType("google.auth")
+google_auth_transport = types.ModuleType("google.auth.transport")
+google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
+
+
+class _AuthorizedSession:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+google_auth.default = lambda scopes=None: (object(), None)
+google_auth_transport_requests.AuthorizedSession = _AuthorizedSession
+google.auth = google_auth
+sys.modules["google"] = google
+sys.modules["google.auth"] = google_auth
+sys.modules["google.auth.transport"] = google_auth_transport
+sys.modules["google.auth.transport.requests"] = google_auth_transport_requests
+
+nacl = types.ModuleType("nacl")
+nacl_exceptions = types.ModuleType("nacl.exceptions")
+nacl_signing = types.ModuleType("nacl.signing")
+
+
+class _BadSignatureError(Exception):
+    pass
+
+
+class _VerifyKey:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def verify(self, *args, **kwargs):
+        return True
+
+
+nacl_exceptions.BadSignatureError = _BadSignatureError
+nacl_signing.VerifyKey = _VerifyKey
+sys.modules["nacl"] = nacl
+sys.modules["nacl.exceptions"] = nacl_exceptions
+sys.modules["nacl.signing"] = nacl_signing
+
+from manga_watch.discord_interactions import DiscordInteractionService
+from manga_watch.discord_search import SEARCH_COMMAND
+
+
+class RecordingSearchHandler:
+    def __init__(self):
+        self.start_calls = []
+        self.component_calls = []
+
+    def start(self, **kwargs):
+        self.start_calls.append(kwargs)
+        return {
+            "content": "検索結果を選んでください。",
+            "components": [
+                {
+                    "type": 1,
+                    "components": [
+                        {
+                            "type": 3,
+                            "custom_id": "search_select:visible",
+                            "options": [{"label": "作品A", "value": "https://example.com/a"}],
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def handle_component(self, data, **kwargs):
+        self.component_calls.append({"data": data, **kwargs})
+        return {"content": "追加しました: 作品A", "components": []}
+
+
+class RecordingFetchDispatcher:
+    def dispatch(self):
+        return {"message": "fetch ok"}
+
+
+class DiscordInteractionSearchTests(unittest.TestCase):
+    def signed_command_payload(self, command_name):
+        return {
+            "type": 2,
+            "data": {
+                "name": command_name,
+                "options": [
+                    {"name": "source", "type": 3, "value": "champion-cross"},
+                    {"name": "query", "type": 3, "value": "まんが"},
+                ],
+            },
+        }
+
+    def test_search_command_routes_to_search_handler(self):
+        search_handler = RecordingSearchHandler()
+        service = DiscordInteractionService(
+            timezone_name="Asia/Tokyo",
+            fetch_dispatcher=RecordingFetchDispatcher(),
+            verification_disabled=True,
+            search_handler=search_handler,
+        )
+
+        response = service.handle_request(
+            method="POST",
+            path="/",
+            headers={},
+            body=json.dumps(self.signed_command_payload(SEARCH_COMMAND)).encode("utf-8"),
+        )
+
+        payload = json.loads(response.body)
+        self.assertEqual(4, payload["type"])
+        self.assertEqual(64, payload["data"]["flags"])
+        self.assertEqual("検索結果を選んでください。", payload["data"]["content"])
+        self.assertEqual("champion-cross", search_handler.start_calls[0]["source"])
+        self.assertEqual("まんが", search_handler.start_calls[0]["query"])
+
+    def test_search_component_routes_to_search_handler(self):
+        search_handler = RecordingSearchHandler()
+        service = DiscordInteractionService(
+            timezone_name="Asia/Tokyo",
+            fetch_dispatcher=RecordingFetchDispatcher(),
+            verification_disabled=True,
+            search_handler=search_handler,
+        )
+
+        response = service.handle_request(
+            method="POST",
+            path="/",
+            headers={},
+            body=json.dumps(
+                {"type": 3, "data": {"custom_id": "search_select:visible", "values": ["https://example.com/a"]}}
+            ).encode("utf-8"),
+        )
+
+        payload = json.loads(response.body)
+        self.assertEqual(7, payload["type"])
+        self.assertEqual("追加しました: 作品A", payload["data"]["content"])
+        self.assertEqual("search_select:visible", search_handler.component_calls[0]["data"]["custom_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discord_interactions_search.py
+++ b/tests/test_discord_interactions_search.py
@@ -1,50 +1,7 @@
 import json
-import sys
-import types
 import unittest
 
-
-google = types.ModuleType("google")
-google_auth = types.ModuleType("google.auth")
-google_auth_transport = types.ModuleType("google.auth.transport")
-google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
-
-
-class _AuthorizedSession:
-    def __init__(self, *args, **kwargs):
-        pass
-
-
-google_auth.default = lambda scopes=None: (object(), None)
-google_auth_transport_requests.AuthorizedSession = _AuthorizedSession
-google.auth = google_auth
-sys.modules["google"] = google
-sys.modules["google.auth"] = google_auth
-sys.modules["google.auth.transport"] = google_auth_transport
-sys.modules["google.auth.transport.requests"] = google_auth_transport_requests
-
-nacl = types.ModuleType("nacl")
-nacl_exceptions = types.ModuleType("nacl.exceptions")
-nacl_signing = types.ModuleType("nacl.signing")
-
-
-class _BadSignatureError(Exception):
-    pass
-
-
-class _VerifyKey:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def verify(self, *args, **kwargs):
-        return True
-
-
-nacl_exceptions.BadSignatureError = _BadSignatureError
-nacl_signing.VerifyKey = _VerifyKey
-sys.modules["nacl"] = nacl
-sys.modules["nacl.exceptions"] = nacl_exceptions
-sys.modules["nacl.signing"] = nacl_signing
+from nacl_test_support import SigningKey  # noqa: F401  # ensures nacl/google fallback is installed when needed
 
 from manga_watch.discord_interactions import DiscordInteractionService
 from manga_watch.discord_search import SEARCH_COMMAND

--- a/tests/test_discord_latest.py
+++ b/tests/test_discord_latest.py
@@ -147,6 +147,47 @@ class DiscordLatestTests(unittest.TestCase):
         self.assertNotIn("作品C", response)
         self.assertNotIn("孤児", response)
 
+    def test_build_latest_query_response_excludes_hidden_entries(self):
+        watchlist = self.make_watchlist(
+            [
+                {
+                    "id": "work-visible",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-visible",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+                {
+                    "id": "work-hidden",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-hidden",
+                    "enabled": True,
+                    "hidden": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+            ]
+        )
+        state = self.make_state(
+            {
+                "work-visible": {
+                    "latest": {"series_title": "表示作品", "episode_title": "第3話", "url": "https://example.com/visible"},
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                },
+                "work-hidden": {
+                    "latest": {"series_title": "非表示作品", "episode_title": "第9話", "url": "https://example.com/hidden"},
+                    "history": [],
+                    "health": {"consecutive_failures": 0},
+                },
+            },
+            last_run_at=1_700_000_000,
+        )
+
+        response = build_latest_query_response(watchlist, state, timezone_name="Asia/Tokyo")
+
+        self.assertIn("表示作品", response)
+        self.assertNotIn("非表示作品", response)
+
     def test_build_latest_query_response_returns_empty_message_when_all_works_are_unfetched(self):
         watchlist = self.make_watchlist(
             [

--- a/tests/test_discord_outbound.py
+++ b/tests/test_discord_outbound.py
@@ -9,6 +9,7 @@ from manga_watch.discord_outbound import (
     DiscordOutboundConfig,
     build_daily_notification_message,
     enqueue_daily_notification,
+    filter_updates_for_daily_notifications,
 )
 from manga_watch.storage import load_state, save_state
 
@@ -194,6 +195,39 @@ class DiscordOutboundTests(unittest.TestCase):
 
         self.assertEqual({"queued": False, "candidateUpdateCount": 0}, result)
         self.assertEqual([], state["discord_delivery"]["daily_notification"]["pending_messages"])
+
+    def test_filter_updates_for_daily_notifications_excludes_hidden_watchlist_entries(self):
+        updates = [
+            self.make_update(series="表示作品", latest_key="episode-visible"),
+            {
+                **self.make_update(series="非表示作品", latest_key="episode-hidden"),
+                "id": "work-hidden",
+            },
+        ]
+        watchlist = {
+            "version": 2,
+            "works": [
+                {
+                    "id": "work-1",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-1",
+                    "enabled": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+                {
+                    "id": "work-hidden",
+                    "source": "comic-walker",
+                    "seed_url": "https://example.com/work-hidden",
+                    "enabled": True,
+                    "hidden": True,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+            ],
+        }
+
+        filtered = filter_updates_for_daily_notifications(updates, watchlist)
+
+        self.assertEqual(["work-1"], [update["id"] for update in filtered])
 
     def test_discord_channel_client_posts_bot_message(self):
         session = FakeSession(responses=[FakeResponse(200)])

--- a/tests/test_discord_search.py
+++ b/tests/test_discord_search.py
@@ -101,6 +101,49 @@ class DiscordSearchTests(unittest.TestCase):
             response["components"][0]["components"][0]["options"],
         )
 
+    def test_start_truncates_option_text_and_tokenizes_long_urls(self):
+        long_title = "作品" + "あ" * 120
+        long_subtitle = "説明" + "い" * 120
+        long_url = "https://example.com/" + "x" * 180
+        search_source = FakeSearchSource(
+            [
+                SearchResult(
+                    source="champion-cross",
+                    title=long_title,
+                    seed_url=long_url,
+                    subtitle=long_subtitle,
+                )
+            ]
+        )
+        add_subscription = FakeAddSubscription()
+        handler = SearchCommandHandler(search_source=search_source, add_subscription=add_subscription)
+
+        response = handler.start(source="champion-cross", query="長い", watchlist_path="/tmp/watchlist.json")
+        option = response["components"][0]["components"][0]["options"][0]
+
+        self.assertLessEqual(len(option["label"]), 100)
+        self.assertLessEqual(len(option["value"]), 100)
+        self.assertLessEqual(len(option["description"]), 100)
+        self.assertNotEqual(long_url, option["value"])
+        self.assertTrue(option["value"].startswith("u:"))
+
+        add_response = handler.handle_component(
+            {"custom_id": "search_select:visible", "values": [option["value"]]},
+            watchlist_path="/tmp/watchlist.json",
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "url": long_url,
+                    "watchlist_path": "/tmp/watchlist.json",
+                    "hidden": False,
+                }
+            ],
+            add_subscription.calls,
+        )
+        self.assertIn(long_url, add_response["content"])
+
     def test_handle_component_adds_selected_result_with_hidden_flag(self):
         add_subscription = FakeAddSubscription()
         handler = SearchCommandHandler(

--- a/tests/test_discord_search.py
+++ b/tests/test_discord_search.py
@@ -1,0 +1,130 @@
+import unittest
+
+from manga_watch.discord_search import SEARCH_COMMAND, SearchCommandHandler
+from manga_watch.source_search import SearchResult
+
+
+class FakeSearchSource:
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls = []
+
+    def __call__(self, source, query, *, http_client=None, limit=10):
+        self.calls.append(
+            {
+                "source": source,
+                "query": query,
+                "http_client": http_client,
+                "limit": limit,
+            }
+        )
+        return list(self.results)
+
+
+class FakeAddSubscription:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, url, *, watchlist_path=None, hidden=False):
+        self.calls.append(
+            {
+                "url": url,
+                "watchlist_path": watchlist_path,
+                "hidden": hidden,
+            }
+        )
+        return {
+            "action": "added",
+            "entry": {
+                "id": "champion-cross:e349a3791821b",
+                "seed_url": url,
+                "hidden": hidden,
+            },
+            "work_count": 1,
+        }
+
+
+class DiscordSearchTests(unittest.TestCase):
+    def test_search_command_name_is_exported(self):
+        self.assertEqual("search", SEARCH_COMMAND)
+
+    def test_start_returns_ephemeral_select_menu_for_results(self):
+        search_source = FakeSearchSource(
+            [
+                SearchResult(
+                    source="champion-cross",
+                    title="酒井美羽の少女まんが戦記",
+                    seed_url="https://championcross.jp/series/e349a3791821b",
+                    subtitle="champion-cross",
+                ),
+                SearchResult(
+                    source="champion-cross",
+                    title="別の作品",
+                    seed_url="https://championcross.jp/series/aaaaaaaaaaaaa",
+                    subtitle="champion-cross",
+                ),
+            ]
+        )
+        handler = SearchCommandHandler(search_source=search_source)
+
+        response = handler.start(
+            source="champion-cross",
+            query="まんが",
+            visibility="hidden",
+            watchlist_path="/tmp/watchlist.json",
+        )
+
+        self.assertEqual(
+            {
+                "source": "champion-cross",
+                "query": "まんが",
+                "http_client": None,
+                "limit": 10,
+            },
+            search_source.calls[0],
+        )
+        self.assertIn("検索結果", response["content"])
+        self.assertEqual("search_select:hidden", response["components"][0]["components"][0]["custom_id"])
+        self.assertEqual(
+            [
+                {
+                    "label": "酒井美羽の少女まんが戦記",
+                    "value": "https://championcross.jp/series/e349a3791821b",
+                    "description": "champion-cross",
+                },
+                {
+                    "label": "別の作品",
+                    "value": "https://championcross.jp/series/aaaaaaaaaaaaa",
+                    "description": "champion-cross",
+                },
+            ],
+            response["components"][0]["components"][0]["options"],
+        )
+
+    def test_handle_component_adds_selected_result_with_hidden_flag(self):
+        add_subscription = FakeAddSubscription()
+        handler = SearchCommandHandler(
+            search_source=lambda *_args, **_kwargs: [],
+            add_subscription=add_subscription,
+        )
+
+        response = handler.handle_component(
+            {"custom_id": "search_select:hidden", "values": ["https://championcross.jp/series/e349a3791821b"]},
+            watchlist_path="/tmp/watchlist.json",
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "url": "https://championcross.jp/series/e349a3791821b",
+                    "watchlist_path": "/tmp/watchlist.json",
+                    "hidden": True,
+                }
+            ],
+            add_subscription.calls,
+        )
+        self.assertIn("非表示", response["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discord_search.py
+++ b/tests/test_discord_search.py
@@ -168,6 +168,21 @@ class DiscordSearchTests(unittest.TestCase):
         )
         self.assertIn("非表示", response["content"])
 
+    def test_handle_component_rejects_stale_tokenized_url(self):
+        add_subscription = FakeAddSubscription()
+        handler = SearchCommandHandler(
+            search_source=lambda *_args, **_kwargs: [],
+            add_subscription=add_subscription,
+        )
+
+        response = handler.handle_component(
+            {"custom_id": "search_select:visible", "values": ["u:stale-token"]},
+            watchlist_path="/tmp/watchlist.json",
+        )
+
+        self.assertEqual([], add_subscription.calls)
+        self.assertIn("選択された作品URLが見つかりませんでした", response["content"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_discord_supertwins.py
+++ b/tests/test_discord_supertwins.py
@@ -195,9 +195,10 @@ class DiscordSupertwinsSearchTests(unittest.TestCase):
             next(entry for entry in saved_watchlist["works"] if entry["id"] == "kakuyomu:123")["hidden"]
         )
         self.assertEqual(
-            ["kakuyomu:123", "root-1"],
-            saved_state["supertwins"]["groups"]["root-1"]["member_work_ids"],
+            ["kakuyomu:123", "root-1", "work-2"],
+            saved_state["supertwins"]["groups"]["group-1"]["member_work_ids"],
         )
+        self.assertNotIn("root-1", saved_state["supertwins"]["groups"])
 
     def test_result_selection_hides_existing_duplicate_and_registers_group(self):
         watchlist = make_watchlist()
@@ -241,9 +242,14 @@ class DiscordSupertwinsSearchTests(unittest.TestCase):
                 )
 
             saved_watchlist = json.loads(watchlist_path.read_text(encoding="utf-8"))
+            saved_state = json.loads(state_path.read_text(encoding="utf-8"))
 
         self.assertTrue(
             next(entry for entry in saved_watchlist["works"] if entry["id"] == "kakuyomu:123")["hidden"]
+        )
+        self.assertEqual(
+            ["kakuyomu:123", "root-1", "work-2"],
+            saved_state["supertwins"]["groups"]["group-1"]["member_work_ids"],
         )
 
 

--- a/tests/test_discord_supertwins.py
+++ b/tests/test_discord_supertwins.py
@@ -8,6 +8,7 @@ from manga_watch.discord_supertwins_manage import (
     SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX,
     SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX,
     SUPERTWINS_MANAGE_GROUP_SELECT,
+    SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX,
     SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX,
     ManageSupertwinsCommandHandler,
 )
@@ -78,6 +79,31 @@ def make_state():
 
 def write_json(path: Path, payload):
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def make_state_with_many_supertwins_members(member_count: int = 26):
+    state = make_state()
+    member_work_ids = [f"work-{index:02d}" for index in range(1, member_count + 1)]
+    state["works"] = {
+        work_id: {
+            "latest": {
+                "series_title": f"作品{index:02d}",
+                "episode_title": "第1話",
+            },
+            "history": [],
+            "unread": {"event_ids": []},
+            "health": {},
+        }
+        for index, work_id in enumerate(member_work_ids, start=1)
+    }
+    state["supertwins"] = {
+        "groups": {
+            "group-1": {
+                "member_work_ids": member_work_ids,
+            }
+        }
+    }
+    return state, member_work_ids
 
 
 class FakeSearchSource:
@@ -273,6 +299,65 @@ class DiscordSupertwinsManageTests(unittest.TestCase):
         select = payload["components"][0]["components"][0]
         self.assertEqual(f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}group-1", select["custom_id"])
         self.assertEqual(["作品A", "作品B"], [option["label"] for option in select["options"]])
+
+    def test_member_selection_paginates_beyond_25_options(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_path = tmpdir / "state.json"
+            state, _member_work_ids = make_state_with_many_supertwins_members()
+            write_json(state_path, state)
+
+            handler = ManageSupertwinsCommandHandler()
+            payload = handler.handle_component(
+                {"custom_id": SUPERTWINS_MANAGE_GROUP_SELECT, "values": ["group-1"]},
+                state_path=str(state_path),
+            )
+            select = payload["components"][0]["components"][0]
+            next_button = payload["components"][1]["components"][1]
+
+            second_page = handler.handle_component(
+                {"custom_id": next_button["custom_id"]},
+                state_path=str(state_path),
+            )
+            second_select = second_page["components"][0]["components"][0]
+
+        self.assertEqual(25, len(select["options"]))
+        self.assertEqual(["work-01", "work-25"], [select["options"][0]["value"], select["options"][-1]["value"]])
+        self.assertEqual(f"{SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX}group-1:1", next_button["custom_id"])
+        self.assertEqual(1, len(second_select["options"]))
+        self.assertEqual("work-26", second_select["options"][0]["value"])
+        self.assertEqual(f"{SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX}group-1:0", second_page["components"][1]["components"][0]["custom_id"])
+
+    def test_later_page_member_can_be_selected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_path = tmpdir / "state.json"
+            state, _member_work_ids = make_state_with_many_supertwins_members()
+            write_json(state_path, state)
+
+            handler = ManageSupertwinsCommandHandler()
+            handler.handle_component(
+                {"custom_id": SUPERTWINS_MANAGE_GROUP_SELECT, "values": ["group-1"]},
+                state_path=str(state_path),
+            )
+            handler.handle_component(
+                {"custom_id": f"{SUPERTWINS_MANAGE_MEMBER_PAGE_PREFIX}group-1:1"},
+                state_path=str(state_path),
+            )
+            payload = handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}group-1",
+                    "values": ["work-26"],
+                },
+                state_path=str(state_path),
+            )
+            saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("member を group から外したあと、どう扱うか選んでください。", payload["content"])
+        self.assertEqual(
+            ["work-26"],
+            next(iter(saved_state["supertwins"]["pending_actions"].values()))["member_work_ids"],
+        )
 
     def test_keep_hidden_removes_member_from_group_without_unhiding(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_discord_supertwins.py
+++ b/tests/test_discord_supertwins.py
@@ -1,0 +1,400 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from manga_watch.discord_supertwins_manage import (
+    SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX,
+    SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX,
+    SUPERTWINS_MANAGE_GROUP_SELECT,
+    SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX,
+    ManageSupertwinsCommandHandler,
+)
+from manga_watch.discord_supertwins_search import (
+    SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX,
+    SUPERTWINS_SEARCH_WORK_SELECT,
+    SearchSupertwinsCommandHandler,
+)
+from manga_watch.source_search import SearchResult
+
+
+def make_watchlist():
+    return {
+        "version": 2,
+        "works": [
+            {
+                "id": "root-1",
+                "source": "champion-cross",
+                "seed_url": "https://championcross.jp/series/root-1",
+                "enabled": True,
+                "hidden": False,
+                "notification_policy": {"mode": "all", "allowed_update_types": None},
+            },
+            {
+                "id": "work-2",
+                "source": "kakuyomu",
+                "seed_url": "https://kakuyomu.jp/works/222",
+                "enabled": True,
+                "hidden": True,
+                "notification_policy": {"mode": "all", "allowed_update_types": None},
+            },
+        ],
+    }
+
+
+def make_state():
+    return {
+        "version": 2,
+        "works": {
+            "root-1": {
+                "latest": {"series_title": "作品A", "episode_title": "第1話"},
+                "history": [],
+                "unread": {"event_ids": []},
+                "health": {},
+            },
+            "work-2": {
+                "latest": {"series_title": "作品B", "episode_title": "第2話"},
+                "history": [],
+                "unread": {"event_ids": []},
+                "health": {},
+            },
+        },
+        "last_run_at": None,
+        "notification_outbox": [],
+        "discord_delivery": {
+            "daily_notification": {
+                "delivered_latest_keys": {},
+                "pending_messages": [],
+            }
+        },
+        "supertwins": {
+            "groups": {
+                "group-1": {"member_work_ids": ["root-1", "work-2"]},
+            }
+        },
+    }
+
+
+def write_json(path: Path, payload):
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+class FakeSearchSource:
+    def __init__(self, results_by_source):
+        self.results_by_source = results_by_source
+        self.calls = []
+
+    def __call__(self, source, query, *, http_client=None, limit=10):
+        self.calls.append(
+            {
+                "source": source,
+                "query": query,
+                "http_client": http_client,
+                "limit": limit,
+            }
+        )
+        return list(self.results_by_source.get(source, []))
+
+
+class DiscordSupertwinsSearchTests(unittest.TestCase):
+    def test_start_lists_existing_watchlist_works(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, make_watchlist())
+            write_json(state_path, make_state())
+
+            handler = SearchSupertwinsCommandHandler(search_source=FakeSearchSource({}))
+            payload = handler.start(
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+
+        select = payload["components"][0]["components"][0]
+        self.assertEqual(SUPERTWINS_SEARCH_WORK_SELECT, select["custom_id"])
+        self.assertEqual(["作品A", "作品B"], [option["label"] for option in select["options"]])
+
+    def test_work_selection_searches_other_supported_sources_using_current_title(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, make_watchlist())
+            write_json(state_path, make_state())
+
+            search_source = FakeSearchSource(
+                {
+                    "kakuyomu": [
+                        SearchResult(
+                            source="kakuyomu",
+                            title="作品A",
+                            seed_url="https://kakuyomu.jp/works/123",
+                            subtitle="kakuyomu",
+                        )
+                    ]
+                }
+            )
+            handler = SearchSupertwinsCommandHandler(search_source=search_source)
+            payload = handler.handle_component(
+                {"custom_id": SUPERTWINS_SEARCH_WORK_SELECT, "values": ["root-1"]},
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+
+        self.assertEqual(
+            [
+                {
+                    "source": "kakuyomu",
+                    "query": "作品A",
+                    "http_client": None,
+                    "limit": 10,
+                }
+            ],
+            search_source.calls,
+        )
+        select = payload["components"][0]["components"][0]
+        self.assertEqual(f"{SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX}root-1", select["custom_id"])
+        self.assertEqual("作品A", select["options"][0]["label"])
+
+    def test_result_selection_adds_hidden_subscription_and_registers_group(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, make_watchlist())
+            write_json(state_path, make_state())
+
+            handler = SearchSupertwinsCommandHandler(search_source=FakeSearchSource({}))
+            with mock.patch(
+                "manga_watch.discord_supertwins_search.build_watchlist_preview",
+                return_value={
+                    "id": "kakuyomu:123",
+                    "source": "kakuyomu",
+                    "seed_url": "https://kakuyomu.jp/works/123",
+                    "enabled": True,
+                    "hidden": False,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+            ):
+                payload = handler.handle_component(
+                    {
+                        "custom_id": f"{SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX}root-1",
+                        "values": ["https://kakuyomu.jp/works/123"],
+                    },
+                    watchlist_path=str(watchlist_path),
+                    state_path=str(state_path),
+                )
+
+            saved_watchlist = json.loads(watchlist_path.read_text(encoding="utf-8"))
+            saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertIn("hidden で追加", payload["content"])
+        self.assertTrue(
+            next(entry for entry in saved_watchlist["works"] if entry["id"] == "kakuyomu:123")["hidden"]
+        )
+        self.assertEqual(
+            ["kakuyomu:123", "root-1"],
+            saved_state["supertwins"]["groups"]["root-1"]["member_work_ids"],
+        )
+
+    def test_result_selection_hides_existing_duplicate_and_registers_group(self):
+        watchlist = make_watchlist()
+        watchlist["works"].append(
+            {
+                "id": "kakuyomu:123",
+                "source": "kakuyomu",
+                "seed_url": "https://kakuyomu.jp/works/123",
+                "enabled": True,
+                "hidden": False,
+                "notification_policy": {"mode": "all", "allowed_update_types": None},
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, watchlist)
+            write_json(state_path, make_state())
+
+            handler = SearchSupertwinsCommandHandler(search_source=FakeSearchSource({}))
+            with mock.patch(
+                "manga_watch.discord_supertwins_search.build_watchlist_preview",
+                return_value={
+                    "id": "kakuyomu:123",
+                    "source": "kakuyomu",
+                    "seed_url": "https://kakuyomu.jp/works/123",
+                    "enabled": True,
+                    "hidden": False,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                },
+            ):
+                handler.handle_component(
+                    {
+                        "custom_id": f"{SUPERTWINS_SEARCH_RESULT_SELECT_PREFIX}root-1",
+                        "values": ["https://kakuyomu.jp/works/123"],
+                    },
+                    watchlist_path=str(watchlist_path),
+                    state_path=str(state_path),
+                )
+
+            saved_watchlist = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertTrue(
+            next(entry for entry in saved_watchlist["works"] if entry["id"] == "kakuyomu:123")["hidden"]
+        )
+
+
+class DiscordSupertwinsManageTests(unittest.TestCase):
+    def test_start_lists_groups_and_selection_returns_members(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_path = tmpdir / "state.json"
+            write_json(state_path, make_state())
+
+            handler = ManageSupertwinsCommandHandler()
+            payload = handler.start(state_path=str(state_path))
+            select = payload["components"][0]["components"][0]
+            self.assertEqual(SUPERTWINS_MANAGE_GROUP_SELECT, select["custom_id"])
+
+            payload = handler.handle_component(
+                {"custom_id": SUPERTWINS_MANAGE_GROUP_SELECT, "values": ["group-1"]},
+                state_path=str(state_path),
+            )
+
+        select = payload["components"][0]["components"][0]
+        self.assertEqual(f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}group-1", select["custom_id"])
+        self.assertEqual(["作品A", "作品B"], [option["label"] for option in select["options"]])
+
+    def test_keep_hidden_removes_member_from_group_without_unhiding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, make_watchlist())
+            write_json(state_path, make_state())
+
+            handler = ManageSupertwinsCommandHandler()
+            handler.handle_component(
+                {"custom_id": SUPERTWINS_MANAGE_GROUP_SELECT, "values": ["group-1"]},
+                state_path=str(state_path),
+            )
+            payload = handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}group-1",
+                    "values": ["work-2"],
+                },
+                state_path=str(state_path),
+            )
+            action_select = payload["components"][0]["components"][0]
+            token = action_select["custom_id"][len(SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX) :]
+            payload = handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX}{token}",
+                    "values": ["keep_hidden"],
+                },
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+            saved_watchlist = json.loads(watchlist_path.read_text(encoding="utf-8"))
+            saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertIn("hidden のまま", payload["content"])
+        self.assertTrue(
+            next(entry for entry in saved_watchlist["works"] if entry["id"] == "work-2")["hidden"]
+        )
+        self.assertEqual(["root-1"], saved_state["supertwins"]["groups"]["group-1"]["member_work_ids"])
+
+    def test_unhide_removes_member_from_group_and_clears_hidden_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, make_watchlist())
+            write_json(state_path, make_state())
+
+            handler = ManageSupertwinsCommandHandler()
+            handler.handle_component(
+                {"custom_id": SUPERTWINS_MANAGE_GROUP_SELECT, "values": ["group-1"]},
+                state_path=str(state_path),
+            )
+            payload = handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}group-1",
+                    "values": ["work-2"],
+                },
+                state_path=str(state_path),
+            )
+            action_select = payload["components"][0]["components"][0]
+            token = action_select["custom_id"][len(SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX) :]
+            handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX}{token}",
+                    "values": ["unhide"],
+                },
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+            saved_watchlist = json.loads(watchlist_path.read_text(encoding="utf-8"))
+            saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertFalse(
+            next(entry for entry in saved_watchlist["works"] if entry["id"] == "work-2")["hidden"]
+        )
+        self.assertEqual(["root-1"], saved_state["supertwins"]["groups"]["group-1"]["member_work_ids"])
+
+    def test_delete_requires_confirm_and_removes_subscription(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, make_watchlist())
+            write_json(state_path, make_state())
+
+            handler = ManageSupertwinsCommandHandler()
+            handler.handle_component(
+                {"custom_id": SUPERTWINS_MANAGE_GROUP_SELECT, "values": ["group-1"]},
+                state_path=str(state_path),
+            )
+            payload = handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_MEMBER_SELECT_PREFIX}group-1",
+                    "values": ["work-2"],
+                },
+                state_path=str(state_path),
+            )
+            action_select = payload["components"][0]["components"][0]
+            token = action_select["custom_id"][len(SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX) :]
+            confirm_payload = handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_ACTION_SELECT_PREFIX}{token}",
+                    "values": ["delete"],
+                },
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+            self.assertEqual("選択した subscription を削除します。よければ confirm を押してください。", confirm_payload["content"])
+            self.assertEqual(
+                f"{SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX}{token}",
+                confirm_payload["components"][0]["components"][0]["custom_id"],
+            )
+
+            handler.handle_component(
+                {
+                    "custom_id": f"{SUPERTWINS_MANAGE_CONFIRM_DELETE_PREFIX}{token}",
+                },
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+            saved_watchlist = json.loads(watchlist_path.read_text(encoding="utf-8"))
+            saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertNotIn("work-2", [entry["id"] for entry in saved_watchlist["works"]])
+        self.assertEqual(["root-1"], saved_state["supertwins"]["groups"]["group-1"]["member_work_ids"])
+        self.assertNotIn("work-2", saved_state["works"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discord_supertwins_interactions.py
+++ b/tests/test_discord_supertwins_interactions.py
@@ -1,68 +1,7 @@
 import json
-import sys
-import types
 import unittest
 
-google = types.ModuleType("google")
-google_auth = types.ModuleType("google.auth")
-google_auth_transport = types.ModuleType("google.auth.transport")
-google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
-
-
-class _AuthorizedSession:
-    def __init__(self, *args, **kwargs):
-        pass
-
-
-google_auth.default = lambda scopes=None: (object(), None)
-google_auth_transport_requests.AuthorizedSession = _AuthorizedSession
-google.auth = google_auth
-sys.modules["google"] = google
-sys.modules["google.auth"] = google_auth
-sys.modules["google.auth.transport"] = google_auth_transport
-sys.modules["google.auth.transport.requests"] = google_auth_transport_requests
-
-try:
-    from nacl.signing import SigningKey
-except Exception:
-    nacl = types.ModuleType("nacl")
-    nacl_exceptions = types.ModuleType("nacl.exceptions")
-    nacl_signing = types.ModuleType("nacl.signing")
-
-    class _BadSignatureError(Exception):
-        pass
-
-    class _VerifyKey:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def verify(self, *args, **kwargs):
-            return True
-
-    class SigningKey:  # type: ignore[no-redef]
-        @staticmethod
-        def generate():
-            class _Key:
-                class verify_key:
-                    @staticmethod
-                    def encode():
-                        return bytes.fromhex("11" * 32)
-
-                @staticmethod
-                def sign(data):
-                    class _Sig:
-                        signature = bytes.fromhex("22" * 64)
-
-                    return _Sig()
-
-            return _Key()
-
-    nacl_exceptions.BadSignatureError = _BadSignatureError
-    nacl_signing.VerifyKey = _VerifyKey
-    nacl_signing.SigningKey = SigningKey
-    sys.modules["nacl"] = nacl
-    sys.modules["nacl.exceptions"] = nacl_exceptions
-    sys.modules["nacl.signing"] = nacl_signing
+from nacl_test_support import SigningKey
 
 from manga_watch.discord_add import AddCommandHandler
 from manga_watch.discord_interactions import (

--- a/tests/test_discord_supertwins_interactions.py
+++ b/tests/test_discord_supertwins_interactions.py
@@ -1,0 +1,208 @@
+import json
+import sys
+import types
+import unittest
+
+google = types.ModuleType("google")
+google_auth = types.ModuleType("google.auth")
+google_auth_transport = types.ModuleType("google.auth.transport")
+google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
+
+
+class _AuthorizedSession:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+google_auth.default = lambda scopes=None: (object(), None)
+google_auth_transport_requests.AuthorizedSession = _AuthorizedSession
+google.auth = google_auth
+sys.modules["google"] = google
+sys.modules["google.auth"] = google_auth
+sys.modules["google.auth.transport"] = google_auth_transport
+sys.modules["google.auth.transport.requests"] = google_auth_transport_requests
+
+try:
+    from nacl.signing import SigningKey
+except Exception:
+    nacl = types.ModuleType("nacl")
+    nacl_exceptions = types.ModuleType("nacl.exceptions")
+    nacl_signing = types.ModuleType("nacl.signing")
+
+    class _BadSignatureError(Exception):
+        pass
+
+    class _VerifyKey:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def verify(self, *args, **kwargs):
+            return True
+
+    class SigningKey:  # type: ignore[no-redef]
+        @staticmethod
+        def generate():
+            class _Key:
+                class verify_key:
+                    @staticmethod
+                    def encode():
+                        return bytes.fromhex("11" * 32)
+
+                @staticmethod
+                def sign(data):
+                    class _Sig:
+                        signature = bytes.fromhex("22" * 64)
+
+                    return _Sig()
+
+            return _Key()
+
+    nacl_exceptions.BadSignatureError = _BadSignatureError
+    nacl_signing.VerifyKey = _VerifyKey
+    nacl_signing.SigningKey = SigningKey
+    sys.modules["nacl"] = nacl
+    sys.modules["nacl.exceptions"] = nacl_exceptions
+    sys.modules["nacl.signing"] = nacl_signing
+
+from manga_watch.discord_add import AddCommandHandler
+from manga_watch.discord_interactions import (
+    DiscordInteractionService,
+    DiscordRequestVerifier,
+)
+from manga_watch.discord_supertwins_manage import SUPERTWINS_MANAGE_COMMAND
+from manga_watch.discord_supertwins_search import SUPERTWINS_SEARCH_COMMAND
+
+
+class RecordingFetchDispatcher:
+    def dispatch(self):
+        return {"message": "ok"}
+
+
+class DiscordSupertwinsInteractionTests(unittest.TestCase):
+    def make_service(
+        self,
+        *,
+        supertwins_search_handler=None,
+        supertwins_manage_handler=None,
+    ):
+        signing_key = SigningKey.generate()
+        service = DiscordInteractionService(
+            timezone_name="Asia/Tokyo",
+            fetch_dispatcher=RecordingFetchDispatcher(),
+            verifier=DiscordRequestVerifier(signing_key.verify_key.encode().hex()),
+            latest_handler=lambda *_args, **_kwargs: "latest",
+            add_handler=AddCommandHandler(
+                add_subscription=lambda *_args, **_kwargs: {"action": "added", "entry": {"id": "unused"}}
+            ),
+            supertwins_search_handler=supertwins_search_handler,
+            supertwins_manage_handler=supertwins_manage_handler,
+        )
+        return service, signing_key
+
+    def signed_request(self, payload, signing_key):
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        timestamp = "1700000000"
+        signature = signing_key.sign(timestamp.encode("utf-8") + body).signature.hex()
+        headers = {
+            "X-Signature-Ed25519": signature,
+            "X-Signature-Timestamp": timestamp,
+        }
+        return headers, body
+
+    def test_supertwins_search_command_routes_to_ephemeral_handler(self):
+        class FakeSearchHandler:
+            def __init__(self):
+                self.calls = []
+
+            def start(self, **kwargs):
+                self.calls.append(kwargs)
+                return {"content": "候補検索はまだ有効化されていません。", "components": []}
+
+        handler = FakeSearchHandler()
+        service, signing_key = self.make_service(supertwins_search_handler=handler)
+        headers, body = self.signed_request(
+            {"type": 2, "data": {"name": SUPERTWINS_SEARCH_COMMAND}},
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        payload = json.loads(response.body)
+        self.assertEqual(4, payload["type"])
+        self.assertEqual(64, payload["data"]["flags"])
+        self.assertEqual("候補検索はまだ有効化されていません。", payload["data"]["content"])
+        self.assertEqual(1, len(handler.calls))
+
+    def test_supertwins_manage_command_routes_to_ephemeral_handler(self):
+        class FakeManageHandler:
+            def __init__(self):
+                self.calls = []
+
+            def start(self, **kwargs):
+                self.calls.append(kwargs)
+                return {"content": "supertwins 管理はまだ有効化されていません。", "components": []}
+
+        handler = FakeManageHandler()
+        service, signing_key = self.make_service(supertwins_manage_handler=handler)
+        headers, body = self.signed_request(
+            {"type": 2, "data": {"name": SUPERTWINS_MANAGE_COMMAND}},
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        payload = json.loads(response.body)
+        self.assertEqual(4, payload["type"])
+        self.assertEqual(64, payload["data"]["flags"])
+        self.assertEqual("supertwins 管理はまだ有効化されていません。", payload["data"]["content"])
+        self.assertEqual(1, len(handler.calls))
+
+    def test_supertwins_search_component_prefix_routes_to_handler(self):
+        class FakeSearchHandler:
+            def __init__(self):
+                self.calls = []
+
+            def handle_component(self, data, **kwargs):
+                self.calls.append({"data": data, **kwargs})
+                return {"content": "updated-search", "components": []}
+
+        handler = FakeSearchHandler()
+        service, signing_key = self.make_service(supertwins_search_handler=handler)
+        headers, body = self.signed_request(
+            {"type": 3, "data": {"custom_id": "supertwins_search:placeholder"}},
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        payload = json.loads(response.body)
+        self.assertEqual(7, payload["type"])
+        self.assertEqual("updated-search", payload["data"]["content"])
+        self.assertEqual("supertwins_search:placeholder", handler.calls[0]["data"]["custom_id"])
+
+    def test_supertwins_manage_component_prefix_routes_to_handler(self):
+        class FakeManageHandler:
+            def __init__(self):
+                self.calls = []
+
+            def handle_component(self, data, **kwargs):
+                self.calls.append({"data": data, **kwargs})
+                return {"content": "updated-manage", "components": []}
+
+        handler = FakeManageHandler()
+        service, signing_key = self.make_service(supertwins_manage_handler=handler)
+        headers, body = self.signed_request(
+            {"type": 3, "data": {"custom_id": "supertwins_manage:placeholder"}},
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        payload = json.loads(response.body)
+        self.assertEqual(7, payload["type"])
+        self.assertEqual("updated-manage", payload["data"]["content"])
+        self.assertEqual("supertwins_manage:placeholder", handler.calls[0]["data"]["custom_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_firestore_storage.py
+++ b/tests/test_firestore_storage.py
@@ -11,6 +11,7 @@ from manga_watch.storage import (
     save_state,
     save_watchlist,
     validate_state,
+    validate_watchlist,
 )
 
 
@@ -179,7 +180,7 @@ class FirestoreStorageTests(unittest.TestCase):
             save_watchlist(watchlist, backend="firestore")
             save_state(state, backend="firestore")
 
-            self.assertEqual(watchlist, load_watchlist(backend="firestore"))
+            self.assertEqual(validate_watchlist(watchlist), load_watchlist(backend="firestore"))
             self.assertEqual(expected_state, load_state(backend="firestore"))
 
         client = repository.client

--- a/tests/test_post_signed_discord_interaction.py
+++ b/tests/test_post_signed_discord_interaction.py
@@ -1,10 +1,10 @@
 import importlib.util
 import json
+from pathlib import Path
 import unittest
 from unittest import mock
-from pathlib import Path
 
-from nacl.signing import SigningKey
+from nacl_test_support import SigningKey
 
 
 def load_script_module():

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from unittest import mock
 
-from nacl.signing import SigningKey
+from nacl_test_support import SigningKey
 
 from manga_watch import run_service
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,6 +8,7 @@ import threading
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import requests
 
@@ -833,6 +834,46 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual([], store["discord_delivery"]["daily_notification"]["pending_messages"])
         self.assertEqual(1, len(reports))
         self.assertIn("daily notification: 送信した", reports[0])
+
+    def test_run_once_with_discord_outbound_skips_hidden_daily_notifications(self):
+        discord = FakeDiscordClient()
+        reports = []
+        store, load_from_store, save_to_store = self.make_state_store()
+
+        with mock.patch(
+            "manga_watch.runner.load_watchlist",
+            return_value={
+                "version": 2,
+                "works": [
+                    {
+                        "id": "work-1",
+                        "source": "comic-walker",
+                        "seed_url": "https://example.com/work-1",
+                        "enabled": True,
+                        "hidden": True,
+                        "notification_policy": {"mode": "all", "allowed_update_types": None},
+                    }
+                ],
+            },
+        ):
+            outcome = run_once(
+                self.make_config(with_discord=True),
+                notifier=FakeNotifier(),
+                discord_client=discord,
+                checker=lambda _: {"updates": [self.make_update()]},
+                state_loader=load_from_store,
+                state_saver=save_to_store,
+                now_fn=lambda: 1_700_000_000,
+                report_logger=reports.append,
+                error_logger=lambda _: self.fail("unexpected error log"),
+            )
+
+        self.assertTrue(outcome["ok"])
+        self.assertFalse(outcome["dailyNotificationSent"])
+        self.assertEqual(["run-report-channel"], [call["channel_id"] for call in discord.calls])
+        self.assertEqual({}, store["discord_delivery"]["daily_notification"]["delivered_latest_keys"])
+        self.assertEqual([], store["discord_delivery"]["daily_notification"]["pending_messages"])
+        self.assertIn("daily notification: 送信なし", reports[0])
 
     def test_run_once_replays_pending_daily_notification_on_next_run(self):
         failing_discord = FakeDiscordClient(fail_channels={"main-channel"})

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -1,0 +1,94 @@
+import unittest
+
+from manga_watch.source_search import SearchResult, search_source, supported_search_sources
+
+
+class StaticHttpClient:
+    def __init__(self, responses):
+        self.responses = dict(responses)
+
+    def get_text(self, url: str) -> str:
+        if url not in self.responses:
+            raise AssertionError(f"unexpected request: {url!r}")
+        return self.responses[url]
+
+
+class SourceSearchTests(unittest.TestCase):
+    def test_supported_search_sources_are_limited_to_the_initial_supported_set(self):
+        self.assertEqual(("champion-cross", "kakuyomu"), supported_search_sources())
+
+    def test_search_source_parses_champion_cross_results(self):
+        html = """
+        <html>
+          <body>
+            <a href="/series/e349a3791821b/?keyword=%E3%81%BE%E3%82%93%E3%81%8C">酒井美羽の少女まんが戦記</a>
+            <a href="/series/aaaaaaaaaaaaa/?keyword=%E3%81%BE%E3%82%93%E3%81%8C">別の作品</a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "champion-cross",
+            "まんが",
+            http_client=StaticHttpClient({"https://championcross.jp/search?keyword=%E3%81%BE%E3%82%93%E3%81%8C": html}),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="champion-cross",
+                    title="酒井美羽の少女まんが戦記",
+                    seed_url="https://championcross.jp/series/e349a3791821b",
+                    subtitle="champion-cross",
+                ),
+                SearchResult(
+                    source="champion-cross",
+                    title="別の作品",
+                    seed_url="https://championcross.jp/series/aaaaaaaaaaaaa",
+                    subtitle="champion-cross",
+                ),
+            ],
+            results,
+        )
+
+    def test_search_source_parses_kakuyomu_results(self):
+        html = """
+        <html>
+          <body>
+            <a title="雉はどっちだ" href="/works/822139840410356917">雉はどっちだ</a>
+            <a title="別作品" href="/works/900000000000000000">別作品</a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "kakuyomu",
+            "まんが",
+            http_client=StaticHttpClient({"https://kakuyomu.jp/search?q=%E3%81%BE%E3%82%93%E3%81%8C": html}),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="kakuyomu",
+                    title="雉はどっちだ",
+                    seed_url="https://kakuyomu.jp/works/822139840410356917",
+                    subtitle="kakuyomu",
+                ),
+                SearchResult(
+                    source="kakuyomu",
+                    title="別作品",
+                    seed_url="https://kakuyomu.jp/works/900000000000000000",
+                    subtitle="kakuyomu",
+                ),
+            ],
+            results,
+        )
+
+    def test_search_source_rejects_unknown_source(self):
+        with self.assertRaisesRegex(ValueError, "unsupported search source"):
+            search_source("unknown", "まんが", http_client=StaticHttpClient({}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,6 +11,7 @@ from manga_watch.storage import (
     save_state,
     state_daily_notification_delivery,
     state_notification_outbox,
+    validate_watchlist,
 )
 
 
@@ -218,6 +219,51 @@ class StorageTests(unittest.TestCase):
 
             self.assertIn(final_latest_key, written_keys)
             self.assertEqual(final_latest_key, json.loads(state_path.read_text(encoding="utf-8"))["works"]["work-1"]["latest"]["latest_key"])
+
+    def test_validate_watchlist_normalizes_hidden_to_boolean(self):
+        normalized = validate_watchlist(
+            {
+                "version": 2,
+                "works": [
+                    {
+                        "id": "work-visible",
+                        "source": "comic-walker",
+                        "seed_url": "https://example.com/visible",
+                        "enabled": True,
+                        "notification_policy": {"mode": "all", "allowed_update_types": None},
+                    },
+                    {
+                        "id": "work-hidden",
+                        "source": "comic-walker",
+                        "seed_url": "https://example.com/hidden",
+                        "enabled": True,
+                        "hidden": True,
+                        "notification_policy": {"mode": "all", "allowed_update_types": None},
+                    },
+                ],
+            }
+        )
+
+        self.assertFalse(normalized["works"][0]["hidden"])
+        self.assertTrue(normalized["works"][1]["hidden"])
+
+    def test_validate_watchlist_rejects_non_boolean_hidden(self):
+        with self.assertRaisesRegex(ValueError, "watchlist entry work-1 hidden must be boolean"):
+            validate_watchlist(
+                {
+                    "version": 2,
+                    "works": [
+                        {
+                            "id": "work-1",
+                            "source": "comic-walker",
+                            "seed_url": "https://example.com/work-1",
+                            "enabled": True,
+                            "hidden": "yes",
+                            "notification_policy": {"mode": "all", "allowed_update_types": None},
+                        }
+                    ],
+                }
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_supertwins.py
+++ b/tests/test_supertwins.py
@@ -1,0 +1,256 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from manga_watch.storage import load_state, save_state, validate_state
+from manga_watch.supertwins import (
+    add_group_members,
+    clear_pending_action,
+    create_group,
+    ensure_supertwins_state,
+    get_pending_action,
+    link_group_members,
+    list_groups,
+    list_group_members,
+    prune_empty_groups,
+    prune_small_groups,
+    remove_group_members,
+    set_pending_action,
+)
+
+
+def make_state():
+    return {
+        "version": 2,
+        "works": {},
+        "last_run_at": None,
+        "notification_outbox": [],
+        "discord_delivery": {
+            "daily_notification": {
+                "delivered_latest_keys": {},
+                "pending_messages": [],
+            }
+        },
+    }
+
+
+class SupertwinsTests(unittest.TestCase):
+    maxDiff = None
+
+    def test_ensure_supertwins_state_initializes_missing_container(self):
+        original = make_state()
+
+        updated = ensure_supertwins_state(original)
+
+        self.assertNotIn("supertwins", original)
+        self.assertEqual({"groups": {}}, updated["supertwins"])
+
+    def test_ensure_supertwins_state_normalizes_existing_groups(self):
+        updated = ensure_supertwins_state(
+            {
+                **make_state(),
+                "supertwins": {
+                    "groups": {
+                        "group-b": {
+                            "member_work_ids": [" work-2 ", "work-1", "work-2", ""],
+                        },
+                        "group-a": {
+                            "member_work_ids": ["work-3"],
+                            "label": "keep-me",
+                        },
+                    },
+                    "note": "preserve-me",
+                },
+            }
+        )
+
+        self.assertEqual(
+            {
+                "groups": {
+                    "group-a": {
+                        "member_work_ids": ["work-3"],
+                        "label": "keep-me",
+                    },
+                    "group-b": {
+                        "member_work_ids": ["work-1", "work-2"],
+                    },
+                },
+                "note": "preserve-me",
+            },
+            updated["supertwins"],
+        )
+
+    def test_create_group_add_members_remove_members_and_prune_groups(self):
+        original = make_state()
+
+        created = create_group(original, "group-1", ["work-2", "work-1"])
+        added = add_group_members(created, "group-1", ["work-3", "work-1"])
+        removed = remove_group_members(added, "group-1", ["work-1", "missing"])
+        pruned = prune_empty_groups(remove_group_members(removed, "group-1", ["work-2", "work-3"]))
+
+        self.assertNotIn("supertwins", original)
+        self.assertEqual(
+            {
+                "groups": {
+                    "group-1": {
+                        "member_work_ids": ["work-1", "work-2"],
+                    }
+                }
+            },
+            created["supertwins"],
+        )
+        self.assertEqual(
+            ["work-1", "work-2", "work-3"],
+            added["supertwins"]["groups"]["group-1"]["member_work_ids"],
+        )
+        self.assertEqual(
+            ["work-2", "work-3"],
+            removed["supertwins"]["groups"]["group-1"]["member_work_ids"],
+        )
+        self.assertEqual({}, pruned["supertwins"]["groups"])
+
+    def test_upsert_watchlist_entry_marks_duplicate_hidden(self):
+        from manga_watch.supertwins import upsert_watchlist_entry
+
+        watchlist = {
+            "version": 2,
+            "works": [
+                {
+                    "id": "work-1",
+                    "source": "champion-cross",
+                    "seed_url": "https://championcross.jp/series/abc",
+                    "enabled": True,
+                    "hidden": False,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                }
+            ],
+        }
+        result = upsert_watchlist_entry(
+            watchlist,
+            {
+                "id": "work-1",
+                "source": "champion-cross",
+                "seed_url": "https://championcross.jp/series/abc",
+                "enabled": True,
+                "notification_policy": {"mode": "all", "allowed_update_types": None},
+            },
+            hidden=True,
+        )
+
+        self.assertEqual("duplicate", result["action"])
+        self.assertTrue(result["watchlist"]["works"][0]["hidden"])
+
+    def test_pending_action_round_trip_preserves_super_twins_payload(self):
+        state = {
+            **make_state(),
+            "supertwins": {
+                "groups": {},
+                "pending_actions": {"stale": {"group_id": "group-1", "member_work_ids": ["work-1"]}},
+            },
+        }
+
+        updated = set_pending_action(
+            state,
+            "token-1",
+            {"group_id": "group-2", "member_work_ids": ["work-2"]},
+        )
+
+        self.assertEqual(
+            {"group_id": "group-2", "member_work_ids": ["work-2"]},
+            get_pending_action(updated, "token-1"),
+        )
+        cleared = clear_pending_action(updated, "token-1")
+        self.assertNotIn("token-1", cleared["supertwins"].get("pending_actions", {}))
+
+    def test_list_groups_returns_stable_sorted_shape(self):
+        state = {
+            **make_state(),
+            "supertwins": {
+                "groups": {
+                    "group-b": {"member_work_ids": ["work-2", "work-1"]},
+                    "group-a": {"member_work_ids": ["work-3"]},
+                }
+            },
+        }
+        listed = list_groups(state)
+
+        self.assertEqual(
+            [
+                {"group_id": "group-a", "member_work_ids": ["work-3"]},
+                {"group_id": "group-b", "member_work_ids": ["work-1", "work-2"]},
+            ],
+            listed,
+        )
+        self.assertEqual(["work-1", "work-2"], list_group_members(state, "group-b"))
+
+    def test_validate_state_preserves_existing_supertwins_payload(self):
+        validated = validate_state(
+            {
+                **make_state(),
+                "supertwins": {
+                    "groups": {
+                        "group-1": {"member_work_ids": ["work-2", "work-1"]},
+                    }
+                },
+            }
+        )
+
+        self.assertEqual(
+            {
+                "groups": {
+                    "group-1": {"member_work_ids": ["work-2", "work-1"]},
+                }
+            },
+            validated["supertwins"],
+        )
+
+    def test_save_and_load_state_round_trip_supertwins(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = Path(tmpdir) / "state.json"
+            state = create_group(make_state(), "group-1", ["work-2", "work-1"])
+
+            save_state(state, path=str(state_path))
+            loaded = load_state(str(state_path))
+
+        self.assertEqual(state["supertwins"], loaded["supertwins"])
+
+    def test_link_group_members_merges_existing_groups(self):
+        state = {
+            **make_state(),
+            "supertwins": {
+                "groups": {
+                    "group-1": {"member_work_ids": ["work-1", "work-2"]},
+                    "group-2": {"member_work_ids": ["work-3", "work-4"]},
+                }
+            },
+        }
+
+        updated, group_id = link_group_members(state, ["work-2", "work-3", "work-5"])
+
+        self.assertEqual("group-1", group_id)
+        self.assertEqual(
+            ["work-1", "work-2", "work-3", "work-4", "work-5"],
+            updated["supertwins"]["groups"]["group-1"]["member_work_ids"],
+        )
+        self.assertNotIn("group-2", updated["supertwins"]["groups"])
+
+    def test_pending_action_round_trip_and_prune_small_groups(self):
+        state = set_pending_action(
+            create_group(make_state(), "group-1", ["work-1", "work-2"]),
+            "token-1",
+            {"group_id": "group-1", "member_work_ids": ["work-2"]},
+        )
+
+        self.assertEqual(
+            {"group_id": "group-1", "member_work_ids": ["work-2"]},
+            get_pending_action(state, "token-1"),
+        )
+        cleared = clear_pending_action(state, "token-1")
+        pruned = prune_small_groups(remove_group_members(cleared, "group-1", ["work-2"]))
+
+        self.assertNotIn("pending_actions", pruned["supertwins"])
+        self.assertEqual({}, pruned["supertwins"]["groups"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -51,6 +51,7 @@ class WatchlistAddLogicTests(unittest.TestCase):
             "source": "kakuyomu",
             "seed_url": "https://kakuyomu.jp/works/123/episodes/456",
             "enabled": True,
+            "hidden": False,
             "notification_policy": {"mode": "all", "allowed_update_types": None},
         }
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -94,6 +95,7 @@ class WatchlistAddLogicTests(unittest.TestCase):
             "source": "comic-action",
             "seed_url": "https://comic-action.com/episode/11341664176570134078",
             "enabled": True,
+            "hidden": False,
             "notification_policy": {"mode": "all", "allowed_update_types": None},
         }
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -110,6 +112,22 @@ class WatchlistAddLogicTests(unittest.TestCase):
         self.assertEqual(existing_entry, payload["existing"])
         self.assertEqual(1, payload["work_count"])
         self.assertEqual([existing_entry], saved["works"])
+
+    def test_add_watchlist_url_can_store_hidden_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            payload = add_watchlist_url(
+                "https://kakuyomu.jp/works/123",
+                watchlist_path=str(watchlist_path),
+                hidden=True,
+            )
+            saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("added", payload["action"])
+        self.assertTrue(payload["entry"]["hidden"])
+        self.assertTrue(saved["works"][0]["hidden"])
 
     def test_add_watchlist_url_accepts_champion_cross_episode_url(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- add hidden watchlist support that suppresses latest and Discord daily notifications while preserving fetch/state updates
- add Discord search with source-specific search support and visible/hidden watchlist registration
- add supertwins state helpers plus supertwins-search and supertwins-manage flows for hidden cross-media linking and cleanup

## Testing
- python3 -m unittest tests.test_source_search tests.test_discord_search tests.test_discord_command_registration_search tests.test_discord_command_registration tests.test_discord_interactions_search tests.test_supertwins tests.test_discord_supertwins tests.test_discord_supertwins_interactions tests.test_check tests.test_storage tests.test_discord_latest tests.test_discord_outbound tests.test_watchlist tests.test_runner
- python3 -m py_compile manga_watch/source_search.py manga_watch/discord_search.py manga_watch/supertwins.py manga_watch/discord_supertwins_search.py manga_watch/discord_supertwins_manage.py manga_watch/discord_command_registration.py manga_watch/discord_interactions.py manga_watch/watchlist.py manga_watch/check.py manga_watch/storage.py manga_watch/discord_latest.py manga_watch/discord_outbound.py manga_watch/runner.py tests/test_source_search.py tests/test_discord_search.py tests/test_discord_command_registration_search.py tests/test_discord_interactions_search.py tests/test_supertwins.py tests/test_discord_supertwins.py tests/test_discord_supertwins_interactions.py

Closes #246
Closes #248
Closes #249
Closes #247
Refs #245