### PR TITLE
[codex] Fix supertwins interaction storage backend

### DIFF
--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -533,6 +533,6 @@ def build_interaction_service_from_env(
         add_handler=AddCommandHandler.from_env(),
         search_handler=SearchCommandHandler(),
         remove_handler=RemoveCommandHandler(backend=storage_backend),
-        supertwins_search_handler=SearchSupertwinsCommandHandler(),
-        supertwins_manage_handler=ManageSupertwinsCommandHandler(),
+        supertwins_search_handler=SearchSupertwinsCommandHandler(backend=storage_backend),
+        supertwins_manage_handler=ManageSupertwinsCommandHandler(backend=storage_backend),
     )

--- a/tests/test_discord_interactions.py
+++ b/tests/test_discord_interactions.py
@@ -399,6 +399,10 @@ class BuildInteractionServiceFromEnvTests(unittest.TestCase):
         self.assertFalse(service.verification_disabled)
         self.assertIsNotNone(service.remove_handler)
         self.assertEqual("firestore", service.remove_handler.backend)
+        self.assertIsNotNone(service.supertwins_search_handler)
+        self.assertEqual("firestore", service.supertwins_search_handler.backend)
+        self.assertIsNotNone(service.supertwins_manage_handler)
+        self.assertEqual("firestore", service.supertwins_manage_handler.backend)
 
     def test_build_interaction_service_configures_github_issue_reporter_when_env_present(self):
         runner_config = RunnerConfig(


### PR DESCRIPTION
### Summary
- pass the configured storage backend through to the `/supertwins-search` and `/supertwins-manage` interaction handlers
- keep these handlers aligned with `/remove`, so Firestore-backed deployments do not fall back to JSON storage during interaction handling
- add a regression test covering backend wiring in `build_interaction_service_from_env`

### Root cause
`DiscordInteractionService` was building `SearchSupertwinsCommandHandler` and `ManageSupertwinsCommandHandler` without `backend=storage_backend`. In Firestore deployments this left both handlers on the default backend, so interaction-time session/state reads and writes could fail even though the rest of the interaction service was configured for Firestore.

### Validation
- `/Users/kentokumatsunami/Documents/GitHub/comic_crawler/.worktrees/pr-265/.venv/bin/python -m unittest tests.test_discord_interactions.BuildInteractionServiceFromEnvTests.test_build_interaction_service_defaults_fetch_backend_to_coordinator tests.test_discord_supertwins_interactions`

### Notes
- A broader `tests.test_discord_supertwins` run in this fresh branch still includes one pre-existing expectation mismatch on `main` around the number of searched sources, so validation here is scoped to the changed interaction wiring.