### PR TITLE
feat: add Discord title command skeleton

### DIFF
--- a/manga_watch/discord_inbound.py
+++ b/manga_watch/discord_inbound.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List, Mapping, Optional, Protocol, Sequence
 
 from manga_watch.discord_fetch import handle_fetch_trigger
 from manga_watch.discord_latest import handle_latest_query
+from manga_watch.discord_title_search import handle_title_query
 
 DEFAULT_COMMAND_POLL_INTERVAL = 5.0
 DISCORD_MESSAGE_LIMIT = 2000
@@ -109,6 +110,7 @@ class DiscordCommandListener:
     poll_interval_seconds: float = DEFAULT_COMMAND_POLL_INTERVAL
     latest_handler: Callable[..., Optional[str]] = handle_latest_query
     fetch_handler: Callable[..., Optional[Dict[str, object]]] = handle_fetch_trigger
+    title_handler: Callable[..., Optional[str]] = handle_title_query
     report_logger: Callable[[str], None] = print
     error_logger: Callable[[str], None] = print
     sleep_fn: Callable[[float], None] = time.sleep
@@ -164,6 +166,11 @@ class DiscordCommandListener:
         if latest_response is not None:
             self._send_response(latest_response)
             return latest_response
+
+        title_response = self.title_handler(content)
+        if title_response is not None:
+            self._send_response(title_response)
+            return title_response
 
         fetch_response = self.fetch_handler(content, coordinator=self.coordinator)
         if fetch_response is None:

--- a/manga_watch/discord_title_search.py
+++ b/manga_watch/discord_title_search.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from manga_watch.source_search import search_source, supported_search_sources
+
+TITLE_COMMAND = "title"
+TITLE_USAGE_MESSAGE = "使い方: `title <作品名>`"
+
+
+def _parse_query(message_content: object) -> Optional[str]:
+    normalized = str(message_content or "").strip()
+    if normalized == TITLE_COMMAND:
+        return ""
+
+    prefix = f"{TITLE_COMMAND} "
+    if not normalized.startswith(prefix):
+        return None
+
+    return normalized[len(prefix) :].strip()
+
+
+def handle_title_query(
+    message_content: object,
+    *,
+    search_source_fn: Callable[..., object] = search_source,
+    supported_sources_fn: Callable[[], tuple[str, ...]] = supported_search_sources,
+) -> Optional[str]:
+    query = _parse_query(message_content)
+    if query is None:
+        return None
+    if not query:
+        return TITLE_USAGE_MESSAGE
+
+    sources = tuple(supported_sources_fn())
+    for source in sources:
+        search_source_fn(source, query, limit=1)
+
+    return f"`{query}` の title 検索を開始しました。対象媒体数: {len(sources)}"

--- a/manga_watch/discord_title_search.py
+++ b/manga_watch/discord_title_search.py
@@ -34,6 +34,9 @@ def handle_title_query(
 
     sources = tuple(supported_sources_fn())
     for source in sources:
-        search_source_fn(source, query, limit=1)
+        try:
+            search_source_fn(source, query, limit=1)
+        except Exception:
+            continue
 
     return f"`{query}` の title 検索を開始しました。対象媒体数: {len(sources)}"

--- a/tests/test_discord_inbound.py
+++ b/tests/test_discord_inbound.py
@@ -120,6 +120,38 @@ class DiscordInboundTests(unittest.TestCase):
         self.assertEqual([FETCH_ACCEPTED_MESSAGE], responses)
         self.assertEqual(FETCH_ACCEPTED_MESSAGE, client.sent_messages[0]["content"])
 
+    def test_listener_handles_title_query(self):
+        client = FakeDiscordClient(
+            polls=[
+                [{"id": "22", "content": "old", "author": {"id": "user-1"}}],
+                [{"id": "23", "content": "title ダンジョン飯", "author": {"id": "user-2"}}],
+            ]
+        )
+        listener = DiscordCommandListener(
+            client=client,
+            channel_id="main-channel",
+            coordinator=object(),
+            timezone_name="Asia/Tokyo",
+            latest_handler=lambda content, **_: None,
+            fetch_handler=lambda content, **_: None,
+            title_handler=lambda content, **_: (
+                "`ダンジョン飯` の title 検索を開始しました。対象媒体数: 2"
+                if str(content).strip() == "title ダンジョン飯"
+                else None
+            ),
+            report_logger=lambda _: None,
+            error_logger=lambda _: None,
+        )
+
+        listener.poll_once()
+        responses = listener.poll_once()
+
+        self.assertEqual(["`ダンジョン飯` の title 検索を開始しました。対象媒体数: 2"], responses)
+        self.assertEqual(
+            "`ダンジョン飯` の title 検索を開始しました。対象媒体数: 2",
+            client.sent_messages[0]["content"],
+        )
+
     def test_listener_ignores_bot_messages(self):
         client = FakeDiscordClient(
             polls=[

--- a/tests/test_discord_title_search.py
+++ b/tests/test_discord_title_search.py
@@ -19,6 +19,24 @@ class RecordingSearchSource:
         return []
 
 
+class PartiallyFailingSearchSource:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, source, query, *, limit=10, http_client=None):
+        self.calls.append(
+            {
+                "source": source,
+                "query": query,
+                "limit": limit,
+                "http_client": http_client,
+            }
+        )
+        if source == "comic-walker":
+            raise RuntimeError("timeout")
+        return []
+
+
 class DiscordTitleSearchTests(unittest.TestCase):
     def test_title_command_name_is_exported(self):
         self.assertEqual("title", TITLE_COMMAND)
@@ -33,6 +51,34 @@ class DiscordTitleSearchTests(unittest.TestCase):
 
     def test_handle_title_query_calls_supported_sources_with_query(self):
         search_source = RecordingSearchSource()
+
+        response = handle_title_query(
+            "title ダンジョン飯",
+            search_source_fn=search_source,
+            supported_sources_fn=lambda: ("comic-walker", "magapoke"),
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "source": "comic-walker",
+                    "query": "ダンジョン飯",
+                    "limit": 1,
+                    "http_client": None,
+                },
+                {
+                    "source": "magapoke",
+                    "query": "ダンジョン飯",
+                    "limit": 1,
+                    "http_client": None,
+                },
+            ],
+            search_source.calls,
+        )
+        self.assertEqual("`ダンジョン飯` の title 検索を開始しました。対象媒体数: 2", response)
+
+    def test_handle_title_query_ignores_source_failures_in_skeleton_mode(self):
+        search_source = PartiallyFailingSearchSource()
 
         response = handle_title_query(
             "title ダンジョン飯",

--- a/tests/test_discord_title_search.py
+++ b/tests/test_discord_title_search.py
@@ -1,0 +1,64 @@
+import unittest
+
+from manga_watch.discord_title_search import TITLE_COMMAND, TITLE_USAGE_MESSAGE, handle_title_query
+
+
+class RecordingSearchSource:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, source, query, *, limit=10, http_client=None):
+        self.calls.append(
+            {
+                "source": source,
+                "query": query,
+                "limit": limit,
+                "http_client": http_client,
+            }
+        )
+        return []
+
+
+class DiscordTitleSearchTests(unittest.TestCase):
+    def test_title_command_name_is_exported(self):
+        self.assertEqual("title", TITLE_COMMAND)
+
+    def test_handle_title_query_returns_none_for_non_title_messages(self):
+        self.assertIsNone(handle_title_query("latest"))
+        self.assertIsNone(handle_title_query("titleworks"))
+
+    def test_handle_title_query_returns_usage_for_empty_query(self):
+        self.assertEqual(TITLE_USAGE_MESSAGE, handle_title_query("title"))
+        self.assertEqual(TITLE_USAGE_MESSAGE, handle_title_query(" title   "))
+
+    def test_handle_title_query_calls_supported_sources_with_query(self):
+        search_source = RecordingSearchSource()
+
+        response = handle_title_query(
+            "title ダンジョン飯",
+            search_source_fn=search_source,
+            supported_sources_fn=lambda: ("comic-walker", "magapoke"),
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "source": "comic-walker",
+                    "query": "ダンジョン飯",
+                    "limit": 1,
+                    "http_client": None,
+                },
+                {
+                    "source": "magapoke",
+                    "query": "ダンジョン飯",
+                    "limit": 1,
+                    "http_client": None,
+                },
+            ],
+            search_source.calls,
+        )
+        self.assertEqual("`ダンジョン飯` の title 検索を開始しました。対象媒体数: 2", response)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a new plain-text Discord handler for `title <query>`
- wire the handler into inbound routing without changing `latest` / `fetch`
- add focused tests for the new command skeleton

## Issue

- Closes #307
- Parent #306

## Verification

- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_search tests.test_discord_title_search tests.test_discord_inbound`

## Residual Risk

- This PR only adds the skeleton flow and a basic success message
- Cross-source aggregation, ranking, and partial-failure rendering are intentionally left to #308 and #309
