### PR TITLE
Fix Discord /search interaction timeout

### DIFF
--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -14,7 +14,12 @@ from nacl.signing import VerifyKey
 from manga_watch.discord_add import ADD_COMMAND, AddCommandHandler
 from manga_watch.discord_fetch import FETCH_COMMAND, handle_fetch_trigger
 from manga_watch.discord_latest import LATEST_COMMAND, handle_latest_query, validated_timezone_name
-from manga_watch.discord_search import SEARCH_COMMAND, SEARCH_SELECT_CUSTOM_ID_PREFIX, SearchCommandHandler
+from manga_watch.discord_search import (
+    SEARCH_COMMAND,
+    SEARCH_FAILURE_MESSAGE,
+    SEARCH_SELECT_CUSTOM_ID_PREFIX,
+    SearchCommandHandler,
+)
 from manga_watch.discord_remove import REMOVE_COMMAND, RemoveCommandHandler
 from manga_watch.discord_supertwins_manage import (
     SUPERTWINS_MANAGE_COMMAND,

--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -130,6 +130,9 @@ class InteractionCallbackClient(Protocol):
     def defer_component(self, *, interaction_id: str, interaction_token: str) -> None:
         ...
 
+    def defer_channel_message(self, *, interaction_id: str, interaction_token: str, ephemeral: bool = False) -> None:
+        ...
+
     def edit_original_response(
         self,
         *,
@@ -212,6 +215,20 @@ class DiscordInteractionCallbackClient:
         response = self.session.post(
             f"https://discord.com/api/v10/interactions/{interaction_id}/{interaction_token}/callback",
             json={"type": INTERACTION_RESPONSE_TYPE_DEFERRED_UPDATE_MESSAGE},
+            timeout=self.defer_timeout,
+        )
+        response.raise_for_status()
+
+    def defer_channel_message(self, *, interaction_id: str, interaction_token: str, ephemeral: bool = False) -> None:
+        data: Dict[str, object] = {}
+        if ephemeral:
+            data["flags"] = EPHEMERAL_MESSAGE_FLAG
+        response = self.session.post(
+            f"https://discord.com/api/v10/interactions/{interaction_id}/{interaction_token}/callback",
+            json={
+                "type": 5,
+                "data": data,
+            },
             timeout=self.defer_timeout,
         )
         response.raise_for_status()
@@ -430,13 +447,7 @@ class DiscordInteractionService:
             )
             return interaction_message_response(str(response_payload.get("content") or "").strip())
         if command_name == SEARCH_COMMAND and self.search_handler is not None:
-            response_payload = self.search_handler.start(
-                source=self._command_option(payload, "source"),
-                query=self._command_option(payload, "query"),
-                visibility=self._command_option(payload, "visibility"),
-                watchlist_path=self.watchlist_path,
-            )
-            return interaction_ephemeral_response(response_payload)
+            return self._handle_deferred_search_command(payload)
         if command_name == REMOVE_COMMAND and self.remove_handler is not None:
             payload = self.remove_handler.start(
                 watchlist_path=self.watchlist_path,
@@ -456,6 +467,61 @@ class DiscordInteractionService:
             )
             return interaction_ephemeral_response(response_payload)
         return text_response(400, f"unsupported command: {command_name or '(missing)'}")
+
+    def _handle_deferred_search_command(self, payload: Mapping[str, object]) -> InteractionHttpResponse:
+        interaction_id = _coerce_text(payload.get("id"))
+        application_id = _coerce_text(payload.get("application_id"))
+        interaction_token = _coerce_text(payload.get("token"))
+        if (
+            not interaction_id
+            or not application_id
+            or not interaction_token
+            or self.interaction_callback_client is None
+            or self.search_handler is None
+        ):
+            response_payload = self.search_handler.start(
+                source=self._command_option(payload, "source"),
+                query=self._command_option(payload, "query"),
+                visibility=self._command_option(payload, "visibility"),
+                watchlist_path=self.watchlist_path,
+            )
+            return interaction_ephemeral_response(response_payload)
+
+        try:
+            self.interaction_callback_client.defer_channel_message(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                ephemeral=True,
+            )
+        except Exception:
+            response_payload = self.search_handler.start(
+                source=self._command_option(payload, "source"),
+                query=self._command_option(payload, "query"),
+                visibility=self._command_option(payload, "visibility"),
+                watchlist_path=self.watchlist_path,
+            )
+            return interaction_ephemeral_response(response_payload)
+
+        response_payload = {"content": SEARCH_FAILURE_MESSAGE, "components": []}
+        try:
+            response_payload = self.search_handler.start(
+                source=self._command_option(payload, "source"),
+                query=self._command_option(payload, "query"),
+                visibility=self._command_option(payload, "visibility"),
+                watchlist_path=self.watchlist_path,
+            )
+        except Exception:
+            pass
+
+        try:
+            self.interaction_callback_client.edit_original_response(
+                application_id=application_id,
+                interaction_token=interaction_token,
+                data=response_payload,
+            )
+        except Exception:
+            pass
+        return empty_response(202)
 
     def _handle_message_component(self, payload: Mapping[str, object]) -> InteractionHttpResponse:
         data = payload.get("data")

--- a/tests/test_discord_interactions.py
+++ b/tests/test_discord_interactions.py
@@ -372,6 +372,11 @@ class FetchDispatcherTests(unittest.TestCase):
         )
 
         client.defer_component(interaction_id="interaction-1", interaction_token="token-1")
+        client.defer_channel_message(
+            interaction_id="interaction-2",
+            interaction_token="token-2",
+            ephemeral=True,
+        )
         client.edit_original_response(
             application_id="app-1",
             interaction_token="token-1",
@@ -379,6 +384,9 @@ class FetchDispatcherTests(unittest.TestCase):
         )
 
         self.assertEqual(2, session.posts[0]["timeout"])
+        self.assertEqual(2, session.posts[1]["timeout"])
+        self.assertEqual(5, session.posts[1]["json"]["type"])
+        self.assertEqual(64, session.posts[1]["json"]["data"]["flags"])
         self.assertEqual(15, session.patches[0]["timeout"])
 
 

--- a/tests/test_discord_interactions_search.py
+++ b/tests/test_discord_interactions_search.py
@@ -40,12 +40,39 @@ class RecordingFetchDispatcher:
         return {"message": "fetch ok"}
 
 
+class RecordingInteractionCallbackClient:
+    def __init__(self):
+        self.deferred_channel_messages = []
+        self.edits = []
+
+    def defer_channel_message(self, *, interaction_id: str, interaction_token: str, ephemeral: bool = False):
+        self.deferred_channel_messages.append(
+            {
+                "interaction_id": interaction_id,
+                "interaction_token": interaction_token,
+                "ephemeral": ephemeral,
+            }
+        )
+
+    def edit_original_response(self, *, application_id: str, interaction_token: str, data):
+        self.edits.append(
+            {
+                "application_id": application_id,
+                "interaction_token": interaction_token,
+                "data": data,
+            }
+        )
+
+
 class DiscordInteractionSearchTests(unittest.TestCase):
     def signed_command_payload(self, command_name, *, query="まんが", source=None):
         options = [{"name": "query", "type": 3, "value": query}]
         if source is not None:
             options.append({"name": "source", "type": 3, "value": source})
         return {
+            "id": "interaction-1",
+            "application_id": "app-1",
+            "token": "token-1",
             "type": 2,
             "data": {
                 "name": command_name,
@@ -55,11 +82,13 @@ class DiscordInteractionSearchTests(unittest.TestCase):
 
     def test_search_command_routes_to_search_handler(self):
         search_handler = RecordingSearchHandler()
+        callback_client = RecordingInteractionCallbackClient()
         service = DiscordInteractionService(
             timezone_name="Asia/Tokyo",
             fetch_dispatcher=RecordingFetchDispatcher(),
             verification_disabled=True,
             search_handler=search_handler,
+            interaction_callback_client=callback_client,
         )
 
         response = service.handle_request(
@@ -71,20 +100,25 @@ class DiscordInteractionSearchTests(unittest.TestCase):
             ).encode("utf-8"),
         )
 
-        payload = json.loads(response.body)
-        self.assertEqual(4, payload["type"])
-        self.assertEqual(64, payload["data"]["flags"])
-        self.assertEqual("検索結果を選んでください。", payload["data"]["content"])
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(b"", response.body)
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1", "ephemeral": True}],
+            callback_client.deferred_channel_messages,
+        )
+        self.assertEqual("検索結果を選んでください。", callback_client.edits[0]["data"]["content"])
         self.assertEqual("champion-cross", search_handler.start_calls[0]["source"])
         self.assertEqual("まんが", search_handler.start_calls[0]["query"])
 
     def test_search_command_routes_to_search_handler_without_source(self):
         search_handler = RecordingSearchHandler()
+        callback_client = RecordingInteractionCallbackClient()
         service = DiscordInteractionService(
             timezone_name="Asia/Tokyo",
             fetch_dispatcher=RecordingFetchDispatcher(),
             verification_disabled=True,
             search_handler=search_handler,
+            interaction_callback_client=callback_client,
         )
 
         response = service.handle_request(
@@ -94,9 +128,8 @@ class DiscordInteractionSearchTests(unittest.TestCase):
             body=json.dumps(self.signed_command_payload(SEARCH_COMMAND)).encode("utf-8"),
         )
 
-        payload = json.loads(response.body)
-        self.assertEqual(4, payload["type"])
-        self.assertEqual("検索結果を選んでください。", payload["data"]["content"])
+        self.assertEqual(202, response.status_code)
+        self.assertEqual("検索結果を選んでください。", callback_client.edits[0]["data"]["content"])
         self.assertIsNone(search_handler.start_calls[0]["source"])
         self.assertEqual("まんが", search_handler.start_calls[0]["query"])
 


### PR DESCRIPTION
## Summary
- defer Discord `/search` application-command responses before running search work
- update the original response with search results after the lookup completes
- add/update tests for the deferred application-command flow

## Why
`/search` was doing synchronous external lookup work inside the initial interaction response path, which could exceed Discord's initial response window and lead to no visible response.

## Changes
- add application-command defer support in `DiscordInteractionCallbackClient`
- route `/search` through a deferred-response helper in `DiscordInteractionService`
- keep a synchronous fallback path if defer cannot be sent
- update tests to assert defer + edit behavior

## Testing
- Intended: `python3 -m pytest -q tests/test_discord_interactions_search.py tests/test_discord_interactions.py`
- Note: not run in this environment because `pytest` is not installed

Closes #316
