### PR TITLE
[codex] Reduce keep-warm health check interval to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ startup registration だけを手動で確認したいときは次を使いま�
 .venv/bin/python scripts/register_discord_commands.py
 ```
 
-`manga_watch.run_service` は Slash Command 用の `POST /` に加えて、署名検証なしの lightweight health check として `GET /healthz` を返します。Cloud Run の scale-to-zero を完全には防げませんが、Cloud Scheduler から `15` 分おきに `GET /healthz` を送って warm 状態を維持しやすくできます。不十分なら、運用しながら間隔を短くします。
+`manga_watch.run_service` は Slash Command 用の `POST /` に加えて、署名検証なしの lightweight health check として `GET /healthz` を返します。Cloud Run の scale-to-zero を完全には防げませんが、Cloud Scheduler から `5` 分おきに `GET /healthz` を送って warm 状態を維持しやすくできます。
 
 ## Status CLI
 

--- a/doc/gcp-deploy.md
+++ b/doc/gcp-deploy.md
@@ -348,7 +348,7 @@ SERVICE_URL="$(gcloud run services describe comic-crawler-service \
 gcloud scheduler jobs create http comic-crawler-service-keep-warm \
   --project=star-light-breaker \
   --location=asia-northeast1 \
-  --schedule='*/15 * * * *' \
+  --schedule='*/5 * * * *' \
   --uri="${SERVICE_URL}/healthz" \
   --http-method=GET
 ```
@@ -356,7 +356,7 @@ gcloud scheduler jobs create http comic-crawler-service-keep-warm \
 補足:
 
 - この ping は cold start 発生率を下げるための best effort であり、`min instances=1` ほどの保証はない
-- 初期値は 15 分間隔とし、不十分なら運用しながら短くする
+- 初期値は 5 分間隔とする
 - `comic-crawler-scheduled-run` とは別用途なので、job 名は分ける
 
 ## 9. Practical run / verify

--- a/tests/test_keep_warm_docs.py
+++ b/tests/test_keep_warm_docs.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+README_PATH = ROOT / "README.md"
+GCP_DEPLOY_PATH = ROOT / "doc" / "gcp-deploy.md"
+
+
+class KeepWarmDocsTests(unittest.TestCase):
+    def test_readme_recommends_five_minute_healthz_ping(self):
+        readme = README_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("5` 分おき", readme)
+        self.assertNotIn("15` 分おき", readme)
+
+    def test_gcp_deploy_doc_uses_five_minute_keep_warm_schedule(self):
+        gcp_deploy = GCP_DEPLOY_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("--schedule='*/5 * * * *'", gcp_deploy)
+        self.assertIn("初期値は 5 分間隔", gcp_deploy)
+        self.assertNotIn("--schedule='*/15 * * * *'", gcp_deploy)
+        self.assertNotIn("初期値は 15 分間隔", gcp_deploy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- updated the Cloud Run service keep-warm guidance from 15 minutes to 5 minutes in `README.md`
- updated the keep-warm `gcloud scheduler jobs create http comic-crawler-service-keep-warm` example in `doc/gcp-deploy.md` to use `*/5 * * * *`
- added `tests/test_keep_warm_docs.py` so the docs stay aligned on the 5-minute interval

## Why
The current docs still describe a 15-minute keep-warm ping for `/healthz`, but the intended operating interval is now 5 minutes to keep the Cloud Run service warmer.

## Impact
Operators following the documented Scheduler setup will configure the keep-warm ping at 5-minute intervals, and future doc drift between the README and GCP deploy guide will be caught by test coverage.

## Validation
- `python3 -m unittest tests.test_keep_warm_docs tests.test_print_cloud_scheduler_job`