### PR TITLE
Add search support for comic-action, nicovideo, and gaugau

### DIFF
--- a/manga_watch/source_drift.py
+++ b/manga_watch/source_drift.py
@@ -41,6 +41,7 @@ from .sources.firecross import (
     extract_firecross_series_id,
     parse_firecross_reader_title,
 )
+from .sources.gaugau import GaugauAdapter
 from .sources.kakuyomu import KakuyomuAdapter
 from .sources.kuragebunch import (
     KuragebunchAdapter,
@@ -258,6 +259,16 @@ DEFAULT_SOURCE_CANARY_CONTRACTS: Dict[str, SourceCanaryContract] = {
             "latest page keeps a watch/mg URL for the newest episode",
             "latest page title still parses into series / episode labels",
             "canonical comic URL remains stable for the same comic id",
+        ),
+    ),
+    "gaugau": SourceCanaryContract(
+        source="gaugau",
+        seed_url="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+        fixture_bundle="tests/fixtures/gaugau/normal",
+        monitored_signals=(
+            "canonical work URL remains stable for the same work token",
+            "work page keeps a latest free episode URL",
+            "latest episode page title still parses into series / episode labels",
         ),
     ),
     "takecomic": SourceCanaryContract(
@@ -832,6 +843,26 @@ def _nicovideo_manga_canary(
     )
 
 
+def _gaugau_canary(
+    contract: SourceCanaryContract,
+    http_client: HttpClient,
+) -> Tuple[Tuple[str, ...], Tuple[CanaryObservation, ...]]:
+    adapter = GaugauAdapter()
+    work = adapter.normalize(contract.seed_url)
+    latest = adapter.fetch_latest(work, http_client)
+    if not latest.episode_title:
+        raise SourceParseError("gaugau: latest episode title not found")
+
+    return (
+        (work.seed_url, latest.url),
+        (
+            CanaryObservation("canonical_seed_url", work.seed_url),
+            CanaryObservation("latest_episode_url", latest.url),
+            CanaryObservation("latest_episode_title", latest.episode_title),
+        ),
+    )
+
+
 CANARY_RUNNERS = {
     "comic-walker": _comic_walker_canary,
     "comic-action": _comic_action_canary,
@@ -846,6 +877,7 @@ CANARY_RUNNERS = {
     "firecross": _firecross_canary,
     "kakuyomu": _kakuyomu_canary,
     "nicovideo-manga": _nicovideo_manga_canary,
+    "gaugau": _gaugau_canary,
     "takecomic": _takecomic_canary,
 }
 

--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -18,7 +18,7 @@ _SOURCE_SEARCH_CONFIG: Dict[str, Dict[str, object]] = {
         "allowed_domains": ("comic-walker.com", "www.comic-walker.com"),
     },
     "comic-action": {
-        "search_url": "https://comic-action.com/search?keyword={query}",
+        "search_url": "https://comic-action.com/search?q={query}",
         "allowed_domains": ("comic-action.com", "www.comic-action.com"),
     },
     "comic-earthstar": {
@@ -62,12 +62,16 @@ _SOURCE_SEARCH_CONFIG: Dict[str, Dict[str, object]] = {
         "allowed_domains": ("takecomic.jp", "www.takecomic.jp"),
     },
     "nicovideo-manga": {
-        "search_url": "https://manga.nicovideo.jp/search?keyword={query}",
+        "search_url": "https://manga.nicovideo.jp/search?q={query}",
         "allowed_domains": ("manga.nicovideo.jp", "sp.manga.nicovideo.jp"),
     },
     "kakuyomu": {
         "search_url": "https://kakuyomu.jp/search?q={query}",
         "allowed_domains": ("kakuyomu.jp", "www.kakuyomu.jp"),
+    },
+    "gaugau": {
+        "search_url": "https://gaugau.futabanet.jp/list/search-result?word={query}",
+        "allowed_domains": ("gaugau.futabanet.jp",),
     },
 }
 
@@ -150,6 +154,72 @@ def _search_via_public_site(
     )
 
 
+def _search_comic_action(
+    query: str,
+    http_client: HttpClient,
+    *,
+    limit: int,
+) -> List[SearchResult]:
+    search_url = str(_SOURCE_SEARCH_CONFIG["comic-action"]["search_url"]).format(query=quote_plus(query))
+    html_text = http_client.get_text(search_url)
+    results: List[SearchResult] = []
+    seen_seed_urls = set()
+
+    for match in re.finditer(r'<li\b[^>]*SearchResultItem_li[^>]*>(.*?)</li>', html_text, re.I | re.S):
+        block = match.group(1)
+        title_match = re.search(r'<p\b[^>]*SearchResultItem_series_title[^>]*>(.*?)</p>', block, re.I | re.S)
+        title = _normalize_anchor_text(title_match.group(1) if title_match else "")
+        if not title:
+            image_alt_match = re.search(r'alt="([^"]+)"', block, re.I | re.S)
+            title = _normalize_anchor_text(image_alt_match.group(1) if image_alt_match else "")
+        if not title:
+            continue
+
+        href_match = re.search(r'href="([^"]+/episode/\d+[^"]*)"', block, re.I | re.S)
+        if not href_match:
+            continue
+
+        resolved_url = _resolve_result_url(href_match.group(1), search_url=search_url)
+        if not resolved_url:
+            continue
+
+        canonical_seed_url = _canonical_seed_url_for_source("comic-action", resolved_url)
+        if not canonical_seed_url or canonical_seed_url in seen_seed_urls:
+            continue
+
+        seen_seed_urls.add(canonical_seed_url)
+        results.append(
+            SearchResult(
+                source="comic-action",
+                title=title,
+                seed_url=canonical_seed_url,
+                subtitle="comic-action",
+            )
+        )
+        if len(results) >= limit:
+            break
+
+    return results
+
+
+def _search_gaugau(
+    query: str,
+    http_client: HttpClient,
+    *,
+    limit: int,
+) -> List[SearchResult]:
+    config = _SOURCE_SEARCH_CONFIG["gaugau"]
+    search_url = str(config["search_url"]).format(query=quote_plus(query))
+    html_text = http_client.get_text(search_url)
+    return _extract_work_results(
+        html_text,
+        source="gaugau",
+        search_url=search_url,
+        allowed_domains=("gaugau.futabanet.jp",),
+        limit=limit,
+    )
+
+
 def _extract_anchor_results(
     html_text: str,
     *,
@@ -175,6 +245,47 @@ def _extract_anchor_results(
         title = _extract_anchor_title(match.group(0), match.group(2))
         if not title:
             title = canonical_seed_url
+
+        seen_seed_urls.add(canonical_seed_url)
+        results.append(
+            SearchResult(
+                source=source,
+                title=title,
+                seed_url=canonical_seed_url,
+                subtitle=source,
+            )
+        )
+        if len(results) >= limit:
+            break
+
+    return results
+
+
+def _extract_work_results(
+    html_text: str,
+    *,
+    source: str,
+    search_url: str,
+    allowed_domains: tuple[str, ...],
+    limit: int,
+) -> List[SearchResult]:
+    results: List[SearchResult] = []
+    seen_seed_urls = set()
+
+    for match in re.finditer(r'<a\b[^>]*href="([^"]+)"[^>]*>(.*?)</a>', html_text, re.I | re.S):
+        resolved_url = _resolve_result_url(match.group(1), search_url=search_url)
+        if not resolved_url or "/episodes/" in resolved_url:
+            continue
+        if not _is_allowed_domain(resolved_url, allowed_domains):
+            continue
+
+        canonical_seed_url = _canonical_seed_url_for_source(source, resolved_url)
+        if not canonical_seed_url or canonical_seed_url in seen_seed_urls:
+            continue
+
+        title = _extract_anchor_title(match.group(0), match.group(2))
+        if not title:
+            continue
 
         seen_seed_urls.add(canonical_seed_url)
         results.append(
@@ -258,3 +369,5 @@ _SEARCHERS: Dict[str, Callable[..., List[SearchResult]]] = {
     )
     for source in SUPPORTED_SEARCH_SOURCES
 }
+_SEARCHERS["comic-action"] = _search_comic_action
+_SEARCHERS["gaugau"] = _search_gaugau

--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -181,13 +181,9 @@ def _search_comic_action(
         if series_id_match:
             candidate_url = canonical_comic_action_series_feed_url("rss", series_id_match.group(1))
         else:
-            latest_match = re.search(
-                r'<a\b[^>]*href="([^"]+/episode/\d+[^"]*)"[^>]*SearchResultItem_sub_link',
-                block,
-                re.I | re.S,
-            )
+            latest_match = _extract_comic_action_latest_link(block)
             if latest_match:
-                candidate_url = latest_match.group(1)
+                candidate_url = latest_match
             else:
                 href_match = re.search(r'href="([^"]+/episode/\d+[^"]*)"', block, re.I | re.S)
                 if href_match:
@@ -217,6 +213,17 @@ def _search_comic_action(
             break
 
     return results
+
+
+def _extract_comic_action_latest_link(block: str) -> str:
+    for match in re.finditer(r'(<a\b[^>]*>.*?</a>)', block, re.I | re.S):
+        anchor_markup = match.group(1)
+        if "SearchResultItem_sub_link" not in anchor_markup:
+            continue
+        href_match = re.search(r'href="([^"]+/episode/\d+[^"]*)"', anchor_markup, re.I | re.S)
+        if href_match:
+            return href_match.group(1)
+    return ""
 
 
 def _search_gaugau(

--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -8,6 +8,7 @@ from urllib.parse import quote_plus, urljoin, urlsplit, urlunsplit
 
 from manga_watch.sources import REGISTERED_SOURCES, normalize_seed_url
 from manga_watch.sources.base import HttpClient, RequestsHttpClient
+from manga_watch.sources.comic_action import canonical_comic_action_series_feed_url
 
 DEFAULT_SEARCH_LIMIT = 10
 SEARCH_RESULT_LIMIT = 25
@@ -175,11 +176,27 @@ def _search_comic_action(
         if not title:
             continue
 
-        href_match = re.search(r'href="([^"]+/episode/\d+[^"]*)"', block, re.I | re.S)
-        if not href_match:
+        series_id_match = re.search(r"/series-thumbnail/(\d+)", block, re.I)
+        candidate_url = ""
+        if series_id_match:
+            candidate_url = canonical_comic_action_series_feed_url("rss", series_id_match.group(1))
+        else:
+            latest_match = re.search(
+                r'<a\b[^>]*href="([^"]+/episode/\d+[^"]*)"[^>]*SearchResultItem_sub_link',
+                block,
+                re.I | re.S,
+            )
+            if latest_match:
+                candidate_url = latest_match.group(1)
+            else:
+                href_match = re.search(r'href="([^"]+/episode/\d+[^"]*)"', block, re.I | re.S)
+                if href_match:
+                    candidate_url = href_match.group(1)
+
+        if not candidate_url:
             continue
 
-        resolved_url = _resolve_result_url(href_match.group(1), search_url=search_url)
+        resolved_url = _resolve_result_url(candidate_url, search_url=search_url)
         if not resolved_url:
             continue
 

--- a/manga_watch/sources/gaugau.py
+++ b/manga_watch/sources/gaugau.py
@@ -1,0 +1,113 @@
+import re
+from typing import Optional, Tuple
+
+from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
+from .util import html_title
+
+
+_WORK_URL = re.compile(
+    r"^https?://gaugau\.futabanet\.jp/list/work/([A-Za-z0-9]+)(?:/)?(?:\?.*)?$"
+)
+
+
+def canonical_gaugau_work_url(work_token: str) -> str:
+    return f"https://gaugau.futabanet.jp/list/work/{work_token}"
+
+
+def parse_gaugau_work_url(seed_url: str) -> Optional[str]:
+    match = _WORK_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_gaugau_work_url(match.group(1))
+
+
+def extract_gaugau_work_token(seed_url: str) -> Optional[str]:
+    match = _WORK_URL.match(seed_url)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def extract_gaugau_latest_episode_url(html_text: str, work_token: str) -> Optional[str]:
+    if not html_text or not work_token:
+        return None
+    match = re.search(
+        rf"https?://gaugau\.futabanet\.jp/list/work/{re.escape(work_token)}/episodes/\d+",
+        html_text,
+    )
+    if not match:
+        return None
+    return match.group(0)
+
+
+def parse_gaugau_title(page_title: str) -> Tuple[Optional[str], Optional[str]]:
+    normalized = str(page_title or "").strip()
+    if not normalized:
+        return None, None
+
+    match = re.match(r"^公式-(?P<series>.+?)\s+(?P<episode>第[^|]+?)\s*\|", normalized)
+    if match:
+        return match.group("series").strip() or None, match.group("episode").strip() or None
+
+    match = re.match(r"^公式-(?P<series>.+?)\s*\|", normalized)
+    if match:
+        return match.group("series").strip() or None, None
+
+    return None, None
+
+
+class GaugauAdapter(SourceAdapter):
+    source = "gaugau"
+
+    def can_handle(self, seed_url: str) -> bool:
+        return bool(parse_gaugau_work_url(seed_url))
+
+    def normalize(self, seed_url: str) -> WorkDescriptor:
+        normalized_work_url = parse_gaugau_work_url(seed_url)
+        work_token = extract_gaugau_work_token(seed_url)
+        if not normalized_work_url or not work_token:
+            raise RuntimeError(f"{self.source}: could not parse work URL: {seed_url}")
+
+        stable_work_id = f"{self.source}:{work_token}"
+        return WorkDescriptor(
+            source=self.source,
+            work_id=stable_work_id,
+            seed_url=normalized_work_url,
+            metadata={
+                "series": stable_work_id,
+                "workToken": work_token,
+            },
+        )
+
+    def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
+        work_token = work.metadata.get("workToken") or extract_gaugau_work_token(work.seed_url)
+        if not work_token:
+            raise RuntimeError(f"{self.source}: workToken is required")
+
+        work_url = canonical_gaugau_work_url(work_token)
+        work_html = http_client.get_text(work_url)
+        latest_url = extract_gaugau_latest_episode_url(work_html, work_token)
+        if not latest_url:
+            raise SourceParseError(f"{self.source}: latest episode URL not found")
+
+        latest_html = http_client.get_text(latest_url)
+        page_title = html_title(latest_html)
+        series_title, episode_title = parse_gaugau_title(page_title or "")
+        if not series_title:
+            work_page_title = html_title(work_html)
+            series_title, _ = parse_gaugau_title(work_page_title or "")
+        if not episode_title:
+            match = re.search(r'<h1[^>]*class="detailHead__title"[^>]*>(.*?)</h1>', latest_html, re.I | re.S)
+            if match:
+                episode_title = re.sub(r"<[^>]+>", "", match.group(1)).strip() or None
+
+        return LatestEpisode(
+            source=self.source,
+            work_id=work.work_id,
+            latest_key=latest_url,
+            url=latest_url,
+            series=work.metadata.get("series"),
+            series_title=series_title,
+            episode_title=episode_title,
+            page_title=page_title,
+        )

--- a/manga_watch/sources/gaugau.py
+++ b/manga_watch/sources/gaugau.py
@@ -31,13 +31,17 @@ def extract_gaugau_work_token(seed_url: str) -> Optional[str]:
 def extract_gaugau_latest_episode_url(html_text: str, work_token: str) -> Optional[str]:
     if not html_text or not work_token:
         return None
-    match = re.search(
-        rf"https?://gaugau\.futabanet\.jp/list/work/{re.escape(work_token)}/episodes/\d+",
-        html_text,
-    )
-    if not match:
-        return None
-    return match.group(0)
+    episode_url_pattern = rf"https?://gaugau\.futabanet\.jp/list/work/{re.escape(work_token)}/episodes/\d+"
+    grid_pattern = rf'<div\b[^>]*episode__grid[^>]*>.*?href="({episode_url_pattern})"'
+    for match in re.finditer(grid_pattern, html_text, re.I | re.S):
+        href_match = re.search(episode_url_pattern, match.group(1))
+        if href_match:
+            return href_match.group(0)
+
+    fallback_match = re.search(episode_url_pattern, html_text)
+    if fallback_match:
+        return fallback_match.group(0)
+    return None
 
 
 def parse_gaugau_title(page_title: str) -> Tuple[Optional[str], Optional[str]]:

--- a/manga_watch/sources/registry.py
+++ b/manga_watch/sources/registry.py
@@ -8,6 +8,7 @@ from .comicborder import ComicBorderAdapter
 from .comic_trail import ComicTrailAdapter
 from .comic_walker import ComicWalkerAdapter
 from .firecross import FirecrossAdapter
+from .gaugau import GaugauAdapter
 from .kakuyomu import KakuyomuAdapter
 from .kuragebunch import KuragebunchAdapter
 from .magapoke import MagapokeAdapter
@@ -32,6 +33,7 @@ REGISTERED_ADAPTERS = (
     TakecomicAdapter(),
     NicovideoMangaAdapter(),
     KakuyomuAdapter(),
+    GaugauAdapter(),
 )
 REGISTERED_SOURCES = tuple(adapter.source for adapter in REGISTERED_ADAPTERS)
 

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -152,6 +152,12 @@ SOURCE_CAPABILITIES = (
             "https://sp.manga.nicovideo.jp/comic/53764",
         ),
     ),
+    SourceCapability(
+        source="gaugau",
+        domains=("gaugau.futabanet.jp",),
+        input_labels=("work URL",),
+        examples=("https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",),
+    ),
 )
 
 

--- a/tests/fixtures/gaugau/normal/01-work.html
+++ b/tests/fixtures/gaugau/normal/01-work.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <title>公式-ダンジョンの中のひと | 作品詳細 | 無料・試し読み豊富、Web漫画・コミックサイト がうがうモンスター＋</title>
+  </head>
+  <body>
+    <h1>ダンジョンの中のひと</h1>
+    <div class="episode">
+      <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99">
+        <div class="episode__main">
+          <div class="episode__num">第51話(2)</div>
+        </div>
+      </a>
+      <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/5">
+        <div class="episode__main">
+          <div class="episode__num">第2話(2)</div>
+        </div>
+      </a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/gaugau/normal/02-latest.html
+++ b/tests/fixtures/gaugau/normal/02-latest.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>公式-ダンジョンの中のひと 第51話(2) | 無料・試し読み豊富、Web漫画・コミックサイト がうがうモンスター＋</title>
+    <meta property="og:title" content="公式-ダンジョンの中のひと 第51話(2) | 無料・試し読み豊富、Web漫画・コミックサイト がうがうモンスター＋" />
+  </head>
+  <body>
+    <h1 class="detailHead__title">第51話(2)</h1>
+    <h2>ダンジョンの中のひと</h2>
+  </body>
+</html>

--- a/tests/fixtures/gaugau/normal/manifest.json
+++ b/tests/fixtures/gaugau/normal/manifest.json
@@ -1,0 +1,49 @@
+{
+  "seedUrl": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+  "expectedWork": {
+    "source": "gaugau",
+    "kind": "gaugau",
+    "workId": "gaugau:600a5fd37765610d30010000",
+    "seedUrl": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+    "series": "gaugau:600a5fd37765610d30010000",
+    "workToken": "600a5fd37765610d30010000"
+  },
+  "steps": [
+    {
+      "url": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+      "response": "01-work.html"
+    },
+    {
+      "url": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99",
+      "response": "02-latest.html"
+    }
+  ],
+  "expectedCheckedUrls": [
+    "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+    "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99"
+  ],
+  "expectedObservations": [
+    {
+      "name": "canonical_seed_url",
+      "value": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000"
+    },
+    {
+      "name": "latest_episode_url",
+      "value": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99"
+    },
+    {
+      "name": "latest_episode_title",
+      "value": "第51話(2)"
+    }
+  ],
+  "expectedLatest": {
+    "source": "gaugau",
+    "workId": "gaugau:600a5fd37765610d30010000",
+    "latestKey": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99",
+    "url": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99",
+    "series": "gaugau:600a5fd37765610d30010000",
+    "seriesTitle": "ダンジョンの中のひと",
+    "episodeTitle": "第51話(2)",
+    "pageTitle": "公式-ダンジョンの中のひと 第51話(2) | 無料・試し読み豊富、Web漫画・コミックサイト がうがうモンスター＋"
+  }
+}

--- a/tests/test_discord_command_registration_search.py
+++ b/tests/test_discord_command_registration_search.py
@@ -48,6 +48,7 @@ class DiscordSearchCommandRegistrationTests(unittest.TestCase):
                         {"name": "takecomic", "value": "takecomic"},
                         {"name": "nicovideo-manga", "value": "nicovideo-manga"},
                         {"name": "kakuyomu", "value": "kakuyomu"},
+                        {"name": "gaugau", "value": "gaugau"},
                     ],
                 },
                 {

--- a/tests/test_discord_supertwins.py
+++ b/tests/test_discord_supertwins.py
@@ -17,7 +17,7 @@ from manga_watch.discord_supertwins_search import (
     SUPERTWINS_SEARCH_WORK_SELECT,
     SearchSupertwinsCommandHandler,
 )
-from manga_watch.source_search import SearchResult
+from manga_watch.source_search import SearchResult, supported_search_sources
 from manga_watch.storage import load_supertwins_search_session
 
 
@@ -170,8 +170,9 @@ class DiscordSupertwinsSearchTests(unittest.TestCase):
                 state_path=str(state_path),
             )
 
-        self.assertNotIn("champion-cross", [call["source"] for call in search_source.calls])
-        self.assertIn("kakuyomu", [call["source"] for call in search_source.calls])
+        called_sources = [call["source"] for call in search_source.calls]
+        expected_sources = [source for source in supported_search_sources() if source != "champion-cross"]
+        self.assertEqual(expected_sources, called_sources)
         self.assertTrue(all(call["query"] == "作品A" for call in search_source.calls))
         self.assertTrue(all(call["limit"] == 10 for call in search_source.calls))
         select = payload["components"][0]["components"][0]
@@ -222,6 +223,84 @@ class DiscordSupertwinsSearchTests(unittest.TestCase):
                 },
             },
             saved_session,
+        )
+
+    def test_work_selection_includes_three_real_target_media_when_title_matches(self):
+        watchlist = {
+            "version": 2,
+            "works": [
+                {
+                    "id": "root-1",
+                    "source": "champion-cross",
+                    "seed_url": "https://championcross.jp/series/root-1",
+                    "enabled": True,
+                    "hidden": False,
+                    "notification_policy": {"mode": "all", "allowed_update_types": None},
+                }
+            ],
+        }
+        state = make_state()
+        state["works"] = {
+            "root-1": {
+                "latest": {"series_title": "ダンジョンの中のひと", "episode_title": "第1話"},
+                "history": [],
+                "unread": {"event_ids": []},
+                "health": {},
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            watchlist_path = tmpdir / "watchlist.json"
+            state_path = tmpdir / "state.json"
+            write_json(watchlist_path, watchlist)
+            write_json(state_path, state)
+
+            search_source = FakeSearchSource(
+                {
+                    "comic-action": [
+                        SearchResult(
+                            source="comic-action",
+                            title="ダンジョンの中のひと",
+                            seed_url="https://comic-action.com/episode/13933686331665056851",
+                            subtitle="comic-action",
+                        )
+                    ],
+                    "nicovideo-manga": [
+                        SearchResult(
+                            source="nicovideo-manga",
+                            title="ダンジョンの中のひと",
+                            seed_url="https://manga.nicovideo.jp/comic/53764",
+                            subtitle="nicovideo-manga",
+                        )
+                    ],
+                    "gaugau": [
+                        SearchResult(
+                            source="gaugau",
+                            title="ダンジョンの中のひと",
+                            seed_url="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+                            subtitle="gaugau",
+                        )
+                    ],
+                }
+            )
+            handler = SearchSupertwinsCommandHandler(search_source=search_source)
+            payload = handler.handle_component(
+                {"custom_id": SUPERTWINS_SEARCH_WORK_SELECT, "values": ["root-1"]},
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+
+        self.assertTrue(
+            {"comic-action", "nicovideo-manga", "gaugau"}.issubset(
+                {call["source"] for call in search_source.calls}
+            )
+        )
+        options = payload["components"][0]["components"][0]["options"]
+        self.assertTrue(
+            {"comic-action", "nicovideo-manga", "gaugau"}.issubset(
+                {option["description"] for option in options}
+            ),
+            msg=str(options),
         )
 
     def test_work_selection_uses_unique_session_token_per_interaction(self):

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -125,7 +125,10 @@ class SourceSearchTests(unittest.TestCase):
                 <li class="SearchResultItem_li__u1Vp8">
                   <div>
                     <a href="https://comic-action.com/episode/13933686331665056851">
-                      <img alt="ダンジョンの中のひと" />
+                      <img
+                        alt="ダンジョンの中のひと"
+                        src="https://cdn-img.comic-action.com/public/series-thumbnail/13933686331663374228-4e8c11f394783f9b8a20a98d4354d771"
+                      />
                     </a>
                   </div>
                   <div class="SearchResultItem_title_box__kqLq3">
@@ -156,7 +159,7 @@ class SourceSearchTests(unittest.TestCase):
                 SearchResult(
                     source="comic-action",
                     title="ダンジョンの中のひと",
-                    seed_url="https://comic-action.com/episode/13933686331665056851",
+                    seed_url="https://comic-action.com/rss/series/13933686331663374228",
                     subtitle="comic-action",
                 )
             ],

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -166,6 +166,53 @@ class SourceSearchTests(unittest.TestCase):
             results,
         )
 
+    def test_search_source_parses_comic_action_latest_link_when_attributes_are_reordered(self):
+        html = """
+        <html>
+          <body>
+            <section>
+              <ul>
+                <li class="SearchResultItem_li__u1Vp8">
+                  <div>
+                    <a href="https://comic-action.com/episode/13933686331665056851">
+                      <img alt="ダンジョンの中のひと" />
+                    </a>
+                  </div>
+                  <div class="SearchResultItem_title_box__kqLq3">
+                    <p class="SearchResultItem_series_title__hDsk1">ダンジョンの中のひと</p>
+                    <a class="SearchResultItem_sub_link__ZIGr8" href="https://comic-action.com/episode/13933686331677886179">
+                      最新話を読む
+                    </a>
+                  </div>
+                </li>
+              </ul>
+            </section>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "comic-action",
+            "ダンジョンの中のひと",
+            http_client=StaticHttpClient(
+                {
+                    "https://comic-action.com/search?q=%E3%83%80%E3%83%B3%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%B8%AD%E3%81%AE%E3%81%B2%E3%81%A8": html
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comic-action",
+                    title="ダンジョンの中のひと",
+                    seed_url="https://comic-action.com/episode/13933686331677886179",
+                    subtitle="comic-action",
+                )
+            ],
+            results,
+        )
+
     def test_search_source_parses_nicovideo_manga_results_via_q_parameter(self):
         html = """
         <html>

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -31,6 +31,7 @@ class SourceSearchTests(unittest.TestCase):
                 "takecomic",
                 "nicovideo-manga",
                 "kakuyomu",
+                "gaugau",
             ),
             supported_search_sources(),
         )
@@ -109,6 +110,142 @@ class SourceSearchTests(unittest.TestCase):
                     title="酒井美羽の少女まんが戦記",
                     seed_url="https://championcross.jp/series/e349a3791821b",
                     subtitle="champion-cross",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_parses_comic_action_results_via_q_parameter(self):
+        html = """
+        <html>
+          <body>
+            <section>
+              <h4>「ダンジョンの中のひと」の検索結果</h4>
+              <ul>
+                <li class="SearchResultItem_li__u1Vp8">
+                  <div>
+                    <a href="https://comic-action.com/episode/13933686331665056851">
+                      <img alt="ダンジョンの中のひと" />
+                    </a>
+                  </div>
+                  <div class="SearchResultItem_title_box__kqLq3">
+                    <p class="SearchResultItem_series_title__hDsk1">ダンジョンの中のひと</p>
+                    <p class="SearchResultItem_author__WEU8G">双見酔</p>
+                    <a href="https://comic-action.com/episode/13933686331665056851" class="SearchResultItem_main_link__NWMR7">1話を読む</a>
+                    <a href="https://comic-action.com/episode/13933686331677886179" class="SearchResultItem_sub_link__ZIGr8">最新話を読む</a>
+                  </div>
+                </li>
+              </ul>
+            </section>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "comic-action",
+            "ダンジョンの中のひと",
+            http_client=StaticHttpClient(
+                {
+                    "https://comic-action.com/search?q=%E3%83%80%E3%83%B3%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%B8%AD%E3%81%AE%E3%81%B2%E3%81%A8": html
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comic-action",
+                    title="ダンジョンの中のひと",
+                    seed_url="https://comic-action.com/episode/13933686331665056851",
+                    subtitle="comic-action",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_parses_nicovideo_manga_results_via_q_parameter(self):
+        html = """
+        <html>
+          <body>
+            <div class="search_result">
+              <div class="search_result__item">
+                <div class="search_result__item__thumbnail">
+                  <a href="/comic/53764?track=keyword_search">
+                    <img alt="ダンジョンの中のひと" />
+                  </a>
+                </div>
+                <div class="search_result__item__info">
+                  <div class="search_result__item__info--title">
+                    <a href="/comic/53764?track=keyword_search">ダンジョンの中のひと</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "nicovideo-manga",
+            "ダンジョンの中のひと",
+            http_client=StaticHttpClient(
+                {
+                    "https://manga.nicovideo.jp/search?q=%E3%83%80%E3%83%B3%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%B8%AD%E3%81%AE%E3%81%B2%E3%81%A8": html
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="nicovideo-manga",
+                    title="ダンジョンの中のひと",
+                    seed_url="https://manga.nicovideo.jp/comic/53764",
+                    subtitle="nicovideo-manga",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_parses_gaugau_results(self):
+        html = """
+        <html>
+          <body>
+            <div class="works__list">
+              <div class="works__grid">
+                <div class="list__box -free">
+                  <a class="thumbnail -youth" href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000">
+                    <div class="img"><img alt="" /></div>
+                  </a>
+                  <div class="list__text">
+                    <h4>
+                      <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000">ダンジョンの中のひと</a>
+                    </h4>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "gaugau",
+            "ダンジョンの中のひと",
+            http_client=StaticHttpClient(
+                {
+                    "https://gaugau.futabanet.jp/list/search-result?word=%E3%83%80%E3%83%B3%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%B8%AD%E3%81%AE%E3%81%B2%E3%81%A8": html
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="gaugau",
+                    title="ダンジョンの中のひと",
+                    seed_url="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+                    subtitle="gaugau",
                 )
             ],
             results,

--- a/tests/test_source_search_e2e.py
+++ b/tests/test_source_search_e2e.py
@@ -20,7 +20,10 @@ class SourceSearchE2ETests(unittest.TestCase):
         gaugau_results = search_source("gaugau", "ダンジョンの中のひと", http_client=client)
 
         self.assertTrue(
-            any(result.seed_url == "https://comic-action.com/episode/13933686331665056851" for result in comic_action_results)
+            any(
+                result.seed_url == "https://comic-action.com/rss/series/13933686331663374228"
+                for result in comic_action_results
+            )
         )
         self.assertTrue(
             any(result.seed_url == "https://manga.nicovideo.jp/comic/53764" for result in nicovideo_results),

--- a/tests/test_source_search_e2e.py
+++ b/tests/test_source_search_e2e.py
@@ -1,0 +1,91 @@
+import os
+import unittest
+from pathlib import Path
+
+from manga_watch.discord_supertwins_search import SUPERTWINS_SEARCH_WORK_SELECT, SearchSupertwinsCommandHandler
+from manga_watch.source_search import RequestsHttpClient, search_source
+from tests.test_discord_supertwins import write_json
+
+
+RUN_REAL_SEARCH_E2E = os.environ.get("RUN_REAL_SEARCH_E2E") == "1"
+
+
+@unittest.skipUnless(RUN_REAL_SEARCH_E2E, "set RUN_REAL_SEARCH_E2E=1 to run real network search e2e tests")
+class SourceSearchE2ETests(unittest.TestCase):
+    def test_real_search_source_requests_include_expected_media_for_dungeon_no_naka_no_hito(self):
+        client = RequestsHttpClient()
+
+        comic_action_results = search_source("comic-action", "ダンジョンの中のひと", http_client=client)
+        nicovideo_results = search_source("nicovideo-manga", "ダンジョンの中のひと", http_client=client)
+        gaugau_results = search_source("gaugau", "ダンジョンの中のひと", http_client=client)
+
+        self.assertTrue(
+            any(result.seed_url == "https://comic-action.com/episode/13933686331665056851" for result in comic_action_results)
+        )
+        self.assertTrue(
+            any(result.seed_url == "https://manga.nicovideo.jp/comic/53764" for result in nicovideo_results),
+            msg=str(nicovideo_results),
+        )
+        self.assertTrue(
+            any(
+                result.seed_url == "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000"
+                for result in gaugau_results
+            )
+        )
+
+    def test_real_supertwins_search_handler_includes_three_target_media(self):
+        root = Path(os.environ.get("TMPDIR", "/tmp"))
+        watchlist_path = root / "issue-268-search-watchlist.json"
+        state_path = root / "issue-268-search-state.json"
+        write_json(
+            watchlist_path,
+            {
+                "version": 2,
+                "works": [
+                    {
+                        "id": "root-1",
+                        "source": "champion-cross",
+                        "seed_url": "https://championcross.jp/series/root-1",
+                        "enabled": True,
+                        "hidden": False,
+                        "notification_policy": {"mode": "all", "allowed_update_types": None},
+                    }
+                ],
+            },
+        )
+        write_json(
+            state_path,
+            {
+                "version": 2,
+                "works": {
+                    "root-1": {
+                        "latest": {"series_title": "ダンジョンの中のひと", "episode_title": "第1話"},
+                        "history": [],
+                        "unread": {"event_ids": []},
+                        "health": {},
+                    }
+                },
+                "last_run_at": None,
+                "notification_outbox": [],
+                "discord_delivery": {"daily_notification": {"delivered_latest_keys": {}, "pending_messages": []}},
+                "supertwins": {"groups": {}},
+            },
+        )
+
+        try:
+            payload = SearchSupertwinsCommandHandler().handle_component(
+                {"custom_id": SUPERTWINS_SEARCH_WORK_SELECT, "values": ["root-1"]},
+                watchlist_path=str(watchlist_path),
+                state_path=str(state_path),
+            )
+        finally:
+            watchlist_path.unlink(missing_ok=True)
+            state_path.unlink(missing_ok=True)
+
+        options = payload["components"][0]["components"][0]["options"]
+        option_sources = {option["description"] for option in options}
+        self.assertTrue({"comic-action", "nicovideo-manga", "gaugau"}.issubset(option_sources), msg=str(options))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1903,7 +1903,7 @@ class SourceAdapterTests(unittest.TestCase):
             work.to_dict(),
         )
 
-    def test_gaugau_fetch_latest_uses_first_free_episode_from_work_page(self):
+    def test_gaugau_fetch_latest_prefers_first_episode_grid_entry_over_earlier_misc_link(self):
         adapter = GaugauAdapter()
         work = adapter.normalize("https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000")
         client = StaticHttpClient(
@@ -1913,9 +1913,21 @@ class SourceAdapterTests(unittest.TestCase):
                   <head><title>公式-ダンジョンの中のひと | 作品詳細 | がうがうモンスター＋</title></head>
                   <body>
                     <h1>ダンジョンの中のひと</h1>
-                    <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99">
-                      <div class="episode__num">第51話(2)</div>
-                    </a>
+                    <div class="hero">
+                      <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/1">
+                        古い導線
+                      </a>
+                    </div>
+                    <div class="episode__grid">
+                      <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99">
+                        <div class="episode__num">第51話(2)</div>
+                      </a>
+                    </div>
+                    <div class="episode__grid">
+                      <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/5">
+                        <div class="episode__num">第5話</div>
+                      </a>
+                    </div>
                   </body>
                 </html>
                 """,

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -20,6 +20,7 @@ from manga_watch.sources.comic_action import ComicActionAdapter
 from manga_watch.sources.comic_earthstar import ComicEarthstarAdapter
 from manga_watch.sources.comic_trail import parse_comic_trail_title
 from manga_watch.sources.comic_walker import ComicWalkerAdapter
+from manga_watch.sources.gaugau import GaugauAdapter
 from manga_watch.sources.kakuyomu import KakuyomuAdapter
 from manga_watch.sources.magapoke import MagapokeAdapter
 from manga_watch.sources.nicovideo_manga import NicovideoMangaAdapter
@@ -91,6 +92,9 @@ SOURCE_CASES = {
     "nicovideo-manga": (
         "normal",
     ),
+    "gaugau": (
+        "normal",
+    ),
 }
 ADAPTERS = {adapter.source: adapter.__class__ for adapter in REGISTERED_ADAPTERS}
 ERROR_TYPES = {
@@ -149,6 +153,9 @@ EXPECTED_LATEST_CLASSIFICATIONS = {
         "normal": "main_story",
     },
     "nicovideo-manga": {
+        "normal": "main_story",
+    },
+    "gaugau": {
         "normal": "main_story",
     },
 }
@@ -254,6 +261,7 @@ class SourceAdapterTests(unittest.TestCase):
                 "takecomic",
                 "nicovideo-manga",
                 "kakuyomu",
+                "gaugau",
             ),
             REGISTERED_SOURCES,
         )
@@ -310,6 +318,9 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_nicovideo_manga_fixtures(self):
         self._assert_fixture_matrix("nicovideo-manga")
+
+    def test_gaugau_fixtures(self):
+        self._assert_fixture_matrix("gaugau")
 
     def test_magapoke_normalize_accepts_episode_url(self):
         work = MagapokeAdapter().normalize(
@@ -1874,6 +1885,65 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertEqual("第51話", latest["episodeTitle"])
         self.assertEqual(
             ["https://manga.nicovideo.jp/comic/53764/new"],
+            client.calls,
+        )
+
+    def test_gaugau_normalize_accepts_work_url(self):
+        work = GaugauAdapter().normalize("https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000?from=search")
+
+        self.assertEqual(
+            {
+                "source": "gaugau",
+                "kind": "gaugau",
+                "workId": "gaugau:600a5fd37765610d30010000",
+                "seedUrl": "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+                "series": "gaugau:600a5fd37765610d30010000",
+                "workToken": "600a5fd37765610d30010000",
+            },
+            work.to_dict(),
+        )
+
+    def test_gaugau_fetch_latest_uses_first_free_episode_from_work_page(self):
+        adapter = GaugauAdapter()
+        work = adapter.normalize("https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000")
+        client = StaticHttpClient(
+            {
+                "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000": """
+                <html>
+                  <head><title>公式-ダンジョンの中のひと | 作品詳細 | がうがうモンスター＋</title></head>
+                  <body>
+                    <h1>ダンジョンの中のひと</h1>
+                    <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99">
+                      <div class="episode__num">第51話(2)</div>
+                    </a>
+                  </body>
+                </html>
+                """,
+                "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99": """
+                <html>
+                  <head>
+                    <title>公式-ダンジョンの中のひと 第51話(2) | 無料・試し読み豊富、Web漫画・コミックサイト がうがうモンスター＋</title>
+                  </head>
+                  <body></body>
+                </html>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("gaugau:600a5fd37765610d30010000", latest["workId"])
+        self.assertEqual(
+            "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99",
+            latest["latestKey"],
+        )
+        self.assertEqual("ダンジョンの中のひと", latest["seriesTitle"])
+        self.assertEqual("第51話(2)", latest["episodeTitle"])
+        self.assertEqual(
+            [
+                "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+                "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000/episodes/99",
+            ],
             client.calls,
         )
 

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -541,6 +541,28 @@ class WatchlistAddLogicTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
+    def test_watchlist_add_accepts_gaugau_work_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            payload = add_watchlist_url(
+                "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000?from=search",
+                watchlist_path=str(watchlist_path),
+                http_client=StaticHttpClient({}),
+            )
+            saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("added", payload["action"])
+        self.assertEqual("gaugau:600a5fd37765610d30010000", payload["entry"]["id"])
+        self.assertEqual(
+            "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+            payload["entry"]["seed_url"],
+        )
+        self.assertEqual("gaugau", payload["entry"]["source"])
+        self.assertEqual(1, payload["work_count"])
+        self.assertEqual(1, len(saved["works"]))
+
     def test_watchlist_add_reports_unsupported_source(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"


### PR DESCRIPTION
## Issue

- Closes #268

## What Changed

- expanded `source_search` to support `comic-action`, `nicovideo-manga`, and `gaugau`
- added a new `gaugau` source adapter so search results can be added through `/search` and `supertwins-search`
- updated Discord search command source choices and supertwins search coverage
- added fixture-backed tests plus opt-in real-request E2E tests for `ダンジョンの中のひと`

## Verification

- `.venv/bin/python -m unittest tests.test_source_search tests.test_source_search_e2e tests.test_discord_supertwins tests.test_discord_search tests.test_discord_command_registration_search tests.test_sources tests.test_watchlist tests.test_source_drift`
- `RUN_REAL_SEARCH_E2E=1 .venv/bin/python -m unittest tests.test_source_search_e2e`

## Residual Risk

- the real-request E2E tests depend on third-party site HTML and may become flaky if those sites change
- `nicovideo-manga` search results intentionally canonicalize to the comic URL so the existing add flow can register the work successfully
