### PR TITLE
fix: firecross search returns canonical web-reading URLs

### DIFF
--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -9,6 +9,7 @@ from urllib.parse import quote_plus, urljoin, urlsplit, urlunsplit
 from manga_watch.sources import REGISTERED_SOURCES, normalize_seed_url
 from manga_watch.sources.base import HttpClient, RequestsHttpClient
 from manga_watch.sources.comic_action import canonical_comic_action_series_feed_url
+from manga_watch.sources.firecross import canonical_firecross_ebook_series_url
 
 DEFAULT_SEARCH_LIMIT = 10
 SEARCH_RESULT_LIMIT = 25
@@ -55,7 +56,7 @@ _SOURCE_SEARCH_CONFIG: Dict[str, Dict[str, object]] = {
         "allowed_domains": ("pocket.shonenmagazine.com",),
     },
     "firecross": {
-        "search_url": "https://firecross.jp/search?keyword={query}",
+        "search_url": "https://firecross.jp/search?q={query}&t=1",
         "allowed_domains": ("firecross.jp", "www.firecross.jp"),
     },
     "takecomic": {
@@ -244,6 +245,92 @@ def _search_gaugau(
     )
 
 
+def _search_firecross(
+    query: str,
+    http_client: HttpClient,
+    *,
+    limit: int,
+) -> List[SearchResult]:
+    config = _SOURCE_SEARCH_CONFIG["firecross"]
+    search_url = str(config["search_url"]).format(query=quote_plus(query))
+    html_text = http_client.get_text(search_url)
+    results: List[SearchResult] = []
+    seen_seed_urls = set()
+
+    for match in re.finditer(r'<li\b[^>]*class="[^"]*\bseriesList_item\b[^"]*"[^>]*>(.*?)</li>', html_text, re.I | re.S):
+        block = match.group(1)
+        title = _extract_firecross_search_title(block)
+        if not title:
+            continue
+
+        candidate_url = _extract_firecross_search_seed_url(block, search_url=search_url)
+        if not candidate_url:
+            continue
+
+        canonical_seed_url = _canonical_seed_url_for_source("firecross", candidate_url)
+        if not canonical_seed_url or canonical_seed_url in seen_seed_urls:
+            continue
+
+        seen_seed_urls.add(canonical_seed_url)
+        results.append(
+            SearchResult(
+                source="firecross",
+                title=title,
+                seed_url=canonical_seed_url,
+                subtitle="firecross",
+            )
+        )
+        if len(results) >= limit:
+            break
+
+    return results
+
+
+def _extract_firecross_search_title(block: str) -> str:
+    title_match = re.search(r'<a\b[^>]*class="[^"]*\bseriesList_itemTitle\b[^"]*"[^>]*>(.*?)</a>', block, re.I | re.S)
+    if title_match:
+        title = _normalize_anchor_text(title_match.group(1))
+        if title:
+            return title
+
+    image_alt_match = re.search(r'<img\b[^>]*alt\s*=\s*(["\'])(.*?)\1', block, re.I | re.S)
+    if image_alt_match:
+        title = _normalize_anchor_text(image_alt_match.group(2))
+        if title:
+            return title
+
+    return ""
+
+
+def _extract_firecross_search_seed_url(block: str, *, search_url: str) -> Optional[str]:
+    web_read_match = re.search(
+        r'<a\b[^>]*href="([^"]+)"[^>]*>\s*WEB読み\s*</a>',
+        block,
+        re.I | re.S,
+    )
+    if web_read_match:
+        resolved_url = _resolve_result_url(web_read_match.group(1), search_url=search_url)
+        if resolved_url:
+            return resolved_url
+
+    series_page_match = re.search(
+        r'<a\b[^>]*class="[^"]*\bseriesList_itemTitle\b[^"]*"[^>]*href="([^"]+)"',
+        block,
+        re.I | re.S,
+    )
+    if series_page_match:
+        resolved_url = _resolve_result_url(series_page_match.group(1), search_url=search_url)
+        if not resolved_url:
+            return None
+        parsed = urlsplit(resolved_url)
+        match = re.match(r"^/(?:comic|hjbunko|hjnovels)/series/([0-9A-Za-z_-]+)$", parsed.path)
+        if not match:
+            return None
+        return canonical_firecross_ebook_series_url(match.group(1))
+
+    return None
+
+
 def _extract_anchor_results(
     html_text: str,
     *,
@@ -394,4 +481,5 @@ _SEARCHERS: Dict[str, Callable[..., List[SearchResult]]] = {
     for source in SUPPORTED_SEARCH_SOURCES
 }
 _SEARCHERS["comic-action"] = _search_comic_action
+_SEARCHERS["firecross"] = _search_firecross
 _SEARCHERS["gaugau"] = _search_gaugau

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -301,6 +301,55 @@ class SourceSearchTests(unittest.TestCase):
             results,
         )
 
+    def test_search_source_parses_firecross_results_via_search_page_web_reading_link(self):
+        html = """
+        <html>
+          <body>
+            <ul class="seriesList" id="search-result">
+              <li class="seriesList_item">
+                <div class="series-list-figure">
+                  <a href="https://firecross.jp/hjbunko/series/441">
+                    <picture>
+                      <img alt="灰原くんの強くて青春ニューゲーム" />
+                    </picture>
+                  </a>
+                </div>
+                <div class="seriesList_itemMeta">
+                  <span class="series-list-label series-list-label--hb">HJ文庫</span>
+                </div>
+                <a class="seriesList_itemTitle border" href="https://firecross.jp/hjbunko/series/441">灰原くんの強くて青春ニューゲーム</a>
+                <div class="seriesList_itemBtnSet">
+                  <a class="btn-search-result" href="https://firecross.jp/hjbunko/series/441">シリーズ紹介</a>
+                  <a class="btn-search-result" href="https://firecross.jp/ebook/series/441">WEB読み</a>
+                </div>
+              </li>
+            </ul>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "firecross",
+            "灰原くん",
+            http_client=StaticHttpClient(
+                {
+                    "https://firecross.jp/search?q=%E7%81%B0%E5%8E%9F%E3%81%8F%E3%82%93&t=1": html
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="firecross",
+                    title="灰原くんの強くて青春ニューゲーム",
+                    seed_url="https://firecross.jp/ebook/series/441",
+                    subtitle="firecross",
+                )
+            ],
+            results,
+        )
+
     def test_search_source_parses_comic_walker_results_via_keyword_parameter(self):
         html = """
         <html>

--- a/tests/test_source_search_e2e.py
+++ b/tests/test_source_search_e2e.py
@@ -36,6 +36,20 @@ class SourceSearchE2ETests(unittest.TestCase):
             )
         )
 
+    def test_real_firecross_search_requests_include_haihara_kun_no_tsurukute_seishun_new_game(self):
+        client = RequestsHttpClient()
+
+        firecross_results = search_source("firecross", "灰原くん", http_client=client)
+
+        self.assertTrue(
+            any(
+                result.title == "灰原くんの強くて青春ニューゲーム"
+                and result.seed_url == "https://firecross.jp/ebook/series/441"
+                for result in firecross_results
+            ),
+            msg=str(firecross_results),
+        )
+
     def test_real_supertwins_search_handler_includes_three_target_media(self):
         root = Path(os.environ.get("TMPDIR", "/tmp"))
         watchlist_path = root / "issue-268-search-watchlist.json"


### PR DESCRIPTION
## Issue

- Closes #271

## Summary

- Add a dedicated `firecross` search parser that reads `seriesList_item` cards from the live search page.
- Prefer the `WEB読み` link so `search_source("firecross", ...)` returns an adapter-compatible canonical seed URL.
- Keep the result title from the card title, not the series introduction link.
- Update the firecross search query to the live form shape: `q=...&t=1`.

## Verification

- `./.venv/bin/python -m unittest tests.test_source_search`
- `RUN_REAL_SEARCH_E2E=1 ./.venv/bin/python -m unittest tests.test_source_search_e2e.SourceSearchE2ETests.test_real_firecross_search_requests_include_haihara_kun_no_tsurukute_seishun_new_game`
- `RUN_REAL_SEARCH_E2E=1 ./.venv/bin/python -m unittest tests.test_source_search_e2e`

## Notes

- Live probe confirmed `https://firecross.jp/search?q=%E7%81%B0%E5%8E%9F%E3%81%8F%E3%82%93&t=1` returns `灰原くんの強くて青春ニューゲーム` with the canonical `https://firecross.jp/ebook/series/441` URL.
- Residual risk is limited to upstream HTML layout changes on the firecross search page.