### PR TITLE
champion-cross の /search 代表作品ヒットを固定し、回帰テストで保証する

### DIFF
--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -226,6 +226,73 @@ def _extract_comic_action_latest_link(block: str) -> str:
     return ""
 
 
+def _search_champion_cross(
+    query: str,
+    http_client: HttpClient,
+    *,
+    limit: int,
+) -> List[SearchResult]:
+    search_url = str(_SOURCE_SEARCH_CONFIG["champion-cross"]["search_url"]).format(query=quote_plus(query))
+    html_text = http_client.get_text(search_url)
+    results: List[SearchResult] = []
+    seen_seed_urls = set()
+
+    for match in re.finditer(r'<a\b[^>]*href="([^"]+)"[^>]*>(.*?)</a>', html_text, re.I | re.S):
+        anchor_markup = match.group(0)
+        if "c-ms-mode-series" not in anchor_markup:
+            continue
+
+        resolved_url = _resolve_result_url(match.group(1), search_url=search_url)
+        if not resolved_url:
+            continue
+
+        canonical_seed_url = _canonical_seed_url_for_source("champion-cross", resolved_url)
+        if not canonical_seed_url or canonical_seed_url in seen_seed_urls:
+            continue
+
+        title = _champion_cross_title(anchor_markup, match.group(2))
+        if not title:
+            continue
+
+        seen_seed_urls.add(canonical_seed_url)
+        results.append(
+            SearchResult(
+                source="champion-cross",
+                title=title,
+                seed_url=canonical_seed_url,
+                subtitle="champion-cross",
+            )
+        )
+        if len(results) >= limit:
+            break
+
+    if results:
+        return results
+
+    return _extract_anchor_results(
+        html_text,
+        source="champion-cross",
+        search_url=search_url,
+        allowed_domains=("championcross.jp", "www.championcross.jp"),
+        limit=limit,
+    )
+
+def _champion_cross_title(anchor_markup: str, anchor_html: str) -> str:
+    title_match = re.search(r'<h2\b[^>]*class="[^"]*\bmanga-title\b[^"]*"[^>]*>(.*?)</h2>', anchor_html, re.I | re.S)
+    if title_match:
+        title = _normalize_anchor_text(title_match.group(1))
+        if title:
+            return title
+
+    image_alt_match = re.search(r'<img\b[^>]*alt\s*=\s*(["\'])(.*?)\1', anchor_html, re.I | re.S)
+    if image_alt_match:
+        title = _normalize_anchor_text(image_alt_match.group(2))
+        if title:
+            return title
+
+    return _extract_anchor_title(anchor_markup, anchor_html)
+
+
 def _search_gaugau(
     query: str,
     http_client: HttpClient,
@@ -394,4 +461,5 @@ _SEARCHERS: Dict[str, Callable[..., List[SearchResult]]] = {
     for source in SUPPORTED_SEARCH_SOURCES
 }
 _SEARCHERS["comic-action"] = _search_comic_action
+_SEARCHERS["champion-cross"] = _search_champion_cross
 _SEARCHERS["gaugau"] = _search_gaugau

--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -277,6 +277,7 @@ def _search_champion_cross(
         limit=limit,
     )
 
+
 def _champion_cross_title(anchor_markup: str, anchor_html: str) -> str:
     title_match = re.search(r'<h2\b[^>]*class="[^"]*\bmanga-title\b[^"]*"[^>]*>(.*?)</h2>', anchor_html, re.I | re.S)
     if title_match:

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -115,6 +115,48 @@ class SourceSearchTests(unittest.TestCase):
             results,
         )
 
+    def test_search_source_prefers_champion_cross_series_card_over_noise_links(self):
+        html = """
+        <html>
+          <body>
+            <div class="incremental-suggestion-panel">
+              <a class="incremental-result-item x-incremental-result-anchor" href="/championcross/series/4756324e1c1b1/?keyword=%E7%B9%94%E6%B4%A5%E6%B1%9F%E5%A4%A7%E5%BF%97">
+                火曜更新
+              </a>
+            </div>
+            <div class="series-list">
+              <div class="manga-store-item">
+                <a class="c-ms-clk-article c-ms-mode-series click-link" href="https://championcross.jp/series/4756324e1c1b1">
+                  <div class="manga-title-box">
+                    <h2 class="manga-title">織津江大志の異世界クリ娘サバイバル日誌</h2>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "champion-cross",
+            "織津江大志",
+            http_client=StaticHttpClient(
+                {"https://championcross.jp/search?keyword=%E7%B9%94%E6%B4%A5%E6%B1%9F%E5%A4%A7%E5%BF%97": html}
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="champion-cross",
+                    title="織津江大志の異世界クリ娘サバイバル日誌",
+                    seed_url="https://championcross.jp/series/4756324e1c1b1",
+                    subtitle="champion-cross",
+                )
+            ],
+            results,
+        )
+
     def test_search_source_parses_comic_action_results_via_q_parameter(self):
         html = """
         <html>


### PR DESCRIPTION
## Issue
- Fix Champion Cross search-result parsing for the representative work from #287.
- Prefer the canonical series card over the incremental suggestion/update-label link.

## Changes
- Added a Champion Cross-specific search parser in `manga_watch/source_search.py` that keys off the live `c-ms-mode-series` result card and extracts the title from `h2.manga-title`.
- Kept the existing image-alt fallback so simpler Champion Cross result snippets still parse.
- Added a regression test that reproduces the live noisy search page shape from `織津江大志`.

## Verification
- `python -m unittest tests.test_source_search`
- `python -m unittest tests.test_sources tests.test_source_drift tests.test_check`
- Live probe against `https://championcross.jp/search?keyword=%E7%B9%94%E6%B4%A5%E6%B1%9F%E5%A4%A7%E5%BF%97`

## Residual risk
- This still depends on Champion Cross keeping the canonical series card structure; if the site changes markup, the regression will need a refresh.
