### PR TITLE
test: pin shonenjumpplus search regression

### DIFF
--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -507,9 +507,9 @@ class SourceSearchTests(unittest.TestCase):
         <html>
           <body>
             <li class="daily-series-item">
-              <a href="https://shonenjumpplus.com/episode/17107419589191808162">
+              <a href="https://shonenjumpplus.com/episode/17107419589372003740">
                 <div class="daily-series-info">
-                  <h2 class="daily-series-title">ふつうの軽音部</h2>
+                  <h2 class="daily-series-title">SPY×FAMILY</h2>
                 </div>
               </a>
             </li>
@@ -519,10 +519,10 @@ class SourceSearchTests(unittest.TestCase):
 
         results = search_source(
             "shonenjumpplus",
-            "ふつうの軽音部",
+            "SPY×FAMILY",
             http_client=StaticHttpClient(
                 {
-                    "https://shonenjumpplus.com/search?query=%E3%81%B5%E3%81%A4%E3%81%86%E3%81%AE%E8%BB%BD%E9%9F%B3%E9%83%A8": "<html></html>",
+                    "https://shonenjumpplus.com/search?query=SPY%C3%97FAMILY": "<html></html>",
                     "https://shonenjumpplus.com/": html,
                 }
             ),
@@ -532,8 +532,8 @@ class SourceSearchTests(unittest.TestCase):
             [
                 SearchResult(
                     source="shonenjumpplus",
-                    title="ふつうの軽音部",
-                    seed_url="https://shonenjumpplus.com/episode/17107419589191808162",
+                    title="SPY×FAMILY",
+                    seed_url="https://shonenjumpplus.com/episode/17107419589372003740",
                     subtitle="shonenjumpplus",
                 )
             ],

--- a/tests/test_source_search_e2e.py
+++ b/tests/test_source_search_e2e.py
@@ -12,6 +12,20 @@ RUN_REAL_SEARCH_E2E = os.environ.get("RUN_REAL_SEARCH_E2E") == "1"
 
 @unittest.skipUnless(RUN_REAL_SEARCH_E2E, "set RUN_REAL_SEARCH_E2E=1 to run real network search e2e tests")
 class SourceSearchE2ETests(unittest.TestCase):
+    def test_real_search_source_requests_reach_expected_work_for_shonenjumpplus_spy_family(self):
+        client = RequestsHttpClient()
+        results = search_source("shonenjumpplus", "SPY×FAMILY", http_client=client)
+
+        self.assertTrue(results, msg="shonenjumpplus returned no results for SPY×FAMILY")
+        self.assertTrue(
+            any(
+                result.title == "SPY×FAMILY"
+                and result.seed_url == "https://shonenjumpplus.com/episode/17107419589372003740"
+                for result in results
+            ),
+            msg=str(results),
+        )
+
     def test_real_search_source_requests_reach_expected_works_for_recognized_media_title_pairs(self):
         client = RequestsHttpClient()
         cases = [
@@ -47,9 +61,9 @@ class SourceSearchE2ETests(unittest.TestCase):
             ),
             (
                 "shonenjumpplus",
-                "ふつうの軽音部",
-                "ふつうの軽音部",
-                "https://shonenjumpplus.com/episode/17107419589191808162",
+                "SPY×FAMILY",
+                "SPY×FAMILY",
+                "https://shonenjumpplus.com/episode/17107419589372003740",
             ),
             (
                 "sunday-webry",


### PR DESCRIPTION
## Issue
- https://github.com/kentoku24/comic_crawler/issues/285

## What changed
- Pin the Jump+ regression matrix to the live-probed `SPY×FAMILY` representative work
- Keep the existing homepage-fallback unit test but align it to the live latest-episode URL returned by `search_source`
- Add a focused opt-in E2E test for the Jump+ representative pair

## Live probe
- `search_source("shonenjumpplus", "SPY×FAMILY")` returns `SPY×FAMILY` with canonical seed URL `https://shonenjumpplus.com/episode/17107419589372003740`

## Verification
- `.venv/bin/python -m unittest tests.test_source_search.SourceSearchTests.test_search_source_parses_shonenjumpplus_homepage_results`
- `RUN_REAL_SEARCH_E2E=1 MANGA_WATCH_HTTP_TIMEOUT=8 MANGA_WATCH_HTTP_RETRIES=0 .venv/bin/python -m unittest tests.test_source_search_e2e.SourceSearchE2ETests.test_real_search_source_requests_reach_expected_work_for_shonenjumpplus_spy_family`
- `.venv/bin/python -m unittest tests.test_source_search.SourceSearchTests`

## Residual risk
- The broader opt-in `tests.test_source_search_e2e` matrix still has unrelated live-drift failures for other media if run wholesale; this PR only pins the Jump+ lane required by #285.
