### PR TITLE
fix: restore search fallbacks for remaining media

### DIFF
--- a/manga_watch/source_search.py
+++ b/manga_watch/source_search.py
@@ -145,15 +145,24 @@ def _search_via_public_site(
 
     search_url = str(config["search_url"]).format(query=_encode_search_query(source, query))
     allowed_domains = tuple(str(domain).lower() for domain in config["allowed_domains"])
-    html_text = http_client.get_text(search_url)
+    fallback_searcher = _FALLBACK_SEARCHERS.get(source)
+    try:
+        html_text = http_client.get_text(search_url)
+    except Exception:
+        if fallback_searcher is None:
+            raise
+        return fallback_searcher(query, http_client, limit=limit)
 
-    return _extract_anchor_results(
+    results = _extract_anchor_results(
         html_text,
         source=source,
         search_url=search_url,
         allowed_domains=allowed_domains,
         limit=limit,
     )
+    if results or fallback_searcher is None:
+        return results
+    return fallback_searcher(query, http_client, limit=limit)
 
 
 def _search_comic_action(
@@ -443,8 +452,16 @@ def _search_gaugau(
     config = _SOURCE_SEARCH_CONFIG["gaugau"]
     search_url = str(config["search_url"]).format(query=quote_plus(query))
     html_text = http_client.get_text(search_url)
-    return _extract_work_results(
-        html_text,
+    section = html_text
+    section_start = html_text.find('<div class="works__list">')
+    if section_start >= 0:
+        section = html_text[section_start:]
+        section_end = section.find('<div class="ranking">')
+        if section_end > 0:
+            section = section[:section_end]
+
+    return _extract_gaugau_results(
+        section,
         source="gaugau",
         search_url=search_url,
         allowed_domains=("gaugau.futabanet.jp",),
@@ -622,6 +639,155 @@ def _extract_work_results(
     return results
 
 
+def _extract_gaugau_results(
+    html_text: str,
+    *,
+    source: str,
+    search_url: str,
+    allowed_domains: tuple[str, ...],
+    limit: int,
+) -> List[SearchResult]:
+    results: List[SearchResult] = []
+    seen_seed_urls = set()
+
+    for title_match in re.finditer(r'<h4>\s*<a\b[^>]*href="([^"]+)"[^>]*>(.*?)</a>\s*</h4>', html_text, re.I | re.S):
+        resolved_url = _resolve_result_url(title_match.group(1), search_url=search_url)
+        if not resolved_url or "/episodes/" in resolved_url:
+            continue
+        if not _is_allowed_domain(resolved_url, allowed_domains):
+            continue
+
+        canonical_seed_url = _canonical_seed_url_for_source(source, resolved_url)
+        if not canonical_seed_url or canonical_seed_url in seen_seed_urls:
+            continue
+
+        title = _normalize_anchor_text(title_match.group(2))
+        if not title:
+            continue
+
+        seen_seed_urls.add(canonical_seed_url)
+        results.append(
+            SearchResult(
+                source=source,
+                title=title,
+                seed_url=canonical_seed_url,
+                subtitle=source,
+            )
+        )
+        if len(results) >= limit:
+            break
+
+    return results
+
+
+def _search_from_homepage(
+    source: str,
+    query: str,
+    http_client: HttpClient,
+    *,
+    limit: int,
+) -> List[SearchResult]:
+    homepage_url = _HOMEPAGE_URLS[source]
+    extractor = _HOMEPAGE_EXTRACTORS[source]
+    html_text = http_client.get_text(homepage_url)
+    return extractor(query, html_text, homepage_url=homepage_url, limit=limit)
+
+
+def _extract_comicborder_homepage_results(
+    query: str,
+    html_text: str,
+    *,
+    homepage_url: str,
+    limit: int,
+) -> List[SearchResult]:
+    return _filter_results_by_query(
+        query,
+        _extract_anchor_results(
+            html_text,
+            source="comicborder",
+            search_url=homepage_url,
+            allowed_domains=("comicborder.com", "www.comicborder.com"),
+            limit=SEARCH_RESULT_LIMIT,
+        ),
+        limit=limit,
+    )
+
+
+def _extract_comic_trail_homepage_results(
+    query: str,
+    html_text: str,
+    *,
+    homepage_url: str,
+    limit: int,
+) -> List[SearchResult]:
+    return _extract_title_block_results(
+        query,
+        html_text,
+        source="comic-trail",
+        homepage_url=homepage_url,
+        limit=limit,
+        block_pattern=r'<a\b[^>]*href="([^"]*?/episode/[^"]+)"[^>]*>(.*?)</a>',
+        title_patterns=(r'alt="([^"|]+)(?:\||｜)[^"]*"', r'<h4[^>]*>(.*?)</h4>'),
+    )
+
+
+def _extract_shonenjumpplus_homepage_results(
+    query: str,
+    html_text: str,
+    *,
+    homepage_url: str,
+    limit: int,
+) -> List[SearchResult]:
+    return _extract_title_block_results(
+        query,
+        html_text,
+        source="shonenjumpplus",
+        homepage_url=homepage_url,
+        limit=limit,
+        block_pattern=r'<a\b[^>]*href="([^"]*?/episode/[^"]+)"[^>]*>(.*?)</a>',
+        title_patterns=(r'daily-series-title[^>]*>(.*?)</h2>', r'gtm-daily-series-thumb-horizontal-([^"\s]+)'),
+    )
+
+
+def _extract_title_block_results(
+    query: str,
+    html_text: str,
+    *,
+    source: str,
+    homepage_url: str,
+    limit: int,
+    block_pattern: str,
+    title_patterns: tuple[str, ...],
+) -> List[SearchResult]:
+    results: List[SearchResult] = []
+    seen_seed_urls = set()
+    for match in re.finditer(block_pattern, html_text, re.I | re.S):
+        title = ""
+        for title_pattern in title_patterns:
+            title_match = re.search(title_pattern, match.group(2), re.I | re.S)
+            title = _normalize_anchor_text(title_match.group(1) if title_match else "")
+            if title:
+                title = re.split(r"[|｜]", title, maxsplit=1)[0].strip()
+                break
+        if not _query_matches_title(query, title):
+            continue
+
+        resolved_url = _resolve_result_url(match.group(1), search_url=homepage_url)
+        if not resolved_url:
+            continue
+
+        canonical_seed_url = _canonical_seed_url_for_source(source, resolved_url)
+        if not canonical_seed_url or canonical_seed_url in seen_seed_urls:
+            continue
+
+        seen_seed_urls.add(canonical_seed_url)
+        results.append(SearchResult(source, title, canonical_seed_url, source))
+        if len(results) >= limit:
+            break
+
+    return results
+
+
 def _extract_anchor_title(anchor_markup: str, anchor_html: str) -> str:
     title_attr_match = re.search(r'title\s*=\s*(["\'])(.*?)\1', anchor_markup, re.I | re.S)
     if title_attr_match:
@@ -677,12 +843,47 @@ def _canonical_seed_url_for_source(source: str, candidate_url: str) -> Optional[
 def _normalize_anchor_text(text: str) -> str:
     normalized = re.sub(r"<[^>]+>", "", text or "")
     normalized = unescape(re.sub(r"\s+", " ", normalized)).strip()
-    normalized = re.sub(r"^最新UP!?\s*", "", normalized)
+    normalized = re.sub(r"^(?:最新UP!?|NEW!)\s*", "", normalized)
     return normalized
 
 
 def _normalize_takecomic_search_title(title: str) -> str:
     return re.sub(r"^更新\s*", "", title or "").strip()
+
+
+def _query_matches_title(query: str, title: str) -> bool:
+    normalized_query = re.sub(r"\s+", "", query or "").casefold()
+    normalized_title = re.sub(r"\s+", "", title or "").casefold()
+    if not normalized_query or not normalized_title:
+        return False
+    return normalized_query == normalized_title or normalized_query in normalized_title or normalized_title in normalized_query
+
+
+def _filter_results_by_query(query: str, results: List[SearchResult], *, limit: int) -> List[SearchResult]:
+    filtered = [result for result in results if _query_matches_title(query, result.title)]
+    return filtered[:limit]
+
+
+_HOMEPAGE_URLS: Dict[str, str] = {
+    "comicborder": "https://comicborder.com/",
+    "comic-trail": "https://comic-trail.com/",
+    "shonenjumpplus": "https://shonenjumpplus.com/",
+}
+
+_HOMEPAGE_EXTRACTORS: Dict[str, Callable[..., List[SearchResult]]] = {
+    "comicborder": _extract_comicborder_homepage_results,
+    "comic-trail": _extract_comic_trail_homepage_results,
+    "shonenjumpplus": _extract_shonenjumpplus_homepage_results,
+}
+
+_FALLBACK_SEARCHERS: Dict[str, Callable[..., List[SearchResult]]] = {
+    source: (
+        lambda query, http_client, *, limit, _source=source: _search_from_homepage(
+            _source, query, http_client, limit=limit
+        )
+    )
+    for source in _HOMEPAGE_EXTRACTORS
+}
 
 
 _SEARCHERS: Dict[str, Callable[..., List[SearchResult]]] = {

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -14,7 +14,10 @@ class StaticHttpClient:
     def get_text(self, url: str) -> str:
         if url not in self.responses:
             raise AssertionError(f"unexpected request: {url!r}")
-        return self.responses[url]
+        response = self.responses[url]
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 class SourceSearchTests(unittest.TestCase):
@@ -467,6 +470,155 @@ class SourceSearchTests(unittest.TestCase):
                     title="ダンジョンの中のひと",
                     seed_url="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
                     subtitle="gaugau",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_prefers_gaugau_series_heading_over_badge_inside_thumbnail_anchor(self):
+        html = """
+        <html>
+          <body>
+            <div class="works__list">
+              <div class="works__grid">
+                <div class="list__box -free">
+                  <a class="thumbnail -youth" href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000">
+                    <div class="img"><img alt="" /></div>
+                    <p class="thumbnail__badge">無料コミック 3/27 更新</p>
+                  </a>
+                  <div class="list__text">
+                    <h4>
+                      <a href="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000">ダンジョンの中のひと</a>
+                    </h4>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "gaugau",
+            "ダンジョンの中のひと",
+            http_client=StaticHttpClient(
+                {
+                    "https://gaugau.futabanet.jp/list/search-result?word=%E3%83%80%E3%83%B3%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%B8%AD%E3%81%AE%E3%81%B2%E3%81%A8": html
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="gaugau",
+                    title="ダンジョンの中のひと",
+                    seed_url="https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000",
+                    subtitle="gaugau",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_falls_back_to_comicborder_homepage_results_when_search_errors(self):
+        homepage_html = """
+        <html><body>
+          <a href="/episode/12207421983382919118">NEW! 殺っちゃえ!! 宇喜多さん</a>
+        </body></html>
+        """
+
+        results = search_source(
+            "comicborder",
+            "殺っちゃえ!! 宇喜多さん",
+            http_client=StaticHttpClient(
+                {
+                    "https://comicborder.com/search?keyword=%E6%AE%BA%E3%81%A3%E3%81%A1%E3%82%83%E3%81%88%21%21+%E5%AE%87%E5%96%9C%E5%A4%9A%E3%81%95%E3%82%93": RuntimeError(
+                        "400"
+                    ),
+                    "https://comicborder.com/": homepage_html,
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comicborder",
+                    title="殺っちゃえ!! 宇喜多さん",
+                    seed_url="https://comicborder.com/episode/12207421983382919118",
+                    subtitle="comicborder",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_falls_back_to_comic_trail_homepage_results_when_search_is_empty(self):
+        homepage_html = """
+        <html>
+          <body>
+            <a href="/episode/2551460910065898017">
+              <img alt="破滅の聖女は運命の夫の溺愛から逃れたい｜コミックトレイル" />
+            </a>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "comic-trail",
+            "破滅の聖女は運命の夫の溺愛から逃れたい",
+            http_client=StaticHttpClient(
+                {
+                    "https://comic-trail.com/search?keyword=%E7%A0%B4%E6%BB%85%E3%81%AE%E8%81%96%E5%A5%B3%E3%81%AF%E9%81%8B%E5%91%BD%E3%81%AE%E5%A4%AB%E3%81%AE%E6%BA%BA%E6%84%9B%E3%81%8B%E3%82%89%E9%80%83%E3%82%8C%E3%81%9F%E3%81%84": "<html></html>",
+                    "https://comic-trail.com/": homepage_html,
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="comic-trail",
+                    title="破滅の聖女は運命の夫の溺愛から逃れたい",
+                    seed_url="https://comic-trail.com/episode/2551460910065898017",
+                    subtitle="comic-trail",
+                )
+            ],
+            results,
+        )
+
+    def test_search_source_falls_back_to_shonenjumpplus_homepage_results_when_search_is_empty(self):
+        homepage_html = """
+        <html>
+          <body>
+            <li class="daily-series-item">
+              <a href="/episode/17107419589372003740">
+                <div class="daily-series-info">
+                  <h2 class="daily-series-title">SPY×FAMILY</h2>
+                </div>
+              </a>
+            </li>
+          </body>
+        </html>
+        """
+
+        results = search_source(
+            "shonenjumpplus",
+            "SPY×FAMILY",
+            http_client=StaticHttpClient(
+                {
+                    "https://shonenjumpplus.com/search?query=SPY%C3%97FAMILY": "<html></html>",
+                    "https://shonenjumpplus.com/": homepage_html,
+                }
+            ),
+        )
+
+        self.assertEqual(
+            [
+                SearchResult(
+                    source="shonenjumpplus",
+                    title="SPY×FAMILY",
+                    seed_url="https://shonenjumpplus.com/episode/17107419589372003740",
+                    subtitle="shonenjumpplus",
                 )
             ],
             results,

--- a/tests/test_source_search_e2e.py
+++ b/tests/test_source_search_e2e.py
@@ -22,6 +22,24 @@ REPRESENTATIVE_SEARCH_CASES = (
         "expected_title": "薫る花は凛と咲く",
         "expected_seed_url": "https://pocket.shonenmagazine.com/title/01524",
     },
+    {
+        "source": "comicborder",
+        "query": "殺っちゃえ!! 宇喜多さん",
+        "expected_title": "殺っちゃえ!! 宇喜多さん",
+        "expected_seed_url": "https://comicborder.com/episode/12207421983382919118",
+    },
+    {
+        "source": "comic-trail",
+        "query": "破滅の聖女は運命の夫の溺愛から逃れたい",
+        "expected_title": "破滅の聖女は運命の夫の溺愛から逃れたい",
+        "expected_seed_url": "https://comic-trail.com/episode/12207421983526323511",
+    },
+    {
+        "source": "shonenjumpplus",
+        "query": "SPY×FAMILY",
+        "expected_title": "SPY×FAMILY",
+        "expected_seed_url": "https://shonenjumpplus.com/episode/17107419589372003740",
+    },
 )
 
 
@@ -66,9 +84,11 @@ class SourceSearchE2ETests(unittest.TestCase):
         )
         self.assertTrue(
             any(
-                result.seed_url == "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000"
+                result.title == "ダンジョンの中のひと"
+                and result.seed_url == "https://gaugau.futabanet.jp/list/work/600a5fd37765610d30010000"
                 for result in gaugau_results
-            )
+            ),
+            msg=str(gaugau_results),
         )
         self.assertTrue(
             any(


### PR DESCRIPTION
## Summary
- restore homepage fallback search for comicborder, comic-trail, and shonenjumpplus when search pages error or return no hits
- prefer gaugau series headings over update badges so live search returns the work title
- pin representative live regressions for comicborder, comic-trail, gaugau, and shonenjumpplus

## Issues
- Closes #279
- Closes #282
- Closes #283
- Closes #285

## Verification
- `python -m unittest tests.test_source_search tests.test_source_search_e2e`
- `RUN_REAL_SEARCH_E2E=1 python -m unittest tests.test_source_search_e2e`
