### PR TITLE
[codex] Add ComicWalker search support

### DIFF
--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -15,7 +15,7 @@ SEARCH_RESULT_LIMIT = 25
 
 _SOURCE_SEARCH_CONFIG: Dict[str, Dict[str, object]] = {
     "comic-walker": {
-        "search_url": "https://comic-walker.com/search?q={query}",
+        "search_url": "https://comic-walker.com/search?keyword={query}",
         "allowed_domains": ("comic-walker.com", "www.comic-walker.com"),
     },
     "comic-action": {

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -301,6 +301,44 @@ class SourceSearchTests(unittest.TestCase):
             results,
         )
 
+    def test_search_source_parses_comic_walker_results_via_keyword_parameter(self):
+        html = """
+        <html>
+          <body>
+            <a class="WorkThumbnail_link__LWlLk" href="/detail/KC_003921_S/episodes/KC_0039210000100011_E">
+              <span class="WorkThumbnail_title__EmZ6E" lang="ja">魔術師クノンは見えている</span>
+            </a>
+            <a class="WorkThumbnail_link__LWlLk" href="/detail/KC_999999_S/episodes/KC_9999990000100011_E">
+              <span class="WorkThumbnail_title__EmZ6E" lang="ja">別作品</span>
+            </a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "comic-walker",
+            "クノン",
+            http_client=StaticHttpClient({"https://comic-walker.com/search?keyword=%E3%82%AF%E3%83%8E%E3%83%B3": html}),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comic-walker",
+                    title="魔術師クノンは見えている",
+                    seed_url="https://comic-walker.com/detail/KC_003921_S",
+                    subtitle="comic-walker",
+                ),
+                SearchResult(
+                    source="comic-walker",
+                    title="別作品",
+                    seed_url="https://comic-walker.com/detail/KC_999999_S",
+                    subtitle="comic-walker",
+                ),
+            ],
+            results,
+        )
+
     def test_search_source_rejects_unknown_source(self):
         with self.assertRaisesRegex(ValueError, "unsupported search source"):
             search_source("unknown", "まんが", http_client=StaticHttpClient({}))


### PR DESCRIPTION
## Issue
- Closes #274

## Summary
- fix the ComicWalker search request to use `?keyword=` instead of `?q=`
- keep the existing generic search pipeline and canonical seed normalization intact
- add a regression test that proves `source=comic-walker, query=クノン` returns `魔術師クノンは見えている` with `https://comic-walker.com/detail/KC_003921_S`

## Scope Mapping
- issue scope: keep `comic-walker` supported in `/search` and make the live query path actually return results
- issue constraint: preserve canonical URL as `https://comic-walker.com/detail/<series_code>`
- issue acceptance: `source=comic-walker, query=クノン` resolves to `魔術師クノンは見えている` with `https://comic-walker.com/detail/KC_003921_S`

## Validation
- `python -m unittest tests.test_source_search tests.test_discord_command_registration_search tests.test_discord_supertwins tests.test_discord_search tests.test_discord_interactions_search tests.test_discord_command_registration tests.test_discord_supertwins_interactions`
- live check: `search_source('comic-walker', 'クノン')` returns `魔術師クノンは見えている` with canonical URL `https://comic-walker.com/detail/KC_003921_S`

## Residual Risk
- ComicWalker search still depends on the public search page keeping result anchors under the current `/detail/<series>/episodes/...` shape
- if ComicWalker changes the query parameter contract again, this regression should fail and point back to `manga_watch/source_search.py`