### PR TITLE
fix: comic-walker live title parsing and regression fixtures

### DIFF
--- a/manga_watch/sources/comic_walker.py
+++ b/manga_watch/sources/comic_walker.py
@@ -9,7 +9,7 @@ def parse_comic_walker_title(page_title: str) -> Tuple[Optional[str], Optional[s
     if not page_title:
         return None, None
     left = page_title.split("｜")[0].strip()
-    match = re.match(r"^【([^】]+)】\s*(.+)$", left)
+    match = re.match(r"^[【〖]\s*([^】〗]+?)\s*[】〗]\s*(.+)$", left)
     if match:
         return match.group(2).strip() or None, match.group(1).strip() or None
     return left or None, None

--- a/tests/fixtures/comic-walker/broken_missing_next_data/01-series.html
+++ b/tests/fixtures/comic-walker/broken_missing_next_data/01-series.html
@@ -1,1 +1,1 @@
-<html><head><title>作品A｜カドコミ (コミックウォーカー)</title></head><body><section>missing next data</section></body></html>
+<html><head><title>蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)</title></head><body><section>missing next data</section></body></html>

--- a/tests/fixtures/comic-walker/broken_missing_next_data/manifest.json
+++ b/tests/fixtures/comic-walker/broken_missing_next_data/manifest.json
@@ -1,16 +1,16 @@
 {
-  "seedUrl": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456001_E",
+  "seedUrl": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130000100011_E",
   "expectedWork": {
     "source": "comic-walker",
     "kind": "comic-walker",
-    "workId": "KC_123456_S",
-    "seedUrl": "https://comic-walker.com/detail/KC_123456_S",
-    "series": "KC_123456_S",
-    "seriesCode": "KC_123456_S"
+    "workId": "KC_003913_S",
+    "seedUrl": "https://comic-walker.com/detail/KC_003913_S",
+    "series": "KC_003913_S",
+    "seriesCode": "KC_003913_S"
   },
   "steps": [
     {
-      "url": "https://comic-walker.com/detail/KC_123456_S",
+      "url": "https://comic-walker.com/detail/KC_003913_S",
       "response": "01-series.html"
     }
   ],

--- a/tests/fixtures/comic-walker/normal/01-series.html
+++ b/tests/fixtures/comic-walker/normal/01-series.html
@@ -1,1 +1,1 @@
-<html><head><title>作品A｜カドコミ (コミックウォーカー)</title></head><body><script id="__NEXT_DATA__" type="application/json">{"episodeCodes":["KC_123456001_E","KC_123456002_E","KC_123456003_E"]}</script></body></html>
+<html><head><title>蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)</title></head><body><script id="__NEXT_DATA__" type="application/json">{"episodeCodes":["KC_0039130006300011_E","KC_0039130006400011_E","KC_0039130009100011_E"]}</script></body></html>

--- a/tests/fixtures/comic-walker/normal/02-latest.html
+++ b/tests/fixtures/comic-walker/normal/02-latest.html
@@ -1,1 +1,1 @@
-<html><head><title>【第3話】作品A｜カドコミ (コミックウォーカー)</title></head><body><div class="EpisodesTabContents_nextUpdateDate__YDQiC">次回更新予定日：未定</div></body></html>
+<html><head><title>〖第78話その2〗蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)</title></head><body><div class="EpisodesTabContents_nextUpdateDate__YDQiC">次回更新予定日：2026/03/26</div></body></html>

--- a/tests/fixtures/comic-walker/normal/manifest.json
+++ b/tests/fixtures/comic-walker/normal/manifest.json
@@ -1,26 +1,26 @@
 {
-  "seedUrl": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456001_E",
+  "seedUrl": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130000100011_E",
   "expectedWork": {
     "source": "comic-walker",
     "kind": "comic-walker",
-    "workId": "KC_123456_S",
-    "seedUrl": "https://comic-walker.com/detail/KC_123456_S",
-    "series": "KC_123456_S",
-    "seriesCode": "KC_123456_S"
+    "workId": "KC_003913_S",
+    "seedUrl": "https://comic-walker.com/detail/KC_003913_S",
+    "series": "KC_003913_S",
+    "seriesCode": "KC_003913_S"
   },
   "steps": [
     {
-      "url": "https://comic-walker.com/detail/KC_123456_S",
+      "url": "https://comic-walker.com/detail/KC_003913_S",
       "response": "01-series.html"
     },
     {
-      "url": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456003_E?episodeType=latest",
+      "url": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130009100011_E?episodeType=latest",
       "response": "02-latest.html"
     }
   ],
   "expectedCheckedUrls": [
-    "https://comic-walker.com/detail/KC_123456_S",
-    "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456003_E?episodeType=latest"
+    "https://comic-walker.com/detail/KC_003913_S",
+    "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130009100011_E?episodeType=latest"
   ],
   "expectedObservations": [
     {
@@ -29,22 +29,22 @@
     },
     {
       "name": "latest_episode_code",
-      "value": "KC_123456003_E"
+      "value": "KC_0039130009100011_E"
     },
     {
       "name": "latest_episode_title",
-      "value": "第3話"
+      "value": "第78話その2"
     }
   ],
   "expectedLatest": {
     "source": "comic-walker",
-    "workId": "KC_123456_S",
-    "latestKey": "KC_123456003_E",
-    "url": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456003_E?episodeType=latest",
-    "series": "KC_123456_S",
-    "seriesTitle": "作品A",
-    "episodeCode": "KC_123456003_E",
-    "episodeTitle": "第3話",
-    "nextUpdateLabel": "未定"
+    "workId": "KC_003913_S",
+    "latestKey": "KC_0039130009100011_E",
+    "url": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130009100011_E?episodeType=latest",
+    "series": "KC_003913_S",
+    "seriesTitle": "蜘蛛ですが、なにか？",
+    "episodeCode": "KC_0039130009100011_E",
+    "episodeTitle": "第78話その2",
+    "nextUpdateLabel": "2026/03/26"
   }
 }

--- a/tests/fixtures/comic-walker/same_episode_refresh/01-series.html
+++ b/tests/fixtures/comic-walker/same_episode_refresh/01-series.html
@@ -1,1 +1,1 @@
-<html><head><title>作品A｜カドコミ (コミックウォーカー)</title></head><body><script id="__NEXT_DATA__" type="application/json">{"episodeCodes":["KC_123456001_E"]}</script></body></html>
+<html><head><title>蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)</title></head><body><script id="__NEXT_DATA__" type="application/json">{"episodeCodes":["KC_0039130000100011_E"]}</script></body></html>

--- a/tests/fixtures/comic-walker/same_episode_refresh/02-latest.html
+++ b/tests/fixtures/comic-walker/same_episode_refresh/02-latest.html
@@ -1,1 +1,1 @@
-<html><head><title>【第1話】作品A｜カドコミ (コミックウォーカー)</title></head><body><article>refresh</article></body></html>
+<html><head><title>〖第0話〗蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)</title></head><body><article>refresh</article></body></html>

--- a/tests/fixtures/comic-walker/same_episode_refresh/manifest.json
+++ b/tests/fixtures/comic-walker/same_episode_refresh/manifest.json
@@ -1,32 +1,32 @@
 {
-  "seedUrl": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456001_E",
+  "seedUrl": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130000100011_E",
   "expectedWork": {
     "source": "comic-walker",
     "kind": "comic-walker",
-    "workId": "KC_123456_S",
-    "seedUrl": "https://comic-walker.com/detail/KC_123456_S",
-    "series": "KC_123456_S",
-    "seriesCode": "KC_123456_S"
+    "workId": "KC_003913_S",
+    "seedUrl": "https://comic-walker.com/detail/KC_003913_S",
+    "series": "KC_003913_S",
+    "seriesCode": "KC_003913_S"
   },
   "steps": [
     {
-      "url": "https://comic-walker.com/detail/KC_123456_S",
+      "url": "https://comic-walker.com/detail/KC_003913_S",
       "response": "01-series.html"
     },
     {
-      "url": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456001_E?episodeType=latest",
+      "url": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130000100011_E?episodeType=latest",
       "response": "02-latest.html"
     }
   ],
   "expectedLatest": {
     "source": "comic-walker",
-    "workId": "KC_123456_S",
-    "latestKey": "KC_123456001_E",
-    "url": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456001_E?episodeType=latest",
-    "series": "KC_123456_S",
-    "seriesTitle": "作品A",
-    "episodeCode": "KC_123456001_E",
-    "episodeTitle": "第1話"
+    "workId": "KC_003913_S",
+    "latestKey": "KC_0039130000100011_E",
+    "url": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130000100011_E?episodeType=latest",
+    "series": "KC_003913_S",
+    "seriesTitle": "蜘蛛ですが、なにか？",
+    "episodeCode": "KC_0039130000100011_E",
+    "episodeTitle": "第0話"
   },
   "missingLatestKeys": ["nextUpdateLabel"]
 }

--- a/tests/fixtures/comic-walker/title_variation_or_bonus/01-series.html
+++ b/tests/fixtures/comic-walker/title_variation_or_bonus/01-series.html
@@ -1,1 +1,1 @@
-<html><head><title>作品A｜カドコミ (コミックウォーカー)</title></head><body><script id="__NEXT_DATA__" type="application/json">{"episodeCodes":["KC_123456001_E","KC_123456099_E"]}</script></body></html>
+<html><head><title>蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)</title></head><body><script id="__NEXT_DATA__" type="application/json">{"episodeCodes":["KC_0039130006300011_E","KC_0039130006500011_E"]}</script></body></html>

--- a/tests/fixtures/comic-walker/title_variation_or_bonus/02-latest.html
+++ b/tests/fixtures/comic-walker/title_variation_or_bonus/02-latest.html
@@ -1,1 +1,1 @@
-<html><head><title>【番外編】作品A｜カドコミ (コミックウォーカー)</title></head><body><section>bonus</section></body></html>
+<html><head><title>〖番外編〗蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)</title></head><body><section>bonus</section></body></html>

--- a/tests/fixtures/comic-walker/title_variation_or_bonus/manifest.json
+++ b/tests/fixtures/comic-walker/title_variation_or_bonus/manifest.json
@@ -1,31 +1,31 @@
 {
-  "seedUrl": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456001_E",
+  "seedUrl": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130000100011_E",
   "expectedWork": {
     "source": "comic-walker",
     "kind": "comic-walker",
-    "workId": "KC_123456_S",
-    "seedUrl": "https://comic-walker.com/detail/KC_123456_S",
-    "series": "KC_123456_S",
-    "seriesCode": "KC_123456_S"
+    "workId": "KC_003913_S",
+    "seedUrl": "https://comic-walker.com/detail/KC_003913_S",
+    "series": "KC_003913_S",
+    "seriesCode": "KC_003913_S"
   },
   "steps": [
     {
-      "url": "https://comic-walker.com/detail/KC_123456_S",
+      "url": "https://comic-walker.com/detail/KC_003913_S",
       "response": "01-series.html"
     },
     {
-      "url": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456099_E?episodeType=latest",
+      "url": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130006500011_E?episodeType=latest",
       "response": "02-latest.html"
     }
   ],
   "expectedLatest": {
     "source": "comic-walker",
-    "workId": "KC_123456_S",
-    "latestKey": "KC_123456099_E",
-    "url": "https://comic-walker.com/detail/KC_123456_S/episodes/KC_123456099_E?episodeType=latest",
-    "series": "KC_123456_S",
-    "seriesTitle": "作品A",
-    "episodeCode": "KC_123456099_E",
+    "workId": "KC_003913_S",
+    "latestKey": "KC_0039130006500011_E",
+    "url": "https://comic-walker.com/detail/KC_003913_S/episodes/KC_0039130006500011_E?episodeType=latest",
+    "series": "KC_003913_S",
+    "seriesTitle": "蜘蛛ですが、なにか？",
+    "episodeCode": "KC_0039130006500011_E",
     "episodeTitle": "番外編"
   }
 }

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -21,6 +21,7 @@ from manga_watch.sources.comic_earthstar import ComicEarthstarAdapter
 from manga_watch.sources.comic_trail import parse_comic_trail_title
 from manga_watch.sources.comic_walker import ComicWalkerAdapter
 from manga_watch.sources.gaugau import GaugauAdapter
+from manga_watch.sources.comic_walker import ComicWalkerAdapter, parse_comic_walker_title
 from manga_watch.sources.kakuyomu import KakuyomuAdapter
 from manga_watch.sources.magapoke import MagapokeAdapter
 from manga_watch.sources.nicovideo_manga import NicovideoMangaAdapter
@@ -522,6 +523,12 @@ class SourceAdapterTests(unittest.TestCase):
                 "seriesCode": "KC_123456_S",
             },
             work.to_dict(),
+        )
+
+    def test_comic_walker_title_parser_accepts_live_unicode_brackets(self):
+        self.assertEqual(
+            ("蜘蛛ですが、なにか？", "第78話その2"),
+            parse_comic_walker_title("〖第78話その2〗蜘蛛ですが、なにか？｜カドコミ (コミックウォーカー)"),
         )
 
     def test_kakuyomu_normalize_accepts_work_url(self):


### PR DESCRIPTION
## Issue

- Closes #280
- Parent: #276

## Change summary

- Accept both `【...】` and the live Comic Walker `〖...〗` episode-title bracket form in `parse_comic_walker_title()`
- Replace the comic-walker fixture data with the real `蜘蛛ですが、なにか？` series and current live latest episode metadata
- Add a regression test for the live `〖第78話その2〗...` title form

## Validation

- `./.venv/bin/python -m unittest discover -s tests -p 'test_sources.py'`\n- `./.venv/bin/python -m unittest discover -s tests -p 'test_source_drift.py'`\n- `./.venv/bin/python -m manga_watch.source_drift --source comic-walker --format json`\n\n## Residual risk\n\n- Comic Walker title punctuation can still drift again; the parser now accepts the two bracket forms observed in the live site and fixture set.\n