### PR TITLE
Add replay protection for Discord interaction verification

### DIFF
--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from dataclasses import dataclass
 from typing import Callable, Dict, Mapping, Optional, Protocol
 
@@ -38,6 +39,7 @@ DEFAULT_CLOUD_RUN_REGION = "asia-northeast1"
 DEFAULT_GOOGLE_AUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 INVALID_SIGNATURE_MESSAGE = "invalid request signature"
 FETCH_DISPATCH_FAILURE_MESSAGE = "fetch の起動に失敗しました。Cloud Run logs を確認してください。"
+MAX_SIGNATURE_AGE_SECONDS = 300
 
 
 def _coerce_text(value: object) -> Optional[str]:
@@ -52,6 +54,15 @@ def _header_value(headers: Mapping[str, str], name: str) -> Optional[str]:
         if key.lower() == name.lower():
             return _coerce_text(value)
     return None
+
+
+def _is_fresh_timestamp(timestamp: str, *, now: Optional[int] = None) -> bool:
+    try:
+        timestamp_seconds = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    current_seconds = int(time.time()) if now is None else now
+    return abs(current_seconds - timestamp_seconds) <= MAX_SIGNATURE_AGE_SECONDS
 
 
 def build_cloud_run_job_run_uri(*, project: str, region: str, job_name: str) -> str:
@@ -380,6 +391,8 @@ class DiscordInteractionService:
         signature = _header_value(headers, "X-Signature-Ed25519")
         timestamp = _header_value(headers, "X-Signature-Timestamp")
         if not signature or not timestamp:
+            return False
+        if not _is_fresh_timestamp(timestamp):
             return False
         return self.verifier.verify(signature=signature, timestamp=timestamp, body=body)
 

--- a/tests/test_discord_interactions.py
+++ b/tests/test_discord_interactions.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 import unittest
 from unittest import mock
 
@@ -53,7 +54,7 @@ class FakeAuthorizedSession:
 class DiscordInteractionServiceTests(unittest.TestCase):
     def signed_request(self, payload, signing_key):
         body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
-        timestamp = "1700000000"
+        timestamp = str(int(time.time()))
         signature = signing_key.sign(timestamp.encode("utf-8") + body).signature.hex()
         headers = {
             "X-Signature-Ed25519": signature,
@@ -203,6 +204,19 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         service, signing_key = self.make_service()
         headers, body = self.signed_request({"type": 2, "data": {"name": "latest"}}, signing_key)
         headers["X-Signature-Ed25519"] = "00" * 64
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(401, response.status_code)
+        self.assertEqual(b"invalid request signature", response.body)
+
+    def test_stale_timestamp_returns_401_even_with_valid_signature(self):
+        service, signing_key = self.make_service()
+        headers, body = self.signed_request({"type": 1}, signing_key)
+        headers["X-Signature-Timestamp"] = "946684800"  # 2000-01-01T00:00:00Z
+        headers["X-Signature-Ed25519"] = signing_key.sign(
+            headers["X-Signature-Timestamp"].encode("utf-8") + body
+        ).signature.hex()
 
         response = service.handle_request(method="POST", path="/", headers=headers, body=body)
 


### PR DESCRIPTION
### Motivation
- The Discord interaction verifier validated signatures but did not enforce timestamp freshness, allowing previously captured signed requests to be replayed indefinitely.
- Discord recommends rejecting requests outside a short age window (5 minutes) to mitigate replay attacks. 
- The change should minimally reject stale or malformed `X-Signature-Timestamp` values while preserving existing signature verification and functionality.

### Description
- Add `MAX_SIGNATURE_AGE_SECONDS = 300` and helper `def _is_fresh_timestamp(...)` that validates the Unix timestamp age using `time.time()`.
- Enforce freshness in `DiscordInteractionService._verify_request` by rejecting requests with missing, malformed, or stale `X-Signature-Timestamp` before calling the cryptographic verifier.
- Update tests in `tests/test_discord_interactions.py` to sign requests with the current timestamp and add `test_stale_timestamp_returns_401_even_with_valid_signature` to assert stale-but-validly-signed requests are rejected.
- Modified files: `manga_watch/discord_interactions.py` and `tests/test_discord_interactions.py`.

### Testing
- Running `pytest -q tests/test_discord_interactions.py` without adjusting `PYTHONPATH` failed during collection due to `ModuleNotFoundError` (environment issue unrelated to the code changes).
- Running `PYTHONPATH=. pytest -q tests/test_discord_interactions.py` exercised the updated tests and succeeded with `19 passed`.
- The new regression test confirms a valid signature with an old timestamp (2000-01-01) is rejected with `401 invalid request signature`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cc61e8ac8320a16c5354c05105d3)