### PR TITLE
Restrict Discord /remove interactions to administrators

### DIFF
--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -28,6 +28,7 @@ INTERACTION_RESPONSE_TYPE_PONG = 1
 INTERACTION_RESPONSE_TYPE_CHANNEL_MESSAGE = 4
 INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE = 7
 EPHEMERAL_MESSAGE_FLAG = 64
+DISCORD_PERMISSION_ADMINISTRATOR = 0x8
 DEFAULT_HTTP_TIMEOUT = 15
 DEFAULT_INTERACTION_PATH = "/"
 DEFAULT_FETCH_BACKEND = "coordinator"
@@ -52,6 +53,18 @@ def _header_value(headers: Mapping[str, str], name: str) -> Optional[str]:
         if key.lower() == name.lower():
             return _coerce_text(value)
     return None
+
+
+def _has_admin_permission(payload: Mapping[str, object]) -> bool:
+    member = payload.get("member")
+    if not isinstance(member, Mapping):
+        return False
+    permissions_raw = member.get("permissions")
+    try:
+        permissions = int(str(permissions_raw or "0").strip() or "0")
+    except ValueError:
+        return False
+    return (permissions & DISCORD_PERMISSION_ADMINISTRATOR) != 0
 
 
 def build_cloud_run_job_run_uri(*, project: str, region: str, job_name: str) -> str:
@@ -351,6 +364,10 @@ class DiscordInteractionService:
             )
             return interaction_message_response(str(response_payload.get("content") or "").strip())
         if command_name == REMOVE_COMMAND and self.remove_handler is not None:
+            if not _has_admin_permission(payload):
+                return interaction_ephemeral_response(
+                    {"content": "このコマンドを実行する権限がありません。", "components": []}
+                )
             payload = self.remove_handler.start(
                 watchlist_path=self.watchlist_path,
                 state_path=self.state_path,
@@ -361,6 +378,11 @@ class DiscordInteractionService:
     def _handle_message_component(self, payload: Mapping[str, object]) -> InteractionHttpResponse:
         if self.remove_handler is None:
             return text_response(400, "unsupported interaction type")
+        if not _has_admin_permission(payload):
+            return interaction_payload_response(
+                INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
+                {"content": "この操作を実行する権限がありません。", "components": []},
+            )
         data = payload.get("data")
         if not isinstance(data, Mapping):
             return text_response(400, "invalid interaction payload")

--- a/tests/test_discord_interactions.py
+++ b/tests/test_discord_interactions.py
@@ -254,7 +254,14 @@ class DiscordInteractionServiceTests(unittest.TestCase):
                 }
 
         service, signing_key = self.make_service(remove_handler=FakeRemoveHandler())
-        headers, body = self.signed_request({"type": 2, "data": {"name": REMOVE_COMMAND}}, signing_key)
+        headers, body = self.signed_request(
+            {
+                "type": 2,
+                "data": {"name": REMOVE_COMMAND},
+                "member": {"permissions": str(0x8)},
+            },
+            signing_key,
+        )
 
         response = service.handle_request(method="POST", path="/", headers=headers, body=body)
 
@@ -275,7 +282,11 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         remove_handler = FakeRemoveHandler()
         service, signing_key = self.make_service(remove_handler=remove_handler)
         headers, body = self.signed_request(
-            {"type": 3, "data": {"custom_id": "remove_select", "values": ["token-a"]}},
+            {
+                "type": 3,
+                "data": {"custom_id": "remove_select", "values": ["token-a"]},
+                "member": {"permissions": str(0x8)},
+            },
             signing_key,
         )
 
@@ -285,6 +296,40 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         self.assertEqual(7, payload["type"])
         self.assertEqual("updated", payload["data"]["content"])
         self.assertEqual("remove_select", remove_handler.calls[0]["custom_id"])
+
+    def test_remove_command_requires_admin_permission(self):
+        class FakeRemoveHandler:
+            def start(self, **_kwargs):
+                raise AssertionError("should not be called")
+
+        service, signing_key = self.make_service(remove_handler=FakeRemoveHandler())
+        headers, body = self.signed_request({"type": 2, "data": {"name": REMOVE_COMMAND}}, signing_key)
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(200, response.status_code)
+        payload = json.loads(response.body)
+        self.assertEqual(4, payload["type"])
+        self.assertEqual(64, payload["data"]["flags"])
+        self.assertIn("権限がありません", payload["data"]["content"])
+
+    def test_remove_component_requires_admin_permission(self):
+        class FakeRemoveHandler:
+            def handle_component(self, *_args, **_kwargs):
+                raise AssertionError("should not be called")
+
+        service, signing_key = self.make_service(remove_handler=FakeRemoveHandler())
+        headers, body = self.signed_request(
+            {"type": 3, "data": {"custom_id": "remove_confirm:token-a"}},
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(200, response.status_code)
+        payload = json.loads(response.body)
+        self.assertEqual(7, payload["type"])
+        self.assertIn("権限がありません", payload["data"]["content"])
 
 
 class FetchDispatcherTests(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- A vulnerability allowed any Discord guild member to trigger the `/remove` flow or replay crafted component interactions (e.g. `remove_confirm:<token>`) and delete watchlist/state entries because the handler accepted deterministic tokens without verifying the caller.
- The intent of this change is to restore authorization controls so only privileged users can start or confirm a remove operation.

### Description
- Add `DISCORD_PERMISSION_ADMINISTRATOR` and a helper ` _has_admin_permission(payload)` that checks `member.permissions` bitmask on incoming interactions.
- Gate the `/remove` application command in `_handle_application_command` and return an ephemeral denial when the caller lacks admin permissions instead of invoking `RemoveCommandHandler.start`.
- Gate message-component interactions in `_handle_message_component` and return a safe update response when the caller lacks admin permissions instead of forwarding to `RemoveCommandHandler.handle_component`.
- Update `tests/test_discord_interactions.py` to provide `member.permissions` for successful remove flows and to add tests asserting non-admin requests are denied and do not invoke removal logic.

### Testing
- Ran `python -m unittest tests.test_discord_interactions tests.test_discord_remove` and all tests passed (`Ran 26 tests ... OK`).
- The change updates `manga_watch/discord_interactions.py` and `tests/test_discord_interactions.py` and the modified tests exercise both allowed and denied paths for `/remove` and component interactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cb1ac90c8320ae0ed5ba79c23999)