### PR TITLE
fix: validate magapoke RSS URL before fetch to prevent SSRF

### DIFF
--- a/manga_watch/sources/magapoke.py
+++ b/manga_watch/sources/magapoke.py
@@ -1,6 +1,7 @@
 import re
 import xml.etree.ElementTree as ET
 from typing import Optional, Tuple
+from urllib.parse import urlparse
 
 from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
 
@@ -12,6 +13,12 @@ _RSS_URL = re.compile(
     r'<link[^>]+rel="alternate"[^>]+type="application/rss\+xml"[^>]+href="([^"]+)"',
     re.I,
 )
+_ALLOWED_RSS_SCHEMES = {"http", "https"}
+_ALLOWED_RSS_HOSTS = {
+    "pocket.shonenmagazine.com",
+    "www.pocket.shonenmagazine.com",
+    "mgpk-cdn.magazinepocket.com",
+}
 
 
 def normalize_magapoke_title_id(raw_title_id: str) -> Tuple[str, str]:
@@ -36,7 +43,17 @@ def extract_magapoke_rss_url(html_text: str) -> Optional[str]:
     match = _RSS_URL.search(html_text)
     if not match:
         return None
-    return match.group(1).strip() or None
+    rss_url = match.group(1).strip()
+    if not rss_url:
+        return None
+
+    parsed = urlparse(rss_url)
+    if parsed.scheme not in _ALLOWED_RSS_SCHEMES:
+        return None
+    if parsed.hostname not in _ALLOWED_RSS_HOSTS:
+        return None
+
+    return rss_url
 
 
 def extract_magapoke_next_update_label(html_text: str) -> Optional[str]:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -498,6 +498,82 @@ class SourceAdapterTests(unittest.TestCase):
             client.calls,
         )
 
+    def test_magapoke_fetch_latest_rejects_non_http_rss_url_from_title_page(self):
+        adapter = MagapokeAdapter()
+        work = adapter.normalize("https://pocket.shonenmagazine.com/title/03021/episode/427856")
+        client = StaticHttpClient(
+            {
+                "https://pocket.shonenmagazine.com/title/03021": """
+                <html>
+                  <head>
+                    <link rel="alternate" type="application/rss+xml" href="file:///etc/passwd">
+                  </head>
+                </html>
+                """,
+                "https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml": """
+                <rss>
+                  <channel>
+                    <title>マガポケ（普通の本はありません！）</title>
+                    <item>
+                      <title>【＃17】ハルとギンギン丸</title>
+                      <link>https://pocket.shonenmagazine.com/title/03021/episode/434393</link>
+                      <description>普通の本はありません！</description>
+                    </item>
+                  </channel>
+                </rss>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("https://pocket.shonenmagazine.com/title/03021/episode/434393", latest["url"])
+        self.assertEqual(
+            [
+                "https://pocket.shonenmagazine.com/title/03021",
+                "https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml",
+            ],
+            client.calls,
+        )
+
+    def test_magapoke_fetch_latest_rejects_untrusted_rss_host_from_title_page(self):
+        adapter = MagapokeAdapter()
+        work = adapter.normalize("https://pocket.shonenmagazine.com/title/03021/episode/427856")
+        client = StaticHttpClient(
+            {
+                "https://pocket.shonenmagazine.com/title/03021": """
+                <html>
+                  <head>
+                    <link rel="alternate" type="application/rss+xml" href="https://attacker.example/rss.xml">
+                  </head>
+                </html>
+                """,
+                "https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml": """
+                <rss>
+                  <channel>
+                    <title>マガポケ（普通の本はありません！）</title>
+                    <item>
+                      <title>【＃17】ハルとギンギン丸</title>
+                      <link>https://pocket.shonenmagazine.com/title/03021/episode/434393</link>
+                      <description>普通の本はありません！</description>
+                    </item>
+                  </channel>
+                </rss>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("https://pocket.shonenmagazine.com/title/03021/episode/434393", latest["url"])
+        self.assertEqual(
+            [
+                "https://pocket.shonenmagazine.com/title/03021",
+                "https://mgpk-cdn.magazinepocket.com/static/rss/3021/feed.xml",
+            ],
+            client.calls,
+        )
+
     def test_comic_walker_normalize_accepts_canonical_series_url(self):
         work = ComicWalkerAdapter().normalize("https://comic-walker.com/detail/KC_123456_S/?from=detail")
 


### PR DESCRIPTION
### Motivation

- Prevent an SSRF vector where the Magapoke adapter would fetch an RSS URL extracted verbatim from a title page HTML, which could point to attacker-controlled or internal hosts.
- Preserve existing behavior of using the canonical RSS URL when the HTML-derived RSS link is missing or untrusted.

### Description

- Add scheme/host validation to `extract_magapoke_rss_url` by importing `urlparse`, and introducing `_ALLOWED_RSS_SCHEMES` and `_ALLOWED_RSS_HOSTS` allowlists.
- Reject extracted RSS URLs whose scheme is not `http`/`https` or whose hostname is not in the trusted set, returning `None` to trigger the existing fallback to `canonical_magapoke_rss_url`.
- Add two regression tests in `tests/test_sources.py` to ensure non-HTTP schemes and untrusted hosts in the title page RSS link are ignored and the adapter falls back to the canonical feed URL.

### Testing

- Ran `PYTHONPATH=. pytest -q tests/test_sources.py -k magapoke` which passed with `5 passed, 58 deselected, 1 subtests passed`.
- Running `pytest` without `PYTHONPATH=.` failed during collection in this environment with `ModuleNotFoundError: No module named 'manga_watch'`, which is an environment setup issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cac20d6c8320aacb994b6afdc844)