### PR TITLE
Fix supertwins-search interaction timeout

### DIFF
--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -202,15 +202,17 @@ class DiscordInteractionCallbackClient:
         *,
         session: Optional[requests.Session] = None,
         timeout: int = DEFAULT_HTTP_TIMEOUT,
+        defer_timeout: float = 2.0,
     ):
         self.session = session or requests.Session()
         self.timeout = timeout
+        self.defer_timeout = defer_timeout
 
     def defer_component(self, *, interaction_id: str, interaction_token: str) -> None:
         response = self.session.post(
             f"https://discord.com/api/v10/interactions/{interaction_id}/{interaction_token}/callback",
             json={"type": INTERACTION_RESPONSE_TYPE_DEFERRED_UPDATE_MESSAGE},
-            timeout=self.timeout,
+            timeout=self.defer_timeout,
         )
         response.raise_for_status()
 

--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, Mapping, Optional, Protocol
 
 import google.auth
+import requests
 from google.auth.transport.requests import AuthorizedSession
 from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
@@ -22,6 +23,8 @@ from manga_watch.discord_supertwins_manage import (
 )
 from manga_watch.discord_supertwins_search import (
     SUPERTWINS_SEARCH_COMMAND,
+    SUPERTWINS_SEARCH_STALE_MESSAGE,
+    SUPERTWINS_SEARCH_WORK_SELECT,
     SearchSupertwinsCommandHandler,
     is_supertwins_search_component,
 )
@@ -37,6 +40,7 @@ INTERACTION_TYPE_APPLICATION_COMMAND = 2
 INTERACTION_TYPE_MESSAGE_COMPONENT = 3
 INTERACTION_RESPONSE_TYPE_PONG = 1
 INTERACTION_RESPONSE_TYPE_CHANNEL_MESSAGE = 4
+INTERACTION_RESPONSE_TYPE_DEFERRED_UPDATE_MESSAGE = 6
 INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE = 7
 EPHEMERAL_MESSAGE_FLAG = 64
 DEFAULT_HTTP_TIMEOUT = 15
@@ -122,6 +126,20 @@ class FetchDispatcher(Protocol):
         ...
 
 
+class InteractionCallbackClient(Protocol):
+    def defer_component(self, *, interaction_id: str, interaction_token: str) -> None:
+        ...
+
+    def edit_original_response(
+        self,
+        *,
+        application_id: str,
+        interaction_token: str,
+        data: Mapping[str, object],
+    ) -> None:
+        ...
+
+
 class InProcessFetchDispatcher:
     def __init__(self, coordinator: RunCoordinator):
         self.coordinator = coordinator
@@ -176,6 +194,42 @@ class CloudRunJobFetchDispatcher:
         raise RuntimeError(
             f"Cloud Run Job launch failed with HTTP {response.status_code}: {detail[:300]}"
         )
+
+
+class DiscordInteractionCallbackClient:
+    def __init__(
+        self,
+        *,
+        session: Optional[requests.Session] = None,
+        timeout: int = DEFAULT_HTTP_TIMEOUT,
+    ):
+        self.session = session or requests.Session()
+        self.timeout = timeout
+
+    def defer_component(self, *, interaction_id: str, interaction_token: str) -> None:
+        response = self.session.post(
+            f"https://discord.com/api/v10/interactions/{interaction_id}/{interaction_token}/callback",
+            json={"type": INTERACTION_RESPONSE_TYPE_DEFERRED_UPDATE_MESSAGE},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+
+    def edit_original_response(
+        self,
+        *,
+        application_id: str,
+        interaction_token: str,
+        data: Mapping[str, object],
+    ) -> None:
+        response = self.session.patch(
+            f"https://discord.com/api/v10/webhooks/{application_id}/{interaction_token}/messages/@original",
+            json={
+                "allowed_mentions": {"parse": []},
+                **dict(data),
+            },
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
 
 
 def build_fetch_dispatcher_from_env(
@@ -256,6 +310,14 @@ def text_response(status_code: int, message: str) -> InteractionHttpResponse:
     )
 
 
+def empty_response(status_code: int) -> InteractionHttpResponse:
+    return InteractionHttpResponse(
+        status_code=status_code,
+        body=b"",
+        content_type="text/plain; charset=utf-8",
+    )
+
+
 def interaction_message_response(content: str) -> InteractionHttpResponse:
     return interaction_payload_response(
         INTERACTION_RESPONSE_TYPE_CHANNEL_MESSAGE,
@@ -305,6 +367,7 @@ class DiscordInteractionService:
     remove_handler: Optional[RemoveCommandHandler] = None
     supertwins_search_handler: Optional[SearchSupertwinsCommandHandler] = None
     supertwins_manage_handler: Optional[ManageSupertwinsCommandHandler] = None
+    interaction_callback_client: Optional[InteractionCallbackClient] = None
 
     def handle_request(
         self,
@@ -413,6 +476,8 @@ class DiscordInteractionService:
                 state_path=self.state_path,
             )
         elif self.supertwins_search_handler is not None and is_supertwins_search_component(custom_id):
+            if custom_id == SUPERTWINS_SEARCH_WORK_SELECT and self.interaction_callback_client is not None:
+                return self._handle_deferred_supertwins_search_work_select(payload, data)
             response_payload = self.supertwins_search_handler.handle_component(
                 data,
                 watchlist_path=self.watchlist_path,
@@ -430,6 +495,70 @@ class DiscordInteractionService:
             INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
             response_payload,
         )
+
+    def _handle_deferred_supertwins_search_work_select(
+        self,
+        payload: Mapping[str, object],
+        data: Mapping[str, object],
+    ) -> InteractionHttpResponse:
+        interaction_id = _coerce_text(payload.get("id"))
+        application_id = _coerce_text(payload.get("application_id"))
+        interaction_token = _coerce_text(payload.get("token"))
+        if (
+            not interaction_id
+            or not application_id
+            or not interaction_token
+            or self.interaction_callback_client is None
+            or self.supertwins_search_handler is None
+        ):
+            response_payload = self.supertwins_search_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+            return interaction_payload_response(
+                INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
+                response_payload,
+            )
+
+        try:
+            self.interaction_callback_client.defer_component(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+            )
+        except Exception:
+            response_payload = self.supertwins_search_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+            return interaction_payload_response(
+                INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
+                response_payload,
+            )
+
+        response_payload: Mapping[str, object] = {
+            "content": SUPERTWINS_SEARCH_STALE_MESSAGE,
+            "components": [],
+        }
+        try:
+            response_payload = self.supertwins_search_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+        except Exception:
+            pass
+
+        try:
+            self.interaction_callback_client.edit_original_response(
+                application_id=application_id,
+                interaction_token=interaction_token,
+                data=response_payload,
+            )
+        except Exception:
+            pass
+        return empty_response(202)
 
     def _verify_request(self, *, headers: Mapping[str, str], body: bytes) -> bool:
         if self.verifier is None:
@@ -535,4 +664,5 @@ def build_interaction_service_from_env(
         remove_handler=RemoveCommandHandler(backend=storage_backend),
         supertwins_search_handler=SearchSupertwinsCommandHandler(backend=storage_backend),
         supertwins_manage_handler=ManageSupertwinsCommandHandler(backend=storage_backend),
+        interaction_callback_client=DiscordInteractionCallbackClient(),
     )

--- a/tests/test_discord_interactions.py
+++ b/tests/test_discord_interactions.py
@@ -39,6 +39,11 @@ class FakeResponse:
         self.status_code = status_code
         self.text = text
 
+    def raise_for_status(self):
+        if 200 <= self.status_code < 300:
+            return None
+        raise RuntimeError(f"HTTP {self.status_code}: {self.text}")
+
 
 class FakeAuthorizedSession:
     def __init__(self, response=None):
@@ -47,6 +52,21 @@ class FakeAuthorizedSession:
 
     def post(self, url, **kwargs):
         self.posts.append({"url": url, **kwargs})
+        return self.response
+
+
+class FakeInteractionCallbackSession:
+    def __init__(self, response=None):
+        self.response = response or FakeResponse()
+        self.posts = []
+        self.patches = []
+
+    def post(self, url, **kwargs):
+        self.posts.append({"url": url, **kwargs})
+        return self.response
+
+    def patch(self, url, **kwargs):
+        self.patches.append({"url": url, **kwargs})
         return self.response
 
 
@@ -340,6 +360,26 @@ class FetchDispatcherTests(unittest.TestCase):
             },
             build_manual_run_request_body(),
         )
+
+    def test_discord_interaction_callback_client_uses_shorter_timeout_for_defer(self):
+        from manga_watch.discord_interactions import DiscordInteractionCallbackClient
+
+        session = FakeInteractionCallbackSession()
+        client = DiscordInteractionCallbackClient(
+            session=session,
+            timeout=15,
+            defer_timeout=2,
+        )
+
+        client.defer_component(interaction_id="interaction-1", interaction_token="token-1")
+        client.edit_original_response(
+            application_id="app-1",
+            interaction_token="token-1",
+            data={"content": "updated"},
+        )
+
+        self.assertEqual(2, session.posts[0]["timeout"])
+        self.assertEqual(15, session.patches[0]["timeout"])
 
 
 class BuildInteractionServiceFromEnvTests(unittest.TestCase):

--- a/tests/test_discord_supertwins_interactions.py
+++ b/tests/test_discord_supertwins_interactions.py
@@ -17,12 +17,36 @@ class RecordingFetchDispatcher:
         return {"message": "ok"}
 
 
+class RecordingInteractionCallbackClient:
+    def __init__(self):
+        self.defer_calls = []
+        self.edit_calls = []
+
+    def defer_component(self, *, interaction_id, interaction_token):
+        self.defer_calls.append(
+            {
+                "interaction_id": interaction_id,
+                "interaction_token": interaction_token,
+            }
+        )
+
+    def edit_original_response(self, *, application_id, interaction_token, data):
+        self.edit_calls.append(
+            {
+                "application_id": application_id,
+                "interaction_token": interaction_token,
+                "data": data,
+            }
+        )
+
+
 class DiscordSupertwinsInteractionTests(unittest.TestCase):
     def make_service(
         self,
         *,
         supertwins_search_handler=None,
         supertwins_manage_handler=None,
+        interaction_callback_client=None,
     ):
         signing_key = SigningKey.generate()
         service = DiscordInteractionService(
@@ -35,6 +59,7 @@ class DiscordSupertwinsInteractionTests(unittest.TestCase):
             ),
             supertwins_search_handler=supertwins_search_handler,
             supertwins_manage_handler=supertwins_manage_handler,
+            interaction_callback_client=interaction_callback_client,
         )
         return service, signing_key
 
@@ -118,6 +143,102 @@ class DiscordSupertwinsInteractionTests(unittest.TestCase):
         self.assertEqual(7, payload["type"])
         self.assertEqual("updated-search", payload["data"]["content"])
         self.assertEqual("supertwins_search:placeholder", handler.calls[0]["data"]["custom_id"])
+
+    def test_supertwins_search_root_select_defers_and_edits_original_message(self):
+        class FakeSearchHandler:
+            def __init__(self):
+                self.calls = []
+
+            def handle_component(self, data, **kwargs):
+                self.calls.append({"data": data, **kwargs})
+                return {
+                    "content": "他媒体候補を選んでください。",
+                    "components": [
+                        {
+                            "type": 1,
+                            "components": [
+                                {
+                                    "type": 3,
+                                    "custom_id": "supertwins_search:results:token-1",
+                                    "options": [{"label": "作品A", "value": "candidate-1"}],
+                                }
+                            ],
+                        }
+                    ],
+                }
+
+        callback_client = RecordingInteractionCallbackClient()
+        handler = FakeSearchHandler()
+        service, signing_key = self.make_service(
+            supertwins_search_handler=handler,
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 3,
+                "data": {
+                    "custom_id": "supertwins_search_work_select",
+                    "values": ["root-1"],
+                },
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(b"", response.body)
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1"}],
+            callback_client.defer_calls,
+        )
+        self.assertEqual("app-1", callback_client.edit_calls[0]["application_id"])
+        self.assertEqual("token-1", callback_client.edit_calls[0]["interaction_token"])
+        self.assertEqual(
+            "他媒体候補を選んでください。",
+            callback_client.edit_calls[0]["data"]["content"],
+        )
+        self.assertEqual("supertwins_search_work_select", handler.calls[0]["data"]["custom_id"])
+
+    def test_supertwins_search_result_select_still_uses_inline_update_message(self):
+        class FakeSearchHandler:
+            def __init__(self):
+                self.calls = []
+
+            def handle_component(self, data, **kwargs):
+                self.calls.append({"data": data, **kwargs})
+                return {"content": "updated-search", "components": []}
+
+        callback_client = RecordingInteractionCallbackClient()
+        handler = FakeSearchHandler()
+        service, signing_key = self.make_service(
+            supertwins_search_handler=handler,
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 3,
+                "data": {
+                    "custom_id": "supertwins_search:results:token-1",
+                    "values": ["candidate-1"],
+                },
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        payload = json.loads(response.body)
+        self.assertEqual(7, payload["type"])
+        self.assertEqual("updated-search", payload["data"]["content"])
+        self.assertEqual([], callback_client.defer_calls)
+        self.assertEqual([], callback_client.edit_calls)
 
     def test_supertwins_manage_component_prefix_routes_to_handler(self):
         class FakeManageHandler:


### PR DESCRIPTION
## Summary
- defer `/supertwins-search` root-work component interactions through the Discord callback API
- patch the original ephemeral message after the slow cross-source search finishes
- add interaction tests covering deferred root selection while keeping result selection inline

## Root cause
Production Cloud Run logs show `/supertwins-search` root selection requests returning HTTP 200 with ~4.0-4.7s latency, which exceeds Discord's 3-second initial response deadline and surfaces as `インタラクションに失敗しました`.

## Verification
- `/Users/kentokumatsunami/.pyenv/shims/python3 -m unittest tests.test_storage tests.test_firestore_storage tests.test_supertwins tests.test_discord_supertwins tests.test_discord_interactions tests.test_discord_supertwins_interactions tests.test_discord_search`