### PR TITLE
feat: aggregate cross-source /search results

### DIFF
--- a/manga_watch/discord_search.py
+++ b/manga_watch/discord_search.py
@@ -4,10 +4,15 @@ import base64
 import hashlib
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Mapping, Optional
+from typing import Callable, Dict, List, Mapping, Optional, Sequence
 
 from manga_watch.discord_add import WatchlistAddError, format_watchlist_add_error
-from manga_watch.source_search import SearchResult, UnsupportedSourceSearchError, search_source
+from manga_watch.source_search import (
+    SearchResult,
+    UnsupportedSourceSearchError,
+    search_source,
+    supported_search_sources,
+)
 from manga_watch.watchlist import add_watchlist_url
 
 SEARCH_COMMAND = "search"
@@ -16,9 +21,12 @@ SEARCH_MISSING_SOURCE_MESSAGE = "検索したい媒体を `source` で指定し�
 SEARCH_MISSING_QUERY_MESSAGE = "検索したい文字列を `query` で指定してください。"
 SEARCH_FAILURE_MESSAGE = "作品検索に失敗しました。サーバーログを確認してください。"
 SEARCH_NO_RESULTS_MESSAGE = "検索結果が見つかりませんでした。"
+SEARCH_CROSS_SOURCE_MESSAGE = "横断検索結果です。1件選んでください。"
 MAX_COMPONENT_TEXT = 100
 MAX_COMPONENT_VALUE = 100
 MAX_SELECT_URL_CACHE_SIZE = 256
+MAX_SELECT_OPTIONS = 25
+DEFAULT_CROSS_SOURCE_LIMIT = 3
 SELECT_URL_TOKEN_PREFIX = "u:"
 
 _SEARCH_SELECT_URL_CACHE: "OrderedDict[str, str]" = OrderedDict()
@@ -106,10 +114,96 @@ def _format_search_add_response(result: Mapping[str, object]) -> str:
     return "\n".join(lines)
 
 
+def _dedupe_bucket_results(results: Sequence[SearchResult], *, default_source: str) -> List[SearchResult]:
+    unique_results: List[SearchResult] = []
+    seen_keys = set()
+    for result in results:
+        source_name = _coerce_text(result.source) or default_source
+        seed_url = _coerce_text(result.seed_url)
+        title = _coerce_text(result.title)
+        if not seed_url or not title:
+            continue
+        dedupe_key = (source_name, seed_url)
+        if dedupe_key in seen_keys:
+            continue
+        seen_keys.add(dedupe_key)
+        unique_results.append(
+            SearchResult(
+                source=source_name,
+                title=title,
+                seed_url=seed_url,
+                subtitle=_coerce_text(result.subtitle),
+            )
+        )
+    return unique_results
+
+
+def _interleave_result_buckets(
+    result_buckets: Sequence[Sequence[SearchResult]],
+    *,
+    max_results: int,
+) -> List[SearchResult]:
+    interleaved: List[SearchResult] = []
+    max_bucket_size = max((len(bucket) for bucket in result_buckets), default=0)
+    for index in range(max_bucket_size):
+        for bucket in result_buckets:
+            if index >= len(bucket):
+                continue
+            interleaved.append(bucket[index])
+            if len(interleaved) >= max_results:
+                return interleaved
+    return interleaved
+
+
+def _build_select_options(
+    results: Sequence[SearchResult],
+    *,
+    cross_source: bool,
+) -> List[Dict[str, str]]:
+    return [
+        {
+            "label": _truncate_component_text(result.title),
+            "value": _select_option_value(result.seed_url),
+            "description": _truncate_component_text(
+                result.source if cross_source else (result.subtitle or result.source)
+            ),
+        }
+        for result in results[:MAX_SELECT_OPTIONS]
+    ]
+
+
+def _build_search_response(
+    *,
+    content: str,
+    results: Sequence[SearchResult],
+    visibility: str,
+    cross_source: bool,
+) -> Dict[str, object]:
+    return {
+        "content": content,
+        "components": [
+            {
+                "type": 1,
+                "components": [
+                    {
+                        "type": 3,
+                        "custom_id": f"{SEARCH_SELECT_CUSTOM_ID_PREFIX}:{visibility}",
+                        "placeholder": "追加する作品を選択",
+                        "min_values": 1,
+                        "max_values": 1,
+                        "options": _build_select_options(results, cross_source=cross_source),
+                    }
+                ],
+            }
+        ],
+    }
+
+
 @dataclass
 class SearchCommandHandler:
     search_source: Callable[..., List[SearchResult]] = search_source
     add_subscription: Callable[..., Mapping[str, object]] = add_watchlist_url
+    supported_sources: Callable[[], Sequence[str]] = supported_search_sources
 
     def start(
         self,
@@ -125,10 +219,18 @@ class SearchCommandHandler:
         normalized_query = _coerce_text(query)
         if not normalized_query:
             return {"content": SEARCH_MISSING_QUERY_MESSAGE}
-        if not normalized_source:
-            return {"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}
 
         normalized_visibility = _normalize_visibility(visibility)
+        if not normalized_source:
+            try:
+                return self._start_cross_source(
+                    query=normalized_query,
+                    visibility=normalized_visibility,
+                    http_client=http_client,
+                )
+            except Exception:
+                return {"content": SEARCH_FAILURE_MESSAGE, "components": []}
+
         try:
             results = self.search_source(
                 normalized_source,
@@ -144,33 +246,48 @@ class SearchCommandHandler:
         if not results:
             return {"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}
 
-        options = [
-            {
-                "label": _truncate_component_text(result.title),
-                "value": _select_option_value(result.seed_url),
-                "description": _truncate_component_text(result.subtitle or result.source),
-            }
-            for result in results[:25]
-        ]
+        return _build_search_response(
+            content=f"{normalized_source} の検索結果です。1件選んでください。",
+            results=results,
+            visibility=normalized_visibility,
+            cross_source=False,
+        )
 
-        return {
-            "content": f"{normalized_source} の検索結果です。1件選んでください。",
-            "components": [
-                {
-                    "type": 1,
-                    "components": [
-                        {
-                            "type": 3,
-                            "custom_id": f"{SEARCH_SELECT_CUSTOM_ID_PREFIX}:{normalized_visibility}",
-                            "placeholder": "追加する作品を選択",
-                            "min_values": 1,
-                            "max_values": 1,
-                            "options": options,
-                        }
-                    ],
-                }
-            ],
-        }
+    def _start_cross_source(
+        self,
+        *,
+        query: str,
+        visibility: str,
+        http_client: object = None,
+    ) -> Dict[str, object]:
+        buckets: List[List[SearchResult]] = []
+        for source_name in self.supported_sources():
+            results = self.search_source(
+                source_name,
+                query,
+                http_client=http_client,
+                limit=DEFAULT_CROSS_SOURCE_LIMIT,
+            )
+            deduped_results = _dedupe_bucket_results(results, default_source=source_name)
+            if deduped_results:
+                buckets.append(deduped_results[:DEFAULT_CROSS_SOURCE_LIMIT])
+
+        if not buckets:
+            return {"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}
+
+        interleaved_results = _interleave_result_buckets(
+            buckets,
+            max_results=MAX_SELECT_OPTIONS,
+        )
+        if not interleaved_results:
+            return {"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}
+
+        return _build_search_response(
+            content=SEARCH_CROSS_SOURCE_MESSAGE,
+            results=interleaved_results,
+            visibility=visibility,
+            cross_source=True,
+        )
 
     def handle_component(
         self,

--- a/tests/test_discord_search.py
+++ b/tests/test_discord_search.py
@@ -26,6 +26,23 @@ class FakeSearchSource:
         return list(self.results)
 
 
+class MultiSourceSearchSource:
+    def __init__(self, results_by_source):
+        self.results_by_source = {key: list(value) for key, value in results_by_source.items()}
+        self.calls = []
+
+    def __call__(self, source, query, *, http_client=None, limit=10):
+        self.calls.append(
+            {
+                "source": source,
+                "query": query,
+                "http_client": http_client,
+                "limit": limit,
+            }
+        )
+        return list(self.results_by_source.get(source, []))
+
+
 class FakeAddSubscription:
     def __init__(self):
         self.calls = []
@@ -151,13 +168,144 @@ class DiscordSearchTests(unittest.TestCase):
 
     def test_start_accepts_missing_source_without_old_error(self):
         search_source = FakeSearchSource([])
-        handler = SearchCommandHandler(search_source=search_source)
+        handler = SearchCommandHandler(search_source=search_source, supported_sources=lambda: ())
 
         response = handler.start(source=None, query="まんが")
 
         self.assertEqual({"content": SEARCH_NO_RESULTS_MESSAGE, "components": []}, response)
         self.assertNotEqual(SEARCH_MISSING_SOURCE_MESSAGE, response["content"])
         self.assertEqual([], search_source.calls)
+
+    def test_start_aggregates_cross_source_results_with_interleaving_and_dedupe(self):
+        search_source = MultiSourceSearchSource(
+            {
+                "comic-walker": [
+                    SearchResult(
+                        source="comic-walker",
+                        title="作品A walker 1",
+                        seed_url="https://comic-walker.com/detail/a",
+                    ),
+                    SearchResult(
+                        source="comic-walker",
+                        title="作品A walker duplicate",
+                        seed_url="https://comic-walker.com/detail/a",
+                    ),
+                    SearchResult(
+                        source="comic-walker",
+                        title="作品A walker 2",
+                        seed_url="https://comic-walker.com/detail/b",
+                    ),
+                ],
+                "champion-cross": [
+                    SearchResult(
+                        source="champion-cross",
+                        title="作品B cross 1",
+                        seed_url="https://championcross.jp/series/a",
+                    ),
+                    SearchResult(
+                        source="champion-cross",
+                        title="作品B cross 2",
+                        seed_url="https://championcross.jp/series/b",
+                    ),
+                ],
+                "takecomic": [
+                    SearchResult(
+                        source="takecomic",
+                        title="作品C take 1",
+                        seed_url="https://takecomic.jp/comics/1",
+                    )
+                ],
+            }
+        )
+        handler = SearchCommandHandler(
+            search_source=search_source,
+            supported_sources=lambda: ("comic-walker", "champion-cross", "takecomic"),
+        )
+
+        response = handler.start(source=None, query="まんが", visibility="visible")
+
+        self.assertEqual(
+            [
+                {
+                    "source": "comic-walker",
+                    "query": "まんが",
+                    "http_client": None,
+                    "limit": 3,
+                },
+                {
+                    "source": "champion-cross",
+                    "query": "まんが",
+                    "http_client": None,
+                    "limit": 3,
+                },
+                {
+                    "source": "takecomic",
+                    "query": "まんが",
+                    "http_client": None,
+                    "limit": 3,
+                },
+            ],
+            search_source.calls,
+        )
+        self.assertEqual("横断検索結果です。1件選んでください。", response["content"])
+        self.assertEqual(
+            [
+                {
+                    "label": "作品A walker 1",
+                    "value": "https://comic-walker.com/detail/a",
+                    "description": "comic-walker",
+                },
+                {
+                    "label": "作品B cross 1",
+                    "value": "https://championcross.jp/series/a",
+                    "description": "champion-cross",
+                },
+                {
+                    "label": "作品C take 1",
+                    "value": "https://takecomic.jp/comics/1",
+                    "description": "takecomic",
+                },
+                {
+                    "label": "作品A walker 2",
+                    "value": "https://comic-walker.com/detail/b",
+                    "description": "comic-walker",
+                },
+                {
+                    "label": "作品B cross 2",
+                    "value": "https://championcross.jp/series/b",
+                    "description": "champion-cross",
+                },
+            ],
+            response["components"][0]["components"][0]["options"],
+        )
+
+    def test_start_caps_cross_source_results_to_select_limit(self):
+        sources = tuple(f"source-{index}" for index in range(9))
+        search_source = MultiSourceSearchSource(
+            {
+                source_name: [
+                    SearchResult(
+                        source=source_name,
+                        title=f"{source_name}-{index}",
+                        seed_url=f"https://example.com/{source_name}/{index}",
+                    )
+                    for index in range(10)
+                ]
+                for source_name in sources
+            }
+        )
+        handler = SearchCommandHandler(
+            search_source=search_source,
+            supported_sources=lambda: sources,
+        )
+
+        response = handler.start(source=None, query="まんが")
+
+        options = response["components"][0]["components"][0]["options"]
+        self.assertEqual(25, len(options))
+        self.assertEqual("source-0-0", options[0]["label"])
+        self.assertEqual("source-1-0", options[1]["label"])
+        self.assertEqual("source-2-0", options[2]["label"])
 
     def test_handle_component_adds_selected_result_with_hidden_flag(self):
         add_subscription = FakeAddSubscription()


### PR DESCRIPTION
## Issue
- closes #308

## Summary
- add cross-source aggregation for `/search` when `source` is omitted
- interleave per-source top results with `source + seed_url` dedupe and select-menu cap
- keep the existing single-source search and add-flow behavior intact

## Testing
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_search tests.test_discord_interactions_search`
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_command_registration_search tests.test_discord_interactions_search tests.test_discord_search tests.test_discord_command_registration tests.test_discord_interactions tests.test_discord_inbound`
