### PR TITLE
feat: add comicborder source adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 .venv/
 .env
+.worktrees/
 
 # Local state (optional)
 # If you want to commit state.json, remove the next line.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ runner が backend に送る update event は次の schema です。
 | --- | --- | --- | --- | --- |
 | ComicWalker | canonical series URL, episode URL | `https://comic-walker.com/detail/<series>` | `KC_XXXXXX_S` | `episodeCode` |
 | webアクション | episode URL, RSS/Atom series feed URL | canonical episode URL または canonical series feed URL | `comic-action:<series_id>` | 最終到達 episode URL |
+| ComicBorder | episode URL | canonical episode URL | `https://comicborder.com/episode/<episode_id>` | latest episode URL |
 | Champion Cross | episode URL, series URL, series RSS URL | canonical episode URL / canonical series URL / canonical series RSS URL | `champion-cross:<series_hash>` | 最新 episode URL |
 | Kakuyomu | work URL, episode URL | 入力 URL のまま | `kakuyomu:<numeric_work_id>` | 最新 episode id |
 
@@ -371,6 +372,7 @@ fixture regression だけでは拾えない upstream HTML / embedded JSON drift 
 | --- | --- | --- | --- |
 | ComicWalker | `https://comic-walker.com/detail/KC_003913_S` | canonical series page の `__NEXT_DATA__`、同一 series の最新 `episodeCode`、最新 episode page title parse | `tests/fixtures/comic-walker/normal` |
 | webアクション | `https://comic-action.com/episode/2550689798784879524` | seed episode page の `series_id`、`nextReadableProductUri`、最終到達 episode page title parse | `tests/fixtures/comic-action/normal` |
+| ComicBorder | `https://comicborder.com/episode/12207421983382919118` | seed episode page の RSS link、RSS feed の latest episode URL、latest episode page title parse | `tests/fixtures/comicborder/normal` |
 | Kakuyomu | `https://kakuyomu.jp/works/16818093092974667738/episodes/822139844009936710` | work page の `__NEXT_DATA__`、最新 episode id/title、最新 episode page title | `tests/fixtures/kakuyomu/normal` |
 
 drift を検知したら、次の順で進めます。

--- a/manga_watch/source_drift.py
+++ b/manga_watch/source_drift.py
@@ -16,6 +16,13 @@ from .sources.champion_cross import (
     parse_champion_cross_rss_latest,
 )
 from .sources.comic_action import ComicActionAdapter, extract_comic_action_series_id, parse_comic_action_title
+from .sources.comicborder import (
+    ComicBorderAdapter,
+    extract_comicborder_next_update_label,
+    extract_comicborder_rss_url,
+    parse_comicborder_rss,
+    parse_comicborder_title,
+)
 from .sources.comic_walker import ComicWalkerAdapter, parse_comic_walker_title
 from .sources.kakuyomu import KakuyomuAdapter
 from .sources.util import html_title
@@ -87,6 +94,16 @@ DEFAULT_SOURCE_CANARY_CONTRACTS: Dict[str, SourceCanaryContract] = {
         monitored_signals=(
             "seed episode page exposes series_id",
             "seed episode page exposes nextReadableProductUri",
+            "latest episode page title still parses into series / episode labels",
+        ),
+    ),
+    "comicborder": SourceCanaryContract(
+        source="comicborder",
+        seed_url="https://comicborder.com/episode/12207421983382919118",
+        fixture_bundle="tests/fixtures/comicborder/normal",
+        monitored_signals=(
+            "seed episode page exposes an RSS feed link",
+            "RSS feed keeps the latest episode URL",
             "latest episode page title still parses into series / episode labels",
         ),
     ),
@@ -198,6 +215,46 @@ def _comic_action_canary(contract: SourceCanaryContract, http_client: HttpClient
     )
 
 
+def _comicborder_canary(
+    contract: SourceCanaryContract,
+    http_client: HttpClient,
+) -> Tuple[Tuple[str, ...], Tuple[CanaryObservation, ...]]:
+    adapter = ComicBorderAdapter()
+    work = adapter.normalize(contract.seed_url)
+
+    seed_html = http_client.get_text(work.seed_url)
+    rss_url = extract_comicborder_rss_url(seed_html)
+    if not rss_url:
+        raise SourceParseError("comicborder: RSS feed link not found")
+
+    feed_text = http_client.get_text(rss_url)
+    latest_url, channel_title, item_title = parse_comicborder_rss(feed_text)
+    latest_html = seed_html if latest_url == work.seed_url else http_client.get_text(latest_url)
+    page_title = html_title(latest_html)
+    series_title, episode_title = parse_comicborder_title(page_title or "")
+    next_update_label = extract_comicborder_next_update_label(latest_html)
+    if not series_title:
+        series_title = channel_title or ""
+    if not episode_title:
+        episode_title = item_title or ""
+    if not episode_title:
+        raise SourceParseError("comicborder: latest episode title not found")
+
+    observations = [
+        CanaryObservation("rss_url", rss_url),
+        CanaryObservation("series_title", series_title or ""),
+        CanaryObservation("latest_episode_url", latest_url),
+        CanaryObservation("latest_episode_title", episode_title),
+    ]
+    if next_update_label:
+        observations.append(CanaryObservation("next_update_label", next_update_label))
+
+    return (
+        (work.seed_url, rss_url, latest_url),
+        tuple(observations),
+    )
+
+
 def _champion_cross_canary(
     contract: SourceCanaryContract,
     http_client: HttpClient,
@@ -288,6 +345,7 @@ def _champion_cross_canary(
 CANARY_RUNNERS = {
     "comic-walker": _comic_walker_canary,
     "comic-action": _comic_action_canary,
+    "comicborder": _comicborder_canary,
     "champion-cross": _champion_cross_canary,
     "kakuyomu": _kakuyomu_canary,
 }

--- a/manga_watch/sources/comicborder.py
+++ b/manga_watch/sources/comicborder.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import html
+import re
+from typing import Optional, Tuple
+from xml.etree import ElementTree
+
+from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
+from .util import html_title
+
+
+_EPISODE_URL = re.compile(
+    r"^https?://(?:www\.)?comicborder\.com/episode/(\d+)(?:/)?(?:\?.*)?$"
+)
+
+
+def canonical_comicborder_episode_url(episode_id: str) -> str:
+    return f"https://comicborder.com/episode/{episode_id}"
+
+
+def parse_comicborder_episode_url(seed_url: str) -> Optional[str]:
+    match = _EPISODE_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_comicborder_episode_url(match.group(1))
+
+
+def extract_comicborder_rss_url(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    decoded = html.unescape(html_text)
+    match = re.search(
+        r'href="(https?://(?:www\.)?comicborder\.com/rss/series/\d+)"',
+        decoded,
+    )
+    if not match:
+        return None
+    return match.group(1)
+
+
+def parse_comicborder_title(page_title: str) -> Tuple[Optional[str], Optional[str]]:
+    if not page_title:
+        return None, None
+    left = page_title.split("|")[0].strip()
+    match = re.match(r"^(.+?)\s*-\s*(.+?)\s*/\s*(.+)$", left)
+    if not match:
+        return None, None
+    series_title = match.group(1).strip() or None
+    episode_title = match.group(3).strip() or None
+    return series_title, episode_title
+
+
+def extract_comicborder_next_update_label(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+    match = re.search(r"次回更新[:：]\s*([^<]+)", html_text)
+    if not match:
+        return None
+    label = re.sub(r"\s+", " ", html.unescape(match.group(1))).strip()
+    return label or None
+
+
+def parse_comicborder_rss(feed_text: str) -> Tuple[str, Optional[str], Optional[str]]:
+    if not feed_text or not feed_text.strip():
+        raise SourceParseError("comicborder: empty RSS feed")
+
+    try:
+        root = ElementTree.fromstring(feed_text)
+    except ElementTree.ParseError as exc:
+        raise SourceParseError(f"comicborder: invalid RSS feed: {exc}") from exc
+
+    channel = root.find("channel")
+    if channel is None:
+        raise SourceParseError("comicborder: RSS channel not found")
+
+    item = channel.find("item")
+    if item is None:
+        raise SourceParseError("comicborder: latest episode not found in RSS feed")
+
+    latest_url = (item.findtext("link") or "").strip()
+    if not latest_url:
+        raise SourceParseError("comicborder: latest episode URL not found in RSS feed")
+
+    latest_url = parse_comicborder_episode_url(latest_url) or latest_url
+    channel_title = (channel.findtext("title") or "").strip() or None
+    item_title = (item.findtext("title") or "").strip() or None
+    return latest_url, channel_title, item_title
+
+
+def _channel_title_to_series_title(channel_title: Optional[str]) -> Optional[str]:
+    if not channel_title:
+        return None
+    match = re.match(r"^コミックボーダー（(.+)）$", channel_title)
+    if match:
+        return match.group(1).strip() or None
+    return channel_title
+
+
+class ComicBorderAdapter(SourceAdapter):
+    source = "comicborder"
+
+    def can_handle(self, seed_url: str) -> bool:
+        return bool(parse_comicborder_episode_url(seed_url))
+
+    def normalize(self, seed_url: str) -> WorkDescriptor:
+        normalized_episode_url = parse_comicborder_episode_url(seed_url)
+        if not normalized_episode_url:
+            raise RuntimeError(f"comicborder: unsupported seed URL: {seed_url}")
+
+        return WorkDescriptor(
+            source=self.source,
+            work_id=normalized_episode_url,
+            seed_url=normalized_episode_url,
+        )
+
+    def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
+        seed_html = self._fetch_episode_page(work.seed_url, http_client)
+        rss_url = extract_comicborder_rss_url(seed_html)
+        if not rss_url:
+            raise SourceParseError("comicborder: RSS feed link not found")
+
+        feed_text = http_client.get_text(rss_url)
+        latest_url, channel_title, item_title = parse_comicborder_rss(feed_text)
+
+        latest_html = seed_html if latest_url == work.seed_url else self._fetch_episode_page(latest_url, http_client)
+        page_title = html_title(latest_html)
+        series_title, episode_title = parse_comicborder_title(page_title or "")
+        if not series_title:
+            series_title = _channel_title_to_series_title(channel_title)
+        if not episode_title:
+            episode_title = item_title
+        next_update_label = extract_comicborder_next_update_label(latest_html)
+
+        return LatestEpisode(
+            source=self.source,
+            work_id=work.work_id,
+            latest_key=latest_url,
+            url=latest_url,
+            series_title=series_title,
+            episode_title=episode_title,
+            page_title=page_title,
+            extra={"rssUrl": rss_url, "nextUpdateLabel": next_update_label}
+            if next_update_label
+            else {"rssUrl": rss_url},
+        )
+
+    def _fetch_episode_page(self, episode_url: str, http_client: HttpClient) -> str:
+        return http_client.get_text(episode_url)

--- a/manga_watch/sources/registry.py
+++ b/manga_watch/sources/registry.py
@@ -1,6 +1,7 @@
 from typing import Optional, Sequence, Tuple
 
 from .base import HttpClient, LatestEpisode, RequestsHttpClient, SourceAdapter, WorkDescriptor
+from .comicborder import ComicBorderAdapter
 from .champion_cross import ChampionCrossAdapter
 from .comic_action import ComicActionAdapter
 from .comic_walker import ComicWalkerAdapter
@@ -10,6 +11,7 @@ from .kakuyomu import KakuyomuAdapter
 REGISTERED_ADAPTERS = (
     ComicWalkerAdapter(),
     ComicActionAdapter(),
+    ComicBorderAdapter(),
     ChampionCrossAdapter(),
     KakuyomuAdapter(),
 )

--- a/tests/fixtures/comicborder/normal/01-episode.html
+++ b/tests/fixtures/comicborder/normal/01-episode.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>殺っちゃえ!! 宇喜多さん - 重野なおき / 第53話 | コミックボーダー</title>
+  </head>
+  <body>
+    <a href="https://comicborder.com/rss/series/3269754496402020044">RSSフィード</a>
+    <div>次回更新： 05月15日</div>
+  </body>
+</html>

--- a/tests/fixtures/comicborder/normal/02-rss.xml
+++ b/tests/fixtures/comicborder/normal/02-rss.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>コミックボーダー（殺っちゃえ!! 宇喜多さん）</title>
+    <link>https://comicborder.com/episode/12207421983382919118</link>
+    <description>謀略、謀反、暗殺――。</description>
+    <item>
+      <title>第53話</title>
+      <link>https://comicborder.com/episode/12207421983382919118</link>
+      <description>殺っちゃえ!! 宇喜多さん</description>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/comicborder/normal/manifest.json
+++ b/tests/fixtures/comicborder/normal/manifest.json
@@ -1,0 +1,29 @@
+{
+  "seedUrl": "https://comicborder.com/episode/12207421983382919118",
+  "expectedWork": {
+    "source": "comicborder",
+    "kind": "comicborder",
+    "workId": "https://comicborder.com/episode/12207421983382919118",
+    "seedUrl": "https://comicborder.com/episode/12207421983382919118"
+  },
+  "steps": [
+    {
+      "url": "https://comicborder.com/episode/12207421983382919118",
+      "response": "01-episode.html"
+    },
+    {
+      "url": "https://comicborder.com/rss/series/3269754496402020044",
+      "response": "02-rss.xml"
+    }
+  ],
+  "expectedLatest": {
+    "source": "comicborder",
+    "workId": "https://comicborder.com/episode/12207421983382919118",
+    "latestKey": "https://comicborder.com/episode/12207421983382919118",
+    "url": "https://comicborder.com/episode/12207421983382919118",
+    "seriesTitle": "殺っちゃえ!! 宇喜多さん",
+    "episodeTitle": "第53話",
+    "pageTitle": "殺っちゃえ!! 宇喜多さん - 重野なおき / 第53話 | コミックボーダー",
+    "nextUpdateLabel": "05月15日"
+  }
+}

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -11,6 +11,7 @@ from manga_watch.sources import REGISTERED_ADAPTERS, REGISTERED_SOURCES, SourceA
 from manga_watch.sources.base import SourceParseError
 from manga_watch.sources.champion_cross import ChampionCrossAdapter
 from manga_watch.sources.comic_action import ComicActionAdapter
+from manga_watch.sources.comicborder import ComicBorderAdapter
 from manga_watch.sources.comic_walker import ComicWalkerAdapter
 from manga_watch.sources.kakuyomu import KakuyomuAdapter
 
@@ -34,6 +35,9 @@ SOURCE_CASES = {
         "escaped_next_uri",
         "broken_missing_next",
         "broken_loop",
+    ),
+    "comicborder": (
+        "normal",
     ),
     "champion-cross": (
         "normal",
@@ -66,6 +70,9 @@ EXPECTED_LATEST_CLASSIFICATIONS = {
         "escaped_next_uri": "main_story",
         "broken_missing_next": "main_story",
         "broken_loop": "main_story",
+    },
+    "comicborder": {
+        "normal": "main_story",
     },
     "champion-cross": {
         "normal": "main_story",
@@ -155,7 +162,7 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_registry_pins_supported_sources(self):
         self.assertEqual(
-            ("comic-walker", "comic-action", "champion-cross", "kakuyomu"),
+            ("comic-walker", "comic-action", "comicborder", "champion-cross", "kakuyomu"),
             REGISTERED_SOURCES,
         )
 
@@ -176,6 +183,9 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_comic_action_fixtures(self):
         self._assert_fixture_matrix("comic-action")
+
+    def test_comicborder_fixtures(self):
+        self._assert_fixture_matrix("comicborder")
 
     def test_kakuyomu_fixtures(self):
         self._assert_fixture_matrix("kakuyomu")
@@ -342,6 +352,63 @@ class SourceAdapterTests(unittest.TestCase):
         latest = adapter.fetch_latest(work, client).to_dict()
 
         self.assertEqual("4月3日", latest["nextUpdateLabel"])
+
+    def test_comicborder_normalize_accepts_episode_url(self):
+        work = ComicBorderAdapter().normalize("https://comicborder.com/episode/12207421983382919118?utm_source=share")
+
+        self.assertEqual(
+            {
+                "source": "comicborder",
+                "kind": "comicborder",
+                "workId": "https://comicborder.com/episode/12207421983382919118",
+                "seedUrl": "https://comicborder.com/episode/12207421983382919118",
+            },
+            work.to_dict(),
+        )
+
+    def test_comicborder_fetch_latest_uses_rss_feed_and_parses_title(self):
+        adapter = ComicBorderAdapter()
+        work = adapter.normalize("https://comicborder.com/episode/12207421983382919118")
+        client = StaticHttpClient(
+            {
+                "https://comicborder.com/episode/12207421983382919118": """
+                <html>
+                  <head>
+                    <title>殺っちゃえ!! 宇喜多さん - 重野なおき / 第53話 | コミックボーダー</title>
+                  </head>
+                  <body>
+                    <a href="https://comicborder.com/rss/series/3269754496402020044">RSSフィード</a>
+                    <div>次回更新： 05月15日</div>
+                  </body>
+                </html>
+                """,
+                "https://comicborder.com/rss/series/3269754496402020044": """
+                <rss version="2.0">
+                  <channel>
+                    <title>コミックボーダー（殺っちゃえ!! 宇喜多さん）</title>
+                    <item>
+                      <title>第53話</title>
+                      <link>https://comicborder.com/episode/12207421983382919118</link>
+                    </item>
+                  </channel>
+                </rss>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("https://comicborder.com/episode/12207421983382919118", latest["latestKey"])
+        self.assertEqual("殺っちゃえ!! 宇喜多さん", latest["seriesTitle"])
+        self.assertEqual("第53話", latest["episodeTitle"])
+        self.assertEqual("05月15日", latest["nextUpdateLabel"])
+        self.assertEqual(
+            [
+                "https://comicborder.com/episode/12207421983382919118",
+                "https://comicborder.com/rss/series/3269754496402020044",
+            ],
+            client.calls,
+        )
 
     def test_comic_walker_fetch_latest_extracts_next_update_label(self):
         adapter = ComicWalkerAdapter()


### PR DESCRIPTION
## Issue

- Fixes #282
- Parent: #276

## Summary

- Added a `comicborder` source adapter that normalizes live episode URLs, discovers the site RSS feed from the seed page, and resolves the latest episode metadata from the feed plus episode page.
- Wired `comicborder` into the registered source list and the live source drift canary contract.
- Added fixture-backed regression coverage for the representative live episode page `https://comicborder.com/episode/12207421983382919118`.

## Verification

- `.venv/bin/python -m unittest discover -s tests -p 'test_sources.py'`
- `.venv/bin/python -m unittest discover -s tests -p 'test_source_drift.py'`
- `.venv/bin/python -m unittest discover -s tests -p 'test_check.py'`
- `.venv/bin/python -m manga_watch.source_drift --source comicborder --format json`

## Residual risk

- The adapter depends on the RSS feed link remaining present on the seed episode page. If comicborder changes that markup, the canary will fail and the fixture will need refresh.