### PR TITLE
fix: rate limit unsupported source issue creation

### DIFF
--- a/manga_watch/discord_add.py
+++ b/manga_watch/discord_add.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Dict, Mapping, Optional, Protocol
+from urllib.parse import urlparse
 
 from manga_watch.github_issue_reporting import build_unsupported_source_issue_reporter_from_env
 from manga_watch.watchlist import WatchlistAddError, add_watchlist_url
@@ -12,6 +14,8 @@ ADD_MISSING_URL_MESSAGE = "追加する作品URLを `url` オプションで指�
 UNSUPPORTED_SOURCE_REPORTED_MESSAGE = "未対応媒体として記録しました"
 UNSUPPORTED_SOURCE_ALREADY_REPORTED_MESSAGE = "未対応媒体として既に記録済みです"
 UNSUPPORTED_SOURCE_REPORT_FAILURE_MESSAGE = "未対応媒体の記録に失敗しました。サーバーログを確認してください。"
+UNSUPPORTED_SOURCE_REPORT_RATE_LIMIT_MESSAGE = "未対応媒体の記録は一定時間ごとに行います"
+DEFAULT_UNSUPPORTED_SOURCE_REPORT_COOLDOWN_SECONDS = 3600
 
 
 class UnsupportedSourceReporter(Protocol):
@@ -49,6 +53,9 @@ def format_watchlist_add_error(exc: WatchlistAddError) -> str:
 class AddCommandHandler:
     add_subscription: Callable[..., Mapping[str, object]] = add_watchlist_url
     unsupported_source_reporter: Optional[UnsupportedSourceReporter] = None
+    unsupported_source_report_cooldown_seconds: int = DEFAULT_UNSUPPORTED_SOURCE_REPORT_COOLDOWN_SECONDS
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc)
+    _last_reported_hosts: Dict[str, datetime] = field(default_factory=dict)
 
     @classmethod
     def from_env(cls) -> "AddCommandHandler":
@@ -78,11 +85,24 @@ class AddCommandHandler:
 
     def _report_unsupported_source(self, url: str, exc: WatchlistAddError) -> Dict[str, object]:
         lines = [format_watchlist_add_error(exc)]
+        host = str(urlparse(url).hostname or "").strip().lower() or str(url).strip().lower()
+        current_time = self.now().astimezone(timezone.utc)
+        last_reported_at = self._last_reported_hosts.get(host)
+        if (
+            self.unsupported_source_report_cooldown_seconds > 0
+            and last_reported_at is not None
+            and (current_time - last_reported_at)
+            < timedelta(seconds=self.unsupported_source_report_cooldown_seconds)
+        ):
+            lines.append(UNSUPPORTED_SOURCE_REPORT_RATE_LIMIT_MESSAGE)
+            return {"content": "\n".join(lines)}
+
         try:
             outcome = self.unsupported_source_reporter.report_unsupported_source(url=url, error=exc)
         except Exception:
             lines.append(UNSUPPORTED_SOURCE_REPORT_FAILURE_MESSAGE)
             return {"content": "\n".join(lines)}
+        self._last_reported_hosts[host] = current_time
 
         issue_number = str(outcome.get("issue_number") or "").strip()
         issue_url = str(outcome.get("issue_url") or "").strip()

--- a/tests/test_discord_add.py
+++ b/tests/test_discord_add.py
@@ -1,12 +1,14 @@
 import json
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 from manga_watch.discord_add import (
     ADD_MISSING_URL_MESSAGE,
     AddCommandHandler,
     UNSUPPORTED_SOURCE_REPORTED_MESSAGE,
+    UNSUPPORTED_SOURCE_REPORT_RATE_LIMIT_MESSAGE,
     UNSUPPORTED_SOURCE_REPORT_FAILURE_MESSAGE,
 )
 from manga_watch.watchlist import WatchlistAddError, add_watchlist_url
@@ -214,6 +216,46 @@ class DiscordAddTests(unittest.TestCase):
         self.assertEqual(0, reporter.calls)
         self.assertIn("追加できませんでした", payload["content"])
         self.assertNotIn(UNSUPPORTED_SOURCE_REPORTED_MESSAGE, payload["content"])
+
+    def test_start_rate_limits_unsupported_source_issue_reporting_per_host(self):
+        calls = []
+
+        class FakeIssueReporter:
+            def report_unsupported_source(self, *, url, error):
+                calls.append({"url": url, "error": error})
+                return {
+                    "action": "created",
+                    "issue_number": 174,
+                    "issue_url": "https://github.com/kentoku24/comic_crawler/issues/174",
+                }
+
+        def add_subscription(_url, *, watchlist_path=None):
+            raise WatchlistAddError(
+                "unsupported_source",
+                "Unsupported source host: example.com",
+                "Use one of the supported sources.",
+            )
+
+        now_values = iter(
+            [
+                1700000000,
+                1700000000 + 60,
+            ]
+        )
+
+        handler = AddCommandHandler(
+            add_subscription=add_subscription,
+            unsupported_source_reporter=FakeIssueReporter(),
+            unsupported_source_report_cooldown_seconds=300,
+            now=lambda: datetime.fromtimestamp(next(now_values), tz=timezone.utc),
+        )
+
+        first_payload = handler.start(url="https://example.com/work/1")
+        second_payload = handler.start(url="https://example.com/work/2")
+
+        self.assertEqual(1, len(calls))
+        self.assertIn(UNSUPPORTED_SOURCE_REPORTED_MESSAGE, first_payload["content"])
+        self.assertIn(UNSUPPORTED_SOURCE_REPORT_RATE_LIMIT_MESSAGE, second_payload["content"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The `/add` flow invoked GitHub issue creation on every unsupported-source error with no local gating, enabling spam and GitHub API token/rate exhaustion.
- Introduce a minimal in-process guard to reduce abuse while preserving existing user-visible behavior and reporter semantics.

### Description
- Add a host-based cooldown to `AddCommandHandler` with a default of `DEFAULT_UNSUPPORTED_SOURCE_REPORT_COOLDOWN_SECONDS = 3600` and a configurable `unsupported_source_report_cooldown_seconds` property. 
- Implement `_last_reported_hosts` tracking and a `now` injection point so the cooldown check uses `now()` and is testable. 
- Short-circuit calls to `unsupported_source_reporter.report_unsupported_source` when the host was reported recently and return a user-facing rate-limit message via `UNSUPPORTED_SOURCE_REPORT_RATE_LIMIT_MESSAGE` while keeping existing error/result messages intact. 
- Add a deterministic unit test `test_start_rate_limits_unsupported_source_issue_reporting_per_host` to validate throttling and update imports/constants used by tests.

### Testing
- Ran `python -m unittest tests.test_discord_add tests.test_discord_interactions tests.test_github_issue_reporting` and all tests passed (36 tests ran and returned `OK`).
- New unit test exercises time-injected paths to assert the reporter is called only once across rapid repeated unsupported-source submissions for the same host.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cae0f4048320bd21e08017063091)