### PR TITLE
feat: add nicovideo-manga search support and regression coverage

### DIFF
--- a/manga_watch/source_drift.py
+++ b/manga_watch/source_drift.py
@@ -18,6 +18,7 @@ from .sources.champion_cross import (
 from .sources.comic_action import ComicActionAdapter, extract_comic_action_series_id, parse_comic_action_title
 from .sources.comic_walker import ComicWalkerAdapter, parse_comic_walker_title
 from .sources.kakuyomu import KakuyomuAdapter
+from .sources.nicovideo_manga import NicovideoMangaAdapter, canonical_nicovideo_manga_latest_url
 from .sources.util import html_title
 
 
@@ -108,6 +109,16 @@ DEFAULT_SOURCE_CANARY_CONTRACTS: Dict[str, SourceCanaryContract] = {
             "work page keeps __NEXT_DATA__",
             "latest episode id / title are discoverable from the work page payload",
             "latest episode page title is still readable",
+        ),
+    ),
+    "nicovideo-manga": SourceCanaryContract(
+        source="nicovideo-manga",
+        seed_url="https://sp.manga.nicovideo.jp/comic/53764",
+        fixture_bundle="tests/fixtures/nicovideo-manga/normal",
+        monitored_signals=(
+            "canonical comic URL is stable",
+            "latest episode URL is discoverable",
+            "latest episode page title still parses into series / episode labels",
         ),
     ),
 }
@@ -256,6 +267,28 @@ def _kakuyomu_canary(contract: SourceCanaryContract, http_client: HttpClient) ->
     )
 
 
+def _nicovideo_manga_canary(
+    contract: SourceCanaryContract,
+    http_client: HttpClient,
+) -> Tuple[Tuple[str, ...], Tuple[CanaryObservation, ...]]:
+    adapter = NicovideoMangaAdapter()
+    work = adapter.normalize(contract.seed_url)
+    latest = adapter.fetch_latest(work, http_client)
+    comic_id = str(work.metadata.get("comicId") or "")
+    latest_page_url = canonical_nicovideo_manga_latest_url(comic_id)
+    if not latest.episode_title:
+        raise SourceParseError("nicovideo-manga: latest episode title not found")
+
+    return (
+        (latest_page_url, latest.url),
+        (
+            CanaryObservation("canonical_seed_url", work.seed_url),
+            CanaryObservation("latest_episode_url", latest.url),
+            CanaryObservation("latest_episode_title", latest.episode_title),
+        ),
+    )
+
+
 def _champion_cross_canary(
     contract: SourceCanaryContract,
     http_client: HttpClient,
@@ -290,6 +323,7 @@ CANARY_RUNNERS = {
     "comic-action": _comic_action_canary,
     "champion-cross": _champion_cross_canary,
     "kakuyomu": _kakuyomu_canary,
+    "nicovideo-manga": _nicovideo_manga_canary,
 }
 
 

--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from html import unescape
+from typing import Callable, Dict, List, Optional
+from urllib.parse import quote_plus, urljoin, urlsplit, urlunsplit
+
+from manga_watch.sources import REGISTERED_SOURCES, normalize_seed_url
+from manga_watch.sources.base import HttpClient, RequestsHttpClient
+
+DEFAULT_SEARCH_LIMIT = 10
+SEARCH_RESULT_LIMIT = 25
+
+_SOURCE_SEARCH_CONFIG: Dict[str, Dict[str, object]] = {
+    "comic-walker": {
+        "search_url": "https://comic-walker.com/search?keyword={query}",
+        "allowed_domains": ("comic-walker.com", "www.comic-walker.com"),
+    },
+    "comic-action": {
+        "search_url": "https://comic-action.com/search?q={query}",
+        "allowed_domains": ("comic-action.com", "www.comic-action.com"),
+    },
+    "champion-cross": {
+        "search_url": "https://championcross.jp/search?keyword={query}",
+        "allowed_domains": ("championcross.jp", "www.championcross.jp"),
+    },
+    "kakuyomu": {
+        "search_url": "https://kakuyomu.jp/search?q={query}",
+        "allowed_domains": ("kakuyomu.jp", "www.kakuyomu.jp"),
+    },
+    "nicovideo-manga": {
+        "search_url": "https://manga.nicovideo.jp/search?q={query}",
+        "allowed_domains": ("manga.nicovideo.jp", "sp.manga.nicovideo.jp"),
+    },
+}
+
+_CONFIGURED_SOURCES = set(_SOURCE_SEARCH_CONFIG)
+_UNKNOWN_CONFIGURED_SOURCES = _CONFIGURED_SOURCES - set(REGISTERED_SOURCES)
+if _UNKNOWN_CONFIGURED_SOURCES:
+    unknown_sources = ", ".join(sorted(_UNKNOWN_CONFIGURED_SOURCES))
+    raise RuntimeError(f"search config contains unknown sources: {unknown_sources}")
+
+SUPPORTED_SEARCH_SOURCES: tuple[str, ...] = tuple(
+    source for source in REGISTERED_SOURCES if source in _CONFIGURED_SOURCES
+)
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    source: str
+    title: str
+    seed_url: str
+    subtitle: Optional[str] = None
+
+
+class UnsupportedSourceSearchError(ValueError):
+    pass
+
+
+def supported_search_sources() -> tuple[str, ...]:
+    return SUPPORTED_SEARCH_SOURCES
+
+
+def searchable_source_choices() -> List[Dict[str, str]]:
+    return [{"name": source, "value": source} for source in supported_search_sources()]
+
+
+def search_source(
+    source: str,
+    query: str,
+    *,
+    http_client: Optional[HttpClient] = None,
+    limit: int = DEFAULT_SEARCH_LIMIT,
+) -> List[SearchResult]:
+    normalized_source = str(source or "").strip()
+    normalized_query = str(query or "").strip()
+    if not normalized_source:
+        raise ValueError("search source is required")
+    if not normalized_query:
+        raise ValueError("search query is required")
+
+    if normalized_source not in _SOURCE_SEARCH_CONFIG:
+        raise UnsupportedSourceSearchError(f"unsupported search source: {normalized_source}")
+
+    client = http_client or RequestsHttpClient()
+    safe_limit = max(1, min(int(limit), SEARCH_RESULT_LIMIT))
+    return _search_via_public_site(normalized_source, normalized_query, client, limit=safe_limit)
+
+
+def _search_via_public_site(
+    source: str,
+    query: str,
+    http_client: HttpClient,
+    *,
+    limit: int,
+) -> List[SearchResult]:
+    config = _SOURCE_SEARCH_CONFIG[source]
+    search_url = str(config["search_url"]).format(query=quote_plus(query))
+    allowed_domains = tuple(str(domain).lower() for domain in config["allowed_domains"])
+    html_text = http_client.get_text(search_url)
+    return _extract_anchor_results(
+        html_text,
+        source=source,
+        search_url=search_url,
+        allowed_domains=allowed_domains,
+        limit=limit,
+    )
+
+
+def _extract_anchor_results(
+    html_text: str,
+    *,
+    source: str,
+    search_url: str,
+    allowed_domains: tuple[str, ...],
+    limit: int,
+) -> List[SearchResult]:
+    results: List[SearchResult] = []
+    seen_seed_urls = set()
+
+    for match in re.finditer(r'<a\b[^>]*href="([^"]+)"[^>]*>(.*?)</a>', html_text, re.I | re.S):
+        resolved_url = _resolve_result_url(match.group(1), search_url=search_url)
+        if not resolved_url:
+            continue
+        if not _is_allowed_domain(resolved_url, allowed_domains):
+            continue
+
+        canonical_seed_url = _canonical_seed_url_for_source(source, resolved_url)
+        if not canonical_seed_url or canonical_seed_url in seen_seed_urls:
+            continue
+
+        title = _extract_anchor_title(match.group(0), match.group(2))
+        if not title:
+            continue
+
+        seen_seed_urls.add(canonical_seed_url)
+        results.append(
+            SearchResult(
+                source=source,
+                title=title,
+                seed_url=canonical_seed_url,
+                subtitle=source,
+            )
+        )
+        if len(results) >= limit:
+            break
+
+    return results
+
+
+def _extract_anchor_title(anchor_markup: str, anchor_html: str) -> str:
+    title_attr_match = re.search(r'title\s*=\s*(["\'])(.*?)\1', anchor_markup, re.I | re.S)
+    if title_attr_match:
+        title = _normalize_anchor_text(title_attr_match.group(2))
+        if title:
+            return title
+
+    title = _normalize_anchor_text(anchor_html)
+    if title:
+        return title
+
+    image_alt_match = re.search(r'<img\b[^>]*alt\s*=\s*(["\'])(.*?)\1', anchor_html, re.I | re.S)
+    if not image_alt_match:
+        return ""
+
+    alt_title = _normalize_anchor_text(image_alt_match.group(2))
+    if not alt_title:
+        return ""
+    stripped_alt_title = re.sub(r"【.*$", "", alt_title).strip()
+    return stripped_alt_title or alt_title
+
+
+def _resolve_result_url(href: str, *, search_url: str) -> Optional[str]:
+    normalized = unescape(str(href or "")).strip().replace("\\/", "/")
+    if not normalized:
+        return None
+
+    parsed = urlsplit(normalized)
+    if not parsed.scheme:
+        normalized = urljoin(search_url, normalized)
+        parsed = urlsplit(normalized)
+
+    if parsed.scheme not in ("http", "https"):
+        return None
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", "")).rstrip("/")
+
+
+def _is_allowed_domain(url: str, allowed_domains: tuple[str, ...]) -> bool:
+    host = (urlsplit(url).netloc or "").lower()
+    return any(host == domain or host.endswith(f".{domain}") for domain in allowed_domains)
+
+
+def _canonical_seed_url_for_source(source: str, candidate_url: str) -> Optional[str]:
+    try:
+        descriptor = normalize_seed_url(candidate_url)
+    except Exception:
+        return None
+    if descriptor.source != source:
+        return None
+    return descriptor.seed_url
+
+
+def _normalize_anchor_text(text: str) -> str:
+    normalized = re.sub(r"<[^>]+>", "", text or "")
+    normalized = unescape(re.sub(r"\s+", " ", normalized)).strip()
+    normalized = re.sub(r"^最新UP!?\s*", "", normalized)
+    return normalized

--- a/manga_watch/sources/__init__.py
+++ b/manga_watch/sources/__init__.py
@@ -1,4 +1,5 @@
 from .base import HttpClient, LatestEpisode, RequestsHttpClient, SourceAdapter, WorkDescriptor
+from .nicovideo_manga import NicovideoMangaAdapter
 from .registry import (
     DEFAULT_ADAPTERS,
     REGISTERED_ADAPTERS,
@@ -15,6 +16,7 @@ __all__ = [
     "REGISTERED_ADAPTERS",
     "REGISTERED_SOURCES",
     "RequestsHttpClient",
+    "NicovideoMangaAdapter",
     "SourceAdapter",
     "WorkDescriptor",
     "fetch_latest_for_work",

--- a/manga_watch/sources/nicovideo_manga.py
+++ b/manga_watch/sources/nicovideo_manga.py
@@ -1,0 +1,119 @@
+import html
+import re
+from typing import Optional, Tuple
+
+from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
+from .util import html_title
+
+
+_CANONICAL_HOST = "manga.nicovideo.jp"
+_COMIC_URL = re.compile(r"^https?://(?:sp\.)?manga\.nicovideo\.jp/comic/(\d+)(?:/)?(?:\?.*)?$")
+_WATCH_URL = re.compile(r"https?://manga\.nicovideo\.jp/watch/(mg\d+)(?:[/?\"'&]|$)")
+_WATCH_PATH = re.compile(r"/watch/(mg\d+)(?:[/?\"'&]|$)")
+_TITLE_SUFFIX = " - ニコニコ漫画"
+_TITLE_PATTERN = re.compile(r"^(?P<series>.+)\s+(?P<episode>第.+?)\s*/\s*(?P<author>.+)$")
+
+
+def canonical_nicovideo_manga_comic_url(comic_id: str) -> str:
+    return f"https://{_CANONICAL_HOST}/comic/{comic_id}"
+
+
+def canonical_nicovideo_manga_latest_url(comic_id: str) -> str:
+    return f"{canonical_nicovideo_manga_comic_url(comic_id)}/new"
+
+
+def canonical_nicovideo_manga_watch_url(watch_id: str) -> str:
+    return f"https://{_CANONICAL_HOST}/watch/{watch_id}"
+
+
+def parse_nicovideo_manga_comic_url(seed_url: str) -> Optional[str]:
+    match = _COMIC_URL.match(seed_url)
+    if not match:
+        return None
+    return canonical_nicovideo_manga_comic_url(match.group(1))
+
+
+def extract_nicovideo_manga_comic_id(seed_url: str) -> Optional[str]:
+    match = _COMIC_URL.match(seed_url)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def extract_nicovideo_manga_watch_url(html_text: str) -> Optional[str]:
+    if not html_text:
+        return None
+
+    normalized = html.unescape(html_text).replace("\\/", "/")
+    match = _WATCH_URL.search(normalized)
+    if match:
+        return canonical_nicovideo_manga_watch_url(match.group(1))
+
+    match = _WATCH_PATH.search(normalized)
+    if match:
+        return canonical_nicovideo_manga_watch_url(match.group(1))
+    return None
+
+
+def parse_nicovideo_manga_title(page_title: str) -> Tuple[Optional[str], Optional[str]]:
+    normalized = str(page_title or "").strip()
+    if not normalized:
+        return None, None
+    if normalized.endswith(_TITLE_SUFFIX):
+        normalized = normalized[: -len(_TITLE_SUFFIX)].rstrip()
+
+    match = _TITLE_PATTERN.match(normalized)
+    if not match:
+        return None, None
+    series_title = match.group("series").strip()
+    episode_title = match.group("episode").strip()
+    return series_title or None, episode_title or None
+
+
+class NicovideoMangaAdapter(SourceAdapter):
+    source = "nicovideo-manga"
+
+    def can_handle(self, seed_url: str) -> bool:
+        return bool(parse_nicovideo_manga_comic_url(seed_url))
+
+    def normalize(self, seed_url: str) -> WorkDescriptor:
+        normalized_comic_url = parse_nicovideo_manga_comic_url(seed_url)
+        comic_id = extract_nicovideo_manga_comic_id(seed_url)
+        if not normalized_comic_url or not comic_id:
+            raise RuntimeError(f"{self.source}: could not parse comic URL: {seed_url}")
+
+        stable_work_id = f"{self.source}:{comic_id}"
+        return WorkDescriptor(
+            source=self.source,
+            work_id=stable_work_id,
+            seed_url=normalized_comic_url,
+            metadata={
+                "series": stable_work_id,
+                "comicId": comic_id,
+            },
+        )
+
+    def fetch_latest(self, work: WorkDescriptor, http_client: HttpClient) -> LatestEpisode:
+        comic_id = work.metadata.get("comicId") or extract_nicovideo_manga_comic_id(work.seed_url)
+        if not comic_id:
+            raise RuntimeError(f"{self.source}: comicId is required")
+
+        latest_page_url = canonical_nicovideo_manga_latest_url(comic_id)
+        html_text = http_client.get_text(latest_page_url)
+        latest_url = extract_nicovideo_manga_watch_url(html_text)
+        if not latest_url:
+            raise SourceParseError(f"{self.source}: latest watch URL not found")
+
+        page_title = html_title(html_text)
+        series_title, episode_title = parse_nicovideo_manga_title(page_title or "")
+
+        return LatestEpisode(
+            source=self.source,
+            work_id=work.work_id,
+            latest_key=latest_url,
+            url=latest_url,
+            series=work.metadata.get("series"),
+            series_title=series_title,
+            episode_title=episode_title,
+            page_title=page_title,
+        )

--- a/manga_watch/sources/registry.py
+++ b/manga_watch/sources/registry.py
@@ -5,6 +5,7 @@ from .champion_cross import ChampionCrossAdapter
 from .comic_action import ComicActionAdapter
 from .comic_walker import ComicWalkerAdapter
 from .kakuyomu import KakuyomuAdapter
+from .nicovideo_manga import NicovideoMangaAdapter
 
 # Explicit runtime registration contract for every supported source adapter.
 REGISTERED_ADAPTERS = (
@@ -12,6 +13,7 @@ REGISTERED_ADAPTERS = (
     ComicActionAdapter(),
     ChampionCrossAdapter(),
     KakuyomuAdapter(),
+    NicovideoMangaAdapter(),
 )
 REGISTERED_SOURCES = tuple(adapter.source for adapter in REGISTERED_ADAPTERS)
 

--- a/manga_watch/watchlist.py
+++ b/manga_watch/watchlist.py
@@ -56,6 +56,15 @@ SOURCE_CAPABILITIES = (
             "https://kakuyomu.jp/works/12345678901234567890/episodes/12345678901234567891",
         ),
     ),
+    SourceCapability(
+        source="nicovideo-manga",
+        domains=("manga.nicovideo.jp", "sp.manga.nicovideo.jp"),
+        input_labels=("comic URL",),
+        examples=(
+            "https://manga.nicovideo.jp/comic/53764",
+            "https://sp.manga.nicovideo.jp/comic/53764",
+        ),
+    ),
 )
 
 

--- a/tests/fixtures/nicovideo-manga/normal/01-latest.html
+++ b/tests/fixtures/nicovideo-manga/normal/01-latest.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta property="og:url" content="https://manga.nicovideo.jp/watch/mg1007626" />
+    <meta property="og:title" content="ダンジョンの中のひと 第51話 / 双見酔" />
+    <title>ダンジョンの中のひと 第51話 / 双見酔 - ニコニコ漫画</title>
+  </head>
+  <body></body>
+</html>

--- a/tests/fixtures/nicovideo-manga/normal/manifest.json
+++ b/tests/fixtures/nicovideo-manga/normal/manifest.json
@@ -1,0 +1,45 @@
+{
+  "seedUrl": "https://sp.manga.nicovideo.jp/comic/53764",
+  "expectedWork": {
+    "source": "nicovideo-manga",
+    "kind": "nicovideo-manga",
+    "workId": "nicovideo-manga:53764",
+    "seedUrl": "https://manga.nicovideo.jp/comic/53764",
+    "series": "nicovideo-manga:53764",
+    "comicId": "53764"
+  },
+  "steps": [
+    {
+      "url": "https://manga.nicovideo.jp/comic/53764/new",
+      "response": "01-latest.html"
+    }
+  ],
+  "expectedCheckedUrls": [
+    "https://manga.nicovideo.jp/comic/53764/new",
+    "https://manga.nicovideo.jp/watch/mg1007626"
+  ],
+  "expectedObservations": [
+    {
+      "name": "canonical_seed_url",
+      "value": "https://manga.nicovideo.jp/comic/53764"
+    },
+    {
+      "name": "latest_episode_url",
+      "value": "https://manga.nicovideo.jp/watch/mg1007626"
+    },
+    {
+      "name": "latest_episode_title",
+      "value": "第51話"
+    }
+  ],
+  "expectedLatest": {
+    "source": "nicovideo-manga",
+    "workId": "nicovideo-manga:53764",
+    "latestKey": "https://manga.nicovideo.jp/watch/mg1007626",
+    "url": "https://manga.nicovideo.jp/watch/mg1007626",
+    "series": "nicovideo-manga:53764",
+    "seriesTitle": "ダンジョンの中のひと",
+    "episodeTitle": "第51話",
+    "pageTitle": "ダンジョンの中のひと 第51話 / 双見酔 - ニコニコ漫画"
+  }
+}

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -1,0 +1,187 @@
+import unittest
+
+from manga_watch.source_search import SearchResult, search_source, supported_search_sources
+
+
+class StaticHttpClient:
+    def __init__(self, responses):
+        self.responses = dict(responses)
+
+    def get_text(self, url: str) -> str:
+        if url not in self.responses:
+            raise AssertionError(f"unexpected request: {url!r}")
+        return self.responses[url]
+
+
+class SourceSearchTests(unittest.TestCase):
+    def test_supported_search_sources_match_registered_sources(self):
+        self.assertEqual(
+            ("comic-walker", "comic-action", "champion-cross", "kakuyomu", "nicovideo-manga"),
+            supported_search_sources(),
+        )
+
+    def test_search_source_parses_comic_walker_results(self):
+        html = """
+        <html>
+          <body>
+            <a title="魔術師クノンは見えている" href="/detail/KC_003921_S/episodes/KC_0039210000100011_E">
+              魔術師クノンは見えている
+            </a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "comic-walker",
+            "クノン",
+            http_client=StaticHttpClient({"https://comic-walker.com/search?keyword=%E3%82%AF%E3%83%8E%E3%83%B3": html}),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comic-walker",
+                    title="魔術師クノンは見えている",
+                    seed_url="https://comic-walker.com/detail/KC_003921_S",
+                    subtitle="comic-walker",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_parses_comic_action_results(self):
+        html = """
+        <html>
+          <body>
+            <a href="https://comic-action.com/episode/11341664176570134078">
+              <img alt="ダンジョンの中のひと" />
+            </a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "comic-action",
+            "ダンジョンの中のひと",
+            http_client=StaticHttpClient(
+                {"https://comic-action.com/search?q=%E3%83%80%E3%83%B3%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%B8%AD%E3%81%AE%E3%81%B2%E3%81%A8": html}
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comic-action",
+                    title="ダンジョンの中のひと",
+                    seed_url="https://comic-action.com/episode/11341664176570134078",
+                    subtitle="comic-action",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_parses_champion_cross_results(self):
+        html = """
+        <html>
+          <body>
+            <a href="/series/e349a3791821b/?keyword=%E3%81%BE%E3%82%93%E3%81%8C">酒井美羽の少女まんが戦記</a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "champion-cross",
+            "まんが",
+            http_client=StaticHttpClient({"https://championcross.jp/search?keyword=%E3%81%BE%E3%82%93%E3%81%8C": html}),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="champion-cross",
+                    title="酒井美羽の少女まんが戦記",
+                    seed_url="https://championcross.jp/series/e349a3791821b",
+                    subtitle="champion-cross",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_parses_kakuyomu_results(self):
+        html = """
+        <html>
+          <body>
+            <a title="雉はどっちだ" href="/works/822139840410356917/episodes/1">雉はどっちだ</a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "kakuyomu",
+            "まんが",
+            http_client=StaticHttpClient({"https://kakuyomu.jp/search?q=%E3%81%BE%E3%82%93%E3%81%8C": html}),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="kakuyomu",
+                    title="雉はどっちだ",
+                    seed_url="https://kakuyomu.jp/works/822139840410356917/episodes/1",
+                    subtitle="kakuyomu",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_parses_nicovideo_manga_results(self):
+        html = """
+        <html>
+          <body>
+            <div class="search_result">
+              <div class="search_result__item">
+                <div class="search_result__item__thumbnail">
+                  <a href="/comic/53764?track=keyword_search">
+                    <img alt="ダンジョンの中のひと" />
+                  </a>
+                </div>
+                <div class="search_result__item__info">
+                  <div class="search_result__item__info--title">
+                    <a href="/comic/53764?track=keyword_search">ダンジョンの中のひと</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "nicovideo-manga",
+            "ダンジョンの中のひと",
+            http_client=StaticHttpClient(
+                {
+                    "https://manga.nicovideo.jp/search?q=%E3%83%80%E3%83%B3%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%B8%AD%E3%81%AE%E3%81%B2%E3%81%A8": html
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="nicovideo-manga",
+                    title="ダンジョンの中のひと",
+                    seed_url="https://manga.nicovideo.jp/comic/53764",
+                    subtitle="nicovideo-manga",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_rejects_unknown_source(self):
+        with self.assertRaisesRegex(ValueError, "unsupported search source"):
+            search_source("unknown", "まんが", http_client=StaticHttpClient({}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_search_e2e.py
+++ b/tests/test_source_search_e2e.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+
+from manga_watch.source_search import RequestsHttpClient, search_source
+
+
+RUN_REAL_SEARCH_E2E = os.environ.get("RUN_REAL_SEARCH_E2E") == "1"
+
+
+@unittest.skipUnless(RUN_REAL_SEARCH_E2E, "set RUN_REAL_SEARCH_E2E=1 to run real network search e2e tests")
+class SourceSearchE2ETests(unittest.TestCase):
+    def test_real_nicovideo_search_hits_dungeon_no_naka_no_hito(self):
+        client = RequestsHttpClient()
+        results = search_source("nicovideo-manga", "ダンジョンの中のひと", http_client=client)
+
+        self.assertTrue(
+            any(
+                result.title == "ダンジョンの中のひと"
+                and result.seed_url == "https://manga.nicovideo.jp/comic/53764"
+                for result in results
+            ),
+            msg=str(results),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -13,6 +13,7 @@ from manga_watch.sources.champion_cross import ChampionCrossAdapter
 from manga_watch.sources.comic_action import ComicActionAdapter
 from manga_watch.sources.comic_walker import ComicWalkerAdapter
 from manga_watch.sources.kakuyomu import KakuyomuAdapter
+from manga_watch.sources.nicovideo_manga import NicovideoMangaAdapter
 
 FIXTURES_ROOT = Path(__file__).parent / "fixtures"
 SOURCE_CASES = {
@@ -43,6 +44,9 @@ SOURCE_CASES = {
         "normal",
         "episode_seed_missing_next_update",
     ),
+    "nicovideo-manga": (
+        "normal",
+    ),
 }
 ADAPTERS = {adapter.source: adapter.__class__ for adapter in REGISTERED_ADAPTERS}
 ERROR_TYPES = {
@@ -71,6 +75,9 @@ EXPECTED_LATEST_CLASSIFICATIONS = {
         "normal": "main_story",
         "episode_seed_missing_next_update": "main_story",
         "episode_seed_missing_next_update": "main_story",
+    },
+    "nicovideo-manga": {
+        "normal": "main_story",
     },
 }
 
@@ -155,7 +162,7 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_registry_pins_supported_sources(self):
         self.assertEqual(
-            ("comic-walker", "comic-action", "champion-cross", "kakuyomu"),
+            ("comic-walker", "comic-action", "champion-cross", "kakuyomu", "nicovideo-manga"),
             REGISTERED_SOURCES,
         )
 
@@ -182,6 +189,9 @@ class SourceAdapterTests(unittest.TestCase):
 
     def test_champion_cross_fixtures(self):
         self._assert_fixture_matrix("champion-cross")
+
+    def test_nicovideo_manga_fixtures(self):
+        self._assert_fixture_matrix("nicovideo-manga")
 
     def test_comic_walker_normalize_accepts_canonical_series_url(self):
         work = ComicWalkerAdapter().normalize("https://comic-walker.com/detail/KC_123456_S/?from=detail")

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -168,6 +168,23 @@ class WatchlistCliTests(unittest.TestCase):
         self.assertEqual(1, payload["work_count"])
         self.assertEqual(1, len(saved["works"]))
 
+    def test_watchlist_add_accepts_nicovideo_manga_comic_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            watchlist_path = Path(tmpdir) / "watchlist.json"
+            write_watchlist(watchlist_path, [])
+
+            payload = add_watchlist_url(
+                "https://manga.nicovideo.jp/comic/53764",
+                watchlist_path=str(watchlist_path),
+            )
+            saved = json.loads(watchlist_path.read_text(encoding="utf-8"))
+
+        self.assertEqual("added", payload["action"])
+        self.assertEqual("nicovideo-manga:53764", payload["entry"]["id"])
+        self.assertEqual("https://manga.nicovideo.jp/comic/53764", payload["entry"]["seed_url"])
+        self.assertEqual(1, payload["work_count"])
+        self.assertEqual(1, len(saved["works"]))
+
     def test_watchlist_add_reports_unsupported_source(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             watchlist_path = Path(tmpdir) / "watchlist.json"


### PR DESCRIPTION
## Summary
- Add `nicovideo-manga` source adapter and register it in the source registry.
- Add `/search` support and nicovideo-specific regression coverage for the representative `ダンジョンの中のひと` query.
- Extend drift checks and watchlist capability wiring so the canonical nicovideo comic URL is accepted end-to-end.

## Verification
- `python -m unittest tests.test_sources tests.test_watchlist tests.test_source_search`
- `RUN_REAL_SEARCH_E2E=1 python -m unittest tests.test_source_search_e2e`
- `python -m unittest discover -s tests`

## Issue
- Fixes #278
- Follows parent #276
