### PR TITLE
feat: switch /search to query-first contract

### DIFF
--- a/docs/superpowers/plans/2026-04-15-search-query-first-contract.md
+++ b/docs/superpowers/plans/2026-04-15-search-query-first-contract.md
@@ -1,0 +1,61 @@
+# Search Query-First Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch `/search` to a query-first slash command contract while preserving single-source behavior when `source` is provided.
+
+**Architecture:** Update slash command registration so `query` is the first required option and `source` becomes optional. Keep interaction routing thin by passing through `source=None`, then relax `SearchCommandHandler.start()` so this slice only accepts the new contract without implementing cross-source aggregation yet.
+
+**Tech Stack:** Python, unittest, Discord interaction payloads
+
+---
+
+### Task 1: Lock the new slash command contract in tests
+
+**Files:**
+- Modify: `tests/test_discord_command_registration_search.py`
+- Modify: `tests/test_discord_interactions_search.py`
+- Modify: `tests/test_discord_search.py`
+
+- [ ] **Step 1: Write failing tests for query-first registration and source-optional routing**
+- [ ] **Step 2: Run focused tests to verify they fail for the expected contract mismatch**
+
+Run:
+```bash
+/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest \
+  tests.test_discord_command_registration_search \
+  tests.test_discord_interactions_search \
+  tests.test_discord_search
+```
+
+### Task 2: Implement the minimal plumbing change
+
+**Files:**
+- Modify: `manga_watch/discord_command_registration.py`
+- Modify: `manga_watch/discord_search.py`
+- Modify: `manga_watch/discord_interactions.py`
+
+- [ ] **Step 1: Reorder `/search` options to `query`, `source`, `visibility` and make `source` optional**
+- [ ] **Step 2: Keep interaction routing unchanged except for allowing missing `source`**
+- [ ] **Step 3: Make `SearchCommandHandler.start()` accept `source=None` without returning the old missing-source message**
+
+### Task 3: Verify the slice and prepare for PR review
+
+**Files:**
+- Verify: `tests/test_discord_command_registration_search.py`
+- Verify: `tests/test_discord_interactions_search.py`
+- Verify: `tests/test_discord_search.py`
+- Verify: `tests/test_discord_inbound.py`
+
+- [ ] **Step 1: Re-run focused tests until green**
+- [ ] **Step 2: Run the nearby regression suite to confirm no contract regressions**
+- [ ] **Step 3: Commit only the slice changes and use the PR reviewer / merger loop**
+
+Run:
+```bash
+/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest \
+  tests.test_discord_command_registration_search \
+  tests.test_discord_interactions_search \
+  tests.test_discord_search \
+  tests.test_discord_inbound
+```

--- a/manga_watch/discord_command_registration.py
+++ b/manga_watch/discord_command_registration.py
@@ -61,16 +61,16 @@ def default_interaction_commands() -> List[Dict[str, object]]:
             "options": [
                 {
                     "type": 3,
-                    "name": "source",
-                    "description": "検索したい媒体",
-                    "required": True,
-                    "choices": searchable_source_choices(),
-                },
-                {
-                    "type": 3,
                     "name": "query",
                     "description": "検索したい文字列",
                     "required": True,
+                },
+                {
+                    "type": 3,
+                    "name": "source",
+                    "description": "検索したい媒体",
+                    "required": False,
+                    "choices": searchable_source_choices(),
                 },
                 {
                     "type": 3,

--- a/manga_watch/discord_search.py
+++ b/manga_watch/discord_search.py
@@ -123,10 +123,10 @@ class SearchCommandHandler:
         del watchlist_path
         normalized_source = _coerce_text(source)
         normalized_query = _coerce_text(query)
-        if not normalized_source:
-            return {"content": SEARCH_MISSING_SOURCE_MESSAGE}
         if not normalized_query:
             return {"content": SEARCH_MISSING_QUERY_MESSAGE}
+        if not normalized_source:
+            return {"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}
 
         normalized_visibility = _normalize_visibility(visibility)
         try:

--- a/tests/test_discord_command_registration_search.py
+++ b/tests/test_discord_command_registration_search.py
@@ -30,9 +30,15 @@ class DiscordSearchCommandRegistrationTests(unittest.TestCase):
             [
                 {
                     "type": 3,
+                    "name": "query",
+                    "description": "検索したい文字列",
+                    "required": True,
+                },
+                {
+                    "type": 3,
                     "name": "source",
                     "description": "検索したい媒体",
-                    "required": True,
+                    "required": False,
                     "choices": [
                         {"name": "comic-walker", "value": "comic-walker"},
                         {"name": "comic-action", "value": "comic-action"},
@@ -50,12 +56,6 @@ class DiscordSearchCommandRegistrationTests(unittest.TestCase):
                         {"name": "kakuyomu", "value": "kakuyomu"},
                         {"name": "gaugau", "value": "gaugau"},
                     ],
-                },
-                {
-                    "type": 3,
-                    "name": "query",
-                    "description": "検索したい文字列",
-                    "required": True,
                 },
                 {
                     "type": 3,

--- a/tests/test_discord_interactions_search.py
+++ b/tests/test_discord_interactions_search.py
@@ -41,19 +41,44 @@ class RecordingFetchDispatcher:
 
 
 class DiscordInteractionSearchTests(unittest.TestCase):
-    def signed_command_payload(self, command_name):
+    def signed_command_payload(self, command_name, *, query="まんが", source=None):
+        options = [{"name": "query", "type": 3, "value": query}]
+        if source is not None:
+            options.append({"name": "source", "type": 3, "value": source})
         return {
             "type": 2,
             "data": {
                 "name": command_name,
-                "options": [
-                    {"name": "source", "type": 3, "value": "champion-cross"},
-                    {"name": "query", "type": 3, "value": "まんが"},
-                ],
+                "options": options,
             },
         }
 
     def test_search_command_routes_to_search_handler(self):
+        search_handler = RecordingSearchHandler()
+        service = DiscordInteractionService(
+            timezone_name="Asia/Tokyo",
+            fetch_dispatcher=RecordingFetchDispatcher(),
+            verification_disabled=True,
+            search_handler=search_handler,
+        )
+
+        response = service.handle_request(
+            method="POST",
+            path="/",
+            headers={},
+            body=json.dumps(
+                self.signed_command_payload(SEARCH_COMMAND, source="champion-cross")
+            ).encode("utf-8"),
+        )
+
+        payload = json.loads(response.body)
+        self.assertEqual(4, payload["type"])
+        self.assertEqual(64, payload["data"]["flags"])
+        self.assertEqual("検索結果を選んでください。", payload["data"]["content"])
+        self.assertEqual("champion-cross", search_handler.start_calls[0]["source"])
+        self.assertEqual("まんが", search_handler.start_calls[0]["query"])
+
+    def test_search_command_routes_to_search_handler_without_source(self):
         search_handler = RecordingSearchHandler()
         service = DiscordInteractionService(
             timezone_name="Asia/Tokyo",
@@ -71,9 +96,8 @@ class DiscordInteractionSearchTests(unittest.TestCase):
 
         payload = json.loads(response.body)
         self.assertEqual(4, payload["type"])
-        self.assertEqual(64, payload["data"]["flags"])
         self.assertEqual("検索結果を選んでください。", payload["data"]["content"])
-        self.assertEqual("champion-cross", search_handler.start_calls[0]["source"])
+        self.assertIsNone(search_handler.start_calls[0]["source"])
         self.assertEqual("まんが", search_handler.start_calls[0]["query"])
 
     def test_search_component_routes_to_search_handler(self):

--- a/tests/test_discord_search.py
+++ b/tests/test_discord_search.py
@@ -1,6 +1,11 @@
 import unittest
 
-from manga_watch.discord_search import SEARCH_COMMAND, SearchCommandHandler
+from manga_watch.discord_search import (
+    SEARCH_COMMAND,
+    SEARCH_MISSING_SOURCE_MESSAGE,
+    SEARCH_NO_RESULTS_MESSAGE,
+    SearchCommandHandler,
+)
 from manga_watch.source_search import SearchResult
 
 
@@ -143,6 +148,16 @@ class DiscordSearchTests(unittest.TestCase):
             add_subscription.calls,
         )
         self.assertIn(long_url, add_response["content"])
+
+    def test_start_accepts_missing_source_without_old_error(self):
+        search_source = FakeSearchSource([])
+        handler = SearchCommandHandler(search_source=search_source)
+
+        response = handler.start(source=None, query="まんが")
+
+        self.assertEqual({"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}, response)
+        self.assertNotEqual(SEARCH_MISSING_SOURCE_MESSAGE, response["content"])
+        self.assertEqual([], search_source.calls)
 
     def test_handle_component_adds_selected_result_with_hidden_flag(self):
         add_subscription = FakeAddSubscription()


### PR DESCRIPTION
## Issue
- closes #312

## Summary
- switch `/search` slash command options to `query` first and optional `source`
- allow interaction routing to call the search handler without a `source`
- stop returning the old missing-source error in the pre-aggregation path

## Testing
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_command_registration_search tests.test_discord_interactions_search tests.test_discord_search`
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_command_registration_search tests.test_discord_interactions_search tests.test_discord_search tests.test_discord_command_registration tests.test_discord_interactions tests.test_discord_inbound`
