### PR TITLE
[codex] remove production approval gate from deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -119,7 +119,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: production
     env:
       IMAGE_REF: ${{ needs.build.outputs.image_ref }}
       IMAGE_DIGEST: ${{ needs.build.outputs.image_digest }}

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -29,7 +29,7 @@ class GitHubWorkflowContractTests(unittest.TestCase):
         self.assertIn("test:", content)
         self.assertIn("build:", content)
         self.assertIn("deploy:", content)
-        self.assertIn("environment: production", content)
+        self.assertNotIn("environment: production", content.split("  deploy:", maxsplit=1)[1])
 
     def test_deploy_workflow_emits_and_consumes_an_image_digest(self):
         content = read_workflow("deploy-production.yml")


### PR DESCRIPTION
## What changed
- removed `environment: production` from the `deploy` job in `Deploy Production`
- updated the workflow contract test to assert the deploy job no longer uses the production environment gate

## Why
`Deploy Production` was blocked by the GitHub Environment approval gate. This change lets deploys triggered by pushes to `main` proceed without manual approval while leaving `Rollback Production` unchanged.

## Impact
Production deploys from `main` will no longer wait for environment reviewer approval.

## Validation
- `python -m unittest tests.test_github_workflows`