### PR TITLE
Add comic-walker as a searchable source

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ export DISCORD_RUN_REPORT_CHANNEL_ID=...
 ```
 
 Discord main channel では trim 後に本文がちょうど `latest` のメッセージで保存済み最新話一覧を返し、`fetch` のメッセージで手動巡回を受け付けます。Discord interaction endpoint では slash command として `/add url:<作品URL>` も受け付け、shared add logic で対応できる URL のみクロール対象へ追加します。`MANGA_WATCH_GITHUB_TOKEN` と `MANGA_WATCH_GITHUB_REPOSITORY` が設定されている場合、`unsupported_source` は追加失敗のまま GitHub Issue を自動作成し、「対応候補として記録した」と返信します。
-Cloud Run Service の interaction endpoint では slash command として `/latest` `/fetch` `/add` `/search` `/remove` `/supertwins-search` `/supertwins-manage` を扱います。`/search` は媒体ごとに作品検索を行い、選択した結果を visible または hidden で watchlist に追加します。初期対応 source は `champion-cross` と `kakuyomu` です。検索未対応 source は明示的に unavailable を返します。
+Cloud Run Service の interaction endpoint では slash command として `/latest` `/fetch` `/add` `/search` `/remove` `/supertwins-search` `/supertwins-manage` を扱います。`/search` は媒体ごとに作品検索を行い、選択した結果を visible または hidden で watchlist に追加します。初期対応 source は `champion-cross` / `kakuyomu` / `comic-walker` です。検索未対応 source は明示的に unavailable を返します。
 `/supertwins-search` は既存 watchlist 作品を起点に他媒体候補を探し、選択した候補を hidden で watchlist に追加しつつ state 上の `supertwins.groups` に登録します。既存 duplicate が選ばれた場合も、その entry を hidden 化したうえで group に追加します。`/supertwins-manage` は group と member を選択して、hidden のまま残す / hidden を解除する / subscription を削除する、の 3 アクションを扱います。削除だけは confirm を返します。`/remove` は ephemeral な select menu と confirm/cancel button を返し、watchlist と state から対象作品を完全削除します。
 Discord 実機補助確認は test guild / test channel だけで `.venv/bin/python -m manga_watch.discord_real_e2e --case all --json` を実行します。これは primary gate ではなく、差異が出たときは先に mocked acceptance (`manga_watch.run_mocked_acceptance`) と formatter / builder を確認します。
 

--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -8,7 +8,7 @@ from urllib.parse import quote, urljoin, urlsplit, urlunsplit
 
 from manga_watch.sources.base import HttpClient, RequestsHttpClient
 
-SUPPORTED_SEARCH_SOURCES: tuple[str, ...] = ("champion-cross", "kakuyomu")
+SUPPORTED_SEARCH_SOURCES: tuple[str, ...] = ("champion-cross", "kakuyomu", "comic-walker")
 DEFAULT_SEARCH_LIMIT = 10
 SEARCH_RESULT_LIMIT = 25
 
@@ -101,6 +101,18 @@ def _search_champion_cross(query: str, http_client: HttpClient, *, limit: int) -
     return results
 
 
+
+
+def _search_comic_walker(query: str, http_client: HttpClient, *, limit: int) -> List[SearchResult]:
+    html = http_client.get_text(f"https://comic-walker.com/search?q={quote(query)}")
+    return _extract_anchor_results(
+        html,
+        source="comic-walker",
+        base_url="https://comic-walker.com",
+        href_pattern="/detail/KC_",
+        limit=limit,
+    )
+
 def _extract_anchor_results(
     html_text: str,
     *,
@@ -154,4 +166,5 @@ def _normalize_result_url(url: str) -> str:
 _SEARCHERS: Dict[str, Callable[..., List[SearchResult]]] = {
     "champion-cross": _search_champion_cross,
     "kakuyomu": _search_kakuyomu,
+    "comic-walker": _search_comic_walker,
 }

--- a/tests/test_discord_command_registration_search.py
+++ b/tests/test_discord_command_registration_search.py
@@ -36,6 +36,7 @@ class DiscordSearchCommandRegistrationTests(unittest.TestCase):
                     "choices": [
                         {"name": "champion-cross", "value": "champion-cross"},
                         {"name": "kakuyomu", "value": "kakuyomu"},
+                        {"name": "comic-walker", "value": "comic-walker"},
                     ],
                 },
                 {

--- a/tests/test_discord_supertwins.py
+++ b/tests/test_discord_supertwins.py
@@ -177,7 +177,13 @@ class DiscordSupertwinsSearchTests(unittest.TestCase):
                     "query": "作品A",
                     "http_client": None,
                     "limit": 10,
-                }
+                },
+                {
+                    "source": "comic-walker",
+                    "query": "作品A",
+                    "http_client": None,
+                    "limit": 10,
+                },
             ],
             search_source.calls,
         )

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -15,7 +15,7 @@ class StaticHttpClient:
 
 class SourceSearchTests(unittest.TestCase):
     def test_supported_search_sources_are_limited_to_the_initial_supported_set(self):
-        self.assertEqual(("champion-cross", "kakuyomu"), supported_search_sources())
+        self.assertEqual(("champion-cross", "kakuyomu", "comic-walker"), supported_search_sources())
 
     def test_search_source_parses_champion_cross_results(self):
         html = """
@@ -80,6 +80,41 @@ class SourceSearchTests(unittest.TestCase):
                     title="別作品",
                     seed_url="https://kakuyomu.jp/works/900000000000000000",
                     subtitle="kakuyomu",
+                ),
+            ],
+            results,
+        )
+
+
+    def test_search_source_parses_comic_walker_results(self):
+        html = """
+        <html>
+          <body>
+            <a title="忍者と極道" href="/detail/KC_005419_S?episodeType=latest">忍者と極道</a>
+            <a title="別作品" href="/detail/KC_999999_S">別作品</a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "comic-walker",
+            "忍者",
+            http_client=StaticHttpClient({"https://comic-walker.com/search?q=%E5%BF%8D%E8%80%85": html}),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comic-walker",
+                    title="忍者と極道",
+                    seed_url="https://comic-walker.com/detail/KC_005419_S",
+                    subtitle="comic-walker",
+                ),
+                SearchResult(
+                    source="comic-walker",
+                    title="別作品",
+                    seed_url="https://comic-walker.com/detail/KC_999999_S",
+                    subtitle="comic-walker",
                 ),
             ],
             results,


### PR DESCRIPTION
### Motivation
- Expand `/search` to cover an additional media provider so users can find works from Comic Walker via the existing search flow.

### Description
- Added `comic-walker` to `SUPPORTED_SEARCH_SOURCES` and the search dispatch so it is available in `search_source` choices and command registration. 
- Implemented `_search_comic_walker` which queries `https://comic-walker.com/search?q=...` and reuses the existing `_extract_anchor_results` path, filtering links by `/detail/KC_` so returned `seed_url`s are adapter-compatible. 
- Updated `_SEARCHERS` mapping and ensured returned `seed_url`s are normalized via the shared `_normalize_result_url` logic. 
- Updated tests and docs: `tests/test_source_search.py` (added Comic Walker parsing test and updated supported list), `tests/test_discord_command_registration_search.py` (added choice), `tests/test_discord_supertwins.py` (updated expectation to include `comic-walker`), and `README.md` (documented `comic-walker` in initial `/search` set).

### Testing
- Ran `python -m unittest tests.test_source_search tests.test_discord_command_registration_search tests.test_discord_search tests.test_discord_supertwins_search` which initially failed with an `ImportError` for a missing `tests.test_discord_supertwins_search` test module. 
- After adjusting tests, ran `python -m unittest tests.test_source_search tests.test_discord_command_registration_search tests.test_discord_search tests.test_discord_supertwins` and all tests passed (`25 tests, OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db03ebfa288332aa76ccbe0d54644b)