### PR TITLE
feat: add Codex approval assessment API scaffold

### DIFF
--- a/apps/codex_approval_menubar/Package.swift
+++ b/apps/codex_approval_menubar/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "CodexApprovalMenubar",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .executable(name: "CodexApprovalMenubar", targets: ["CodexApprovalMenubar"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CodexApprovalMenubar",
+            path: "Sources"
+        ),
+    ]
+)

--- a/apps/codex_approval_menubar/README.md
+++ b/apps/codex_approval_menubar/README.md
@@ -1,0 +1,42 @@
+# Codex Approval Menubar MVP
+
+Codex がユーザー承認を求めたときに、**許可すべきかの判断材料**をすぐ返すための macOS menubar app の骨格です。
+
+## Current scope
+
+このディレクトリは SwiftUI `MenuBarExtra` ベースの **MVP scaffold** です。
+まだ Codex の実イベント監視には接続しておらず、まずは次を確認できます。
+
+- assessment API endpoint の設定
+- command / cwd / source / justification の入力
+- `/api/codex/approval-assess/` への POST
+- risk / recommendation / reasons の表示
+- 高リスク時のローカル通知
+- sample request の切り替え
+
+## Run
+
+```bash
+cd apps/codex_approval_menubar
+swift run
+```
+
+## Expected backend
+
+既定では次の endpoint を叩きます。
+
+- `http://127.0.0.1:8000/api/codex/approval-assess/`
+
+必要なら menubar UI で endpoint を直接書き換えてください。
+
+## Next steps
+
+1. Codex approval event を監視する bridge を足す
+2. bridge からこのアプリへ event を流す
+3. request history の永続化
+4. approve / deny 操作の検討
+
+## Notes
+
+- 本体の判定ロジックは Swift 側ではなく Python backend を source of truth にする
+- Swift 側は「通知と判断表示の surface」に寄せる

--- a/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/ApprovalAPIClient.swift
+++ b/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/ApprovalAPIClient.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct ApprovalAPIClient {
+    func assess(endpoint: URL, request: ApprovalRequestEnvelope) async throws -> ApprovalAssessmentPayload {
+        var urlRequest = URLRequest(url: endpoint)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = try JSONEncoder().encode(request)
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        guard let http = response as? HTTPURLResponse else {
+            throw ApprovalClientError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw ApprovalClientError.httpStatus(http.statusCode, String(data: data, encoding: .utf8) ?? "")
+        }
+
+        let decoded = try JSONDecoder.approvalDecoder.decode(ApprovalAssessmentResponse.self, from: data)
+        return decoded.assessment.toPayload()
+    }
+}
+
+enum ApprovalClientError: LocalizedError {
+    case invalidResponse
+    case httpStatus(Int, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "approval API から不正な応答が返った"
+        case let .httpStatus(code, body):
+            return "approval API error: HTTP \(code) \(body)"
+        }
+    }
+}
+
+private extension JSONDecoder {
+    static var approvalDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        return decoder
+    }
+}

--- a/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/ApprovalStore.swift
+++ b/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/ApprovalStore.swift
@@ -1,0 +1,123 @@
+import Foundation
+import UserNotifications
+
+@MainActor
+final class ApprovalStore: ObservableObject {
+    @Published private(set) var requests: [ApprovalAssessmentPayload]
+    @Published var draftCommand: String
+    @Published var draftWorkingDirectory: String
+    @Published var draftSource: String
+    @Published var draftJustification: String
+    @Published var endpointURL: String
+    @Published var errorMessage: String?
+    @Published var isSubmitting: Bool
+
+    init(
+        requests: [ApprovalAssessmentPayload],
+        draftCommand: String = "",
+        draftWorkingDirectory: String = "",
+        draftSource: String = "codex-cli",
+        draftJustification: String = "",
+        endpointURL: String = "http://127.0.0.1:8000/api/codex/approval-assess/",
+        errorMessage: String? = nil,
+        isSubmitting: Bool = false
+    ) {
+        self.requests = requests
+        self.draftCommand = draftCommand
+        self.draftWorkingDirectory = draftWorkingDirectory
+        self.draftSource = draftSource
+        self.draftJustification = draftJustification
+        self.endpointURL = endpointURL
+        self.errorMessage = errorMessage
+        self.isSubmitting = isSubmitting
+    }
+
+    var latestRequest: ApprovalAssessmentPayload? {
+        requests.first
+    }
+
+    var menuBarSymbolName: String {
+        guard let latestRequest else { return "shield" }
+        switch latestRequest.riskLevel {
+        case .low:
+            return "checkmark.shield"
+        case .medium:
+            return "exclamationmark.shield"
+        case .high:
+            return "xmark.shield"
+        }
+    }
+
+    func submitDraft() async {
+        errorMessage = nil
+        let trimmedCommand = draftCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCommand.isEmpty else {
+            errorMessage = "command が空だ"
+            return
+        }
+        guard let url = URL(string: endpointURL) else {
+            errorMessage = "endpoint URL が不正だ"
+            return
+        }
+
+        isSubmitting = true
+        defer { isSubmitting = false }
+
+        let requestBody = ApprovalRequestEnvelope(
+            command: trimmedCommand,
+            workingDirectory: draftWorkingDirectory.nilIfBlank,
+            source: draftSource.nilIfBlank,
+            justification: draftJustification.nilIfBlank
+        )
+
+        do {
+            let payload = try await ApprovalAPIClient().assess(endpoint: url, request: requestBody)
+            requests.insert(payload, at: 0)
+            await notifyIfNeeded(for: payload)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadSample(_ sample: SampleApproval) {
+        draftCommand = sample.command
+        draftWorkingDirectory = sample.workingDirectory ?? ""
+        draftSource = sample.source ?? "codex-cli"
+        draftJustification = sample.justification ?? ""
+    }
+
+    static func preview() -> ApprovalStore {
+        ApprovalStore(
+            requests: SampleApproval.samples.map { $0.previewPayload },
+            draftCommand: SampleApproval.samples.first?.command ?? "",
+            draftWorkingDirectory: SampleApproval.samples.first?.workingDirectory ?? "",
+            draftSource: SampleApproval.samples.first?.source ?? "codex-cli",
+            draftJustification: SampleApproval.samples.first?.justification ?? ""
+        )
+    }
+
+    private func notifyIfNeeded(for payload: ApprovalAssessmentPayload) async {
+        guard payload.requiresHumanAttention else { return }
+        let center = UNUserNotificationCenter.current()
+        try? await center.requestAuthorization(options: [.alert, .badge, .sound])
+
+        let content = UNMutableNotificationContent()
+        content.title = "Codex approval request"
+        content.body = payload.summary
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: payload.id.uuidString,
+            content: content,
+            trigger: nil
+        )
+        try? await center.add(request)
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/Models.swift
+++ b/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/Models.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+enum ApprovalRiskLevel: String, Codable {
+    case low
+    case medium
+    case high
+}
+
+enum ApprovalRecommendation: String, Codable {
+    case likelyAllow = "likely_allow"
+    case inspectBeforeAllow = "inspect_before_allow"
+    case denyOrInspect = "deny_or_inspect"
+}
+
+struct ApprovalAssessmentPayload: Codable, Identifiable {
+    let id: UUID
+    let summary: String
+    let recommendation: ApprovalRecommendation
+    let riskLevel: ApprovalRiskLevel
+    let requiresHumanAttention: Bool
+    let categories: [String]
+    let reasons: [String]
+    let allowReasons: [String]
+    let denyReasons: [String]
+    let command: String
+    let workingDirectory: String?
+    let source: String?
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        summary: String,
+        recommendation: ApprovalRecommendation,
+        riskLevel: ApprovalRiskLevel,
+        requiresHumanAttention: Bool,
+        categories: [String],
+        reasons: [String],
+        allowReasons: [String],
+        denyReasons: [String],
+        command: String,
+        workingDirectory: String? = nil,
+        source: String? = nil,
+        createdAt: Date = .now
+    ) {
+        self.id = id
+        self.summary = summary
+        self.recommendation = recommendation
+        self.riskLevel = riskLevel
+        self.requiresHumanAttention = requiresHumanAttention
+        self.categories = categories
+        self.reasons = reasons
+        self.allowReasons = allowReasons
+        self.denyReasons = denyReasons
+        self.command = command
+        self.workingDirectory = workingDirectory
+        self.source = source
+        self.createdAt = createdAt
+    }
+}
+
+struct ApprovalRequestEnvelope: Codable {
+    let command: String
+    let workingDirectory: String?
+    let source: String?
+    let justification: String?
+}
+
+struct ApprovalAssessmentResponse: Codable {
+    let ok: Bool
+    let assessment: ApprovalAssessmentDTO
+}
+
+struct ApprovalAssessmentDTO: Codable {
+    let summary: String
+    let recommendation: ApprovalRecommendation
+    let riskLevel: ApprovalRiskLevel
+    let requiresHumanAttention: Bool
+    let categories: [String]
+    let reasons: [String]
+    let allowReasons: [String]
+    let denyReasons: [String]
+    let command: String
+    let workingDirectory: String?
+    let source: String?
+
+    enum CodingKeys: String, CodingKey {
+        case summary
+        case recommendation
+        case riskLevel = "risk_level"
+        case requiresHumanAttention = "requires_human_attention"
+        case categories
+        case reasons
+        case allowReasons = "allow_reasons"
+        case denyReasons = "deny_reasons"
+        case command
+        case workingDirectory = "working_directory"
+        case source
+    }
+
+    func toPayload() -> ApprovalAssessmentPayload {
+        ApprovalAssessmentPayload(
+            summary: summary,
+            recommendation: recommendation,
+            riskLevel: riskLevel,
+            requiresHumanAttention: requiresHumanAttention,
+            categories: categories,
+            reasons: reasons,
+            allowReasons: allowReasons,
+            denyReasons: denyReasons,
+            command: command,
+            workingDirectory: workingDirectory,
+            source: source
+        )
+    }
+}

--- a/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/SampleApproval.swift
+++ b/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/SampleApproval.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+struct SampleApproval: Identifiable {
+    let id = UUID()
+    let title: String
+    let command: String
+    let workingDirectory: String?
+    let source: String?
+    let justification: String?
+    let previewPayload: ApprovalAssessmentPayload
+
+    static let samples: [SampleApproval] = [
+        SampleApproval(
+            title: "Read-only diff",
+            command: "git diff -- README.md",
+            workingDirectory: "/Users/ken/project",
+            source: "codex-cli",
+            justification: "Inspect current changes before editing",
+            previewPayload: ApprovalAssessmentPayload(
+                summary: "risk=low; categories=read_only; command=git diff -- README.md",
+                recommendation: .likelyAllow,
+                riskLevel: .low,
+                requiresHumanAttention: false,
+                categories: ["read_only"],
+                reasons: ["read-only っぽい操作を含む: `git diff`"],
+                allowReasons: ["内容確認や調査目的の読み取り操作に見える"],
+                denyReasons: [],
+                command: "git diff -- README.md",
+                workingDirectory: "/Users/ken/project",
+                source: "codex-cli"
+            )
+        ),
+        SampleApproval(
+            title: "Push branch",
+            command: "git push origin feature/approval-helper",
+            workingDirectory: "/Users/ken/project",
+            source: "codex-cli",
+            justification: "Publish the completed branch for review",
+            previewPayload: ApprovalAssessmentPayload(
+                summary: "risk=medium; categories=write, network; command=git push origin feature/approval-helper",
+                recommendation: .inspectBeforeAllow,
+                riskLevel: .medium,
+                requiresHumanAttention: true,
+                categories: ["write", "network"],
+                reasons: [
+                    "ファイル変更または外部状態変更の可能性がある: `git push`",
+                    "ネットワーク通信を伴う可能性がある: `git push`",
+                ],
+                allowReasons: ["Codex 側の説明: Publish the completed branch for review"],
+                denyReasons: [
+                    "ファイル・git・infra の状態を変更する可能性がある",
+                    "外部送信やリモート変更が起きうる",
+                ],
+                command: "git push origin feature/approval-helper",
+                workingDirectory: "/Users/ken/project",
+                source: "codex-cli"
+            )
+        ),
+        SampleApproval(
+            title: "High-risk cleanup",
+            command: "sudo rm -rf /tmp/build-cache",
+            workingDirectory: "/Users/ken/project",
+            source: "codex-cli",
+            justification: "Reset build cache to recover from a broken state",
+            previewPayload: ApprovalAssessmentPayload(
+                summary: "risk=high; categories=write, privilege, destructive; command=sudo rm -rf /tmp/build-cache",
+                recommendation: .denyOrInspect,
+                riskLevel: .high,
+                requiresHumanAttention: true,
+                categories: ["write", "privilege", "destructive"],
+                reasons: [
+                    "ファイル変更または外部状態変更の可能性がある: `rm`",
+                    "昇格権限を要求する可能性がある: `sudo`",
+                    "破壊的な操作の兆候がある: `rm -rf`",
+                ],
+                allowReasons: [],
+                denyReasons: [
+                    "ファイル・git・infra の状態を変更する可能性がある",
+                    "権限昇格は影響範囲が大きい",
+                    "復旧が面倒、または不可逆の可能性がある",
+                ],
+                command: "sudo rm -rf /tmp/build-cache",
+                workingDirectory: "/Users/ken/project",
+                source: "codex-cli"
+            )
+        ),
+    ]
+}

--- a/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/Views.swift
+++ b/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/Views.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+struct ApprovalMenuView: View {
+    @ObservedObject var store: ApprovalStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Codex Approval Helper")
+                .font(.headline)
+
+            TextField("Assessment API endpoint", text: $store.endpointURL)
+                .textFieldStyle(.roundedBorder)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Command")
+                    .font(.subheadline.weight(.semibold))
+                TextEditor(text: $store.draftCommand)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(minHeight: 88)
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.secondary.opacity(0.35)))
+            }
+
+            TextField("Working directory", text: $store.draftWorkingDirectory)
+                .textFieldStyle(.roundedBorder)
+            TextField("Source", text: $store.draftSource)
+                .textFieldStyle(.roundedBorder)
+            TextField("Justification", text: $store.draftJustification)
+                .textFieldStyle(.roundedBorder)
+
+            HStack(spacing: 8) {
+                Button {
+                    Task { await store.submitDraft() }
+                } label: {
+                    if store.isSubmitting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Assess")
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(store.isSubmitting)
+
+                Menu("Samples") {
+                    ForEach(SampleApproval.samples) { sample in
+                        Button(sample.title) {
+                            store.loadSample(sample)
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+
+            if let errorMessage = store.errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+
+            Divider()
+
+            if let latest = store.latestRequest {
+                LatestApprovalSummaryView(request: latest)
+            } else {
+                Text("まだ承認要求はない")
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            Text("Recent requests")
+                .font(.subheadline.weight(.semibold))
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(store.requests) { request in
+                        ApprovalRowView(request: request)
+                    }
+                }
+            }
+            .frame(minHeight: 180)
+        }
+        .padding(16)
+        .frame(width: 460)
+    }
+}
+
+struct LatestApprovalSummaryView: View {
+    let request: ApprovalAssessmentPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(request.riskLevel.rawValue.uppercased(), systemImage: symbol)
+                .font(.subheadline.weight(.semibold))
+            Text(request.summary)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+            Text(request.command)
+                .font(.system(.footnote, design: .monospaced))
+                .textSelection(.enabled)
+            Text(recommendationText)
+                .font(.footnote)
+        }
+    }
+
+    private var symbol: String {
+        switch request.riskLevel {
+        case .low:
+            return "checkmark.shield"
+        case .medium:
+            return "exclamationmark.shield"
+        case .high:
+            return "xmark.shield"
+        }
+    }
+
+    private var recommendationText: String {
+        switch request.recommendation {
+        case .likelyAllow:
+            return "推奨: 許可寄り"
+        case .inspectBeforeAllow:
+            return "推奨: 許可前に確認"
+        case .denyOrInspect:
+            return "推奨: そのまま許可しない"
+        }
+    }
+}
+
+struct ApprovalRowView: View {
+    let request: ApprovalAssessmentPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(request.riskLevel.rawValue.uppercased())
+                    .font(.caption.weight(.semibold))
+                Text(request.createdAt.formatted(date: .omitted, time: .shortened))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            Text(request.command)
+                .font(.system(.caption, design: .monospaced))
+                .lineLimit(2)
+            Text(request.categories.joined(separator: ", "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct ApprovalDetailView: View {
+    let request: ApprovalAssessmentPayload?
+
+    var body: some View {
+        Group {
+            if let request {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text(request.command)
+                            .font(.system(.headline, design: .monospaced))
+                            .textSelection(.enabled)
+
+                        detailBlock(title: "Summary", lines: [request.summary])
+                        detailBlock(title: "Reasons", lines: request.reasons)
+                        detailBlock(title: "Allow reasons", lines: request.allowReasons)
+                        detailBlock(title: "Deny reasons", lines: request.denyReasons)
+
+                        if let workingDirectory = request.workingDirectory {
+                            detailBlock(title: "Working directory", lines: [workingDirectory])
+                        }
+                        if let source = request.source {
+                            detailBlock(title: "Source", lines: [source])
+                        }
+                    }
+                    .padding(20)
+                }
+            } else {
+                ContentUnavailableView("No approval yet", systemImage: "shield")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func detailBlock(title: String, lines: [String]) -> some View {
+        if !lines.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.headline)
+                ForEach(lines, id: \.self) { line in
+                    Text("• \(line)")
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+}

--- a/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/main.swift
+++ b/apps/codex_approval_menubar/Sources/CodexApprovalMenubar/main.swift
@@ -1,0 +1,52 @@
+import AppKit
+import SwiftUI
+
+@main
+struct CodexApprovalMenubarMain {
+    static func main() {
+        if #available(macOS 14.0, *) {
+            CodexApprovalMenubarApp.main()
+        } else {
+            let app = NSApplication.shared
+            app.setActivationPolicy(.accessory)
+            let delegate = LegacyAppDelegate()
+            app.delegate = delegate
+            app.run()
+        }
+    }
+}
+
+@available(macOS 14.0, *)
+struct CodexApprovalMenubarApp: App {
+    @StateObject private var store = ApprovalStore.preview()
+
+    var body: some Scene {
+        MenuBarExtra("Codex Approval", systemImage: store.menuBarSymbolName) {
+            ApprovalMenuView(store: store)
+        }
+        .menuBarExtraStyle(.window)
+
+        Window("Latest Approval", id: "latest-approval") {
+            ApprovalDetailView(request: store.latestRequest)
+        }
+        .defaultSize(width: 520, height: 420)
+    }
+}
+
+final class LegacyAppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem?.button?.title = "Codex Approval"
+        let menu = NSMenu()
+        menu.addItem(withTitle: "Requires macOS 14+ for full MVP", action: nil, keyEquivalent: "")
+        menu.addItem(.separator())
+        menu.addItem(withTitle: "Quit", action: #selector(quit), keyEquivalent: "q")
+        statusItem?.menu = menu
+    }
+
+    @objc private func quit() {
+        NSApplication.shared.terminate(nil)
+    }
+}

--- a/docs/superpowers/specs/2026-04-26-codex-approval-menubar-mvp-swift-scaffold.md
+++ b/docs/superpowers/specs/2026-04-26-codex-approval-menubar-mvp-swift-scaffold.md
@@ -1,0 +1,79 @@
+# Codex Approval Menubar Swift Scaffold
+
+**Date:** 2026-04-26  
+**Repository:** `kentoku24/comic_crawler`  
+**Status:** Draft scaffold
+
+---
+
+## What this commit adds
+
+`apps/codex_approval_menubar/` に SwiftUI menubar app の最小骨格を追加する。
+
+### Included
+
+- `Package.swift`
+- `MenuBarExtra` ベースのアプリ起動点
+- approval assessment API client
+- in-memory store
+- sample approval requests
+- latest assessment / history 表示
+- high-risk / medium-risk request 時のローカル通知
+
+### Not included yet
+
+- Codex の実 approval event 監視
+- background bridge daemon
+- request history persistence
+- approve / deny を Codex へ返す導線
+- signed distribution / notarization
+
+## Why scaffold first
+
+いきなり実イベント監視まで入れると、Codex 側の event source の不確定さで実装が濁る。  
+そのため今回は、**backend contract を叩ける menubar surface** を先に固定する。
+
+## Proposed next slice
+
+次の実装単位は次のどちらか。
+
+### Option A: local bridge
+
+- Codex approval event を local webhook / stdin / log watch で受ける
+- bridge process が menubar app に転送する
+- app は API assessment 結果を表示する
+
+### Option B: embedded assessment fallback
+
+- backend 未接続時だけ Swift 側の非常用ルールを使う
+- ただし source of truth が二重化するので非推奨
+
+推奨は **Option A**。
+
+## Directory shape
+
+```text
+apps/
+  codex_approval_menubar/
+    Package.swift
+    README.md
+    Sources/
+      CodexApprovalMenubar/
+        main.swift
+        Models.swift
+        ApprovalStore.swift
+        ApprovalAPIClient.swift
+        SampleApproval.swift
+        Views.swift
+```
+
+## Build assumptions
+
+- macOS 14+
+- Swift 5.10+
+- `MenuBarExtra` を使うため SwiftUI App lifecycle を前提
+
+## Recommendation summary
+
+この段階では十分正しい。  
+「Codex からのイベント取得」はまだ未解決だが、**表示面と API 接続面を先に成立**させたことで、残りの work は bridge のみに集中できる。

--- a/docs/superpowers/specs/2026-04-26-codex-approval-menubar-mvp.md
+++ b/docs/superpowers/specs/2026-04-26-codex-approval-menubar-mvp.md
@@ -1,0 +1,201 @@
+# Codex Approval Helper MVP
+
+**Date:** 2026-04-26  
+**Repository:** `kentoku24/comic_crawler`  
+**Status:** Draft MVP / implementation scaffold
+
+---
+
+## Goal
+
+Codex がユーザー承認を要求した瞬間に通知し、**その内容を許可してよいか判断するための短い材料**を返す仕組みを作る。  
+最終形は Mac のメニューバーアプリだが、最初に作るべき source of truth は UI ではなく **approval assessment contract** である。
+
+## Why this order
+
+メニューバーアプリから先に作ると、判定ロジックが UI 内に埋まりやすい。  
+この repo はすでに operations-first で machine-facing API を育てる方針なので、まず Python 側に次を置く。
+
+1. Codex approval request の入力 schema
+2. ルールベースの risk assessment
+3. machine-facing JSON API
+4. 後から Mac app が叩ける安定インターフェース
+
+これにより、Swift 側は「イベント取得 + 通知 + 詳細表示」に集中できる。
+
+## Product shape
+
+### User story
+
+- Codex が「このコマンドを実行してよいか」と承認を求める
+- Mac メニューバーアプリがそれを検知する
+- アプリは assessment API に command / cwd / justification を送る
+- ユーザーは次をひと目で見る
+  - 何をしようとしているか
+  - どの種類のリスクか
+  - 許可してよさそうか
+  - どこを確認すべきか
+
+### Non-goals for MVP
+
+- Codex 本体への approve / deny 自動送信
+- LLM による高度な意図推定
+- 完全な shell parser
+- すべての危険コマンドの厳密判定
+- macOS ネイティブアプリの完成
+
+## MVP architecture
+
+```text
+Codex approval event
+  -> menu bar app / bridge process
+    -> POST /api/codex/approval-assess/
+      -> web_admin.operations.codex_approvals
+        -> rule-based assessment
+      <- JSON assessment
+    -> local notification / menu bar detail panel
+```
+
+## Input contract
+
+```json
+{
+  "command": "git push origin main",
+  "working_directory": "/Users/ken/project",
+  "source": "codex-cli",
+  "justification": "Push the completed fix to remote"
+}
+```
+
+### Required fields
+
+- `command`
+
+### Optional fields
+
+- `working_directory`
+- `source`
+- `justification`
+
+## Output contract
+
+```json
+{
+  "ok": true,
+  "assessment": {
+    "summary": "risk=medium; categories=write, network; command=git push origin main",
+    "recommendation": "inspect_before_allow",
+    "risk_level": "medium",
+    "requires_human_attention": true,
+    "categories": ["write", "network"],
+    "reasons": [
+      "ファイル変更または外部状態変更の可能性がある: `git push`",
+      "ネットワーク通信を伴う可能性がある: `git push`"
+    ],
+    "allow_reasons": [
+      "Codex 側の説明: Push the completed fix to remote"
+    ],
+    "deny_reasons": [
+      "ファイル・git・infra の状態を変更する可能性がある",
+      "外部送信やリモート変更が起きうる"
+    ],
+    "command": "git push origin main",
+    "working_directory": "/Users/ken/project",
+    "source": "codex-cli"
+  }
+}
+```
+
+## Recommendation levels
+
+- `likely_allow`
+  - 低リスクの読み取り中心
+- `inspect_before_allow`
+  - 副作用はあるが、文脈が妥当なら許可しうる
+- `deny_or_inspect`
+  - 破壊的 / 秘密情報 / 権限昇格を含み、追加確認なしで許可すべきでない
+
+## Rule set in MVP
+
+### Category detection
+
+- `read_only`
+- `write`
+- `network`
+- `privilege`
+- `secret`
+- `destructive`
+- `compound`
+- `unknown`
+
+### Current heuristic examples
+
+- `cat`, `ls`, `grep`, `git diff` -> `read_only`
+- `rm`, `chmod`, `git commit`, `docker`, `kubectl`, `gcloud` -> `write`
+- `curl`, `wget`, `scp`, `git push` -> `network`
+- `sudo`, `su`, `doas` -> `privilege`
+- `.env`, `id_rsa`, `token`, `password` -> `secret`
+- `rm -rf`, `mkfs`, `dd`, `drop table` -> `destructive`
+- `&&`, `||`, `|`, `;` を含む -> `compound`
+
+## Why this belongs in comic_crawler
+
+この repo はすでに machine-facing API と operations-first の運用基盤を持つ。  
+そのため、approval helper の核心を **運用 API の一部** として育てるのは自然。  
+将来的に別 repo へ切り出すとしても、先に contract を固める価値がある。
+
+## Next steps
+
+### Step 1: now
+
+- `web_admin.operations.codex_approvals` を追加
+- `/api/codex/approval-assess/` を追加
+- OpenAPI に endpoint を露出
+- ルールベースの MVP 判定を返す
+
+### Step 2: next
+
+- fixture ベースのテスト追加
+- command ごとの reason 文面を改善
+- shell tokenization を少し厳密化
+- allow/deny recommendation の calibration
+
+### Step 3: later
+
+- SwiftUI `MenuBarExtra` アプリ
+- local bridge で Codex approval event を監視
+- assessment API へ転送
+- macOS notification / menu detail / history 表示
+
+## Swift app recommendation
+
+Mac 側は次の構成を推奨する。
+
+- SwiftUI + `MenuBarExtra`
+- approval event watcher
+  - まずは log tail / JSON stdin / local webhook のどれか
+- network client
+  - `POST /api/codex/approval-assess/`
+- notification presenter
+- latest requests list + detail pane
+
+### Do not do first
+
+- いきなり TCC 深掘りや Accessibility hook に突っ込む
+- 判定ロジックを Swift 側へ複製する
+- approve/deny 自動化から始める
+
+## Open questions
+
+- Codex approval event の最良の取得元は何か
+  - structured log
+  - local webhook
+  - stdout interceptor
+  - approval prompt file
+- approve/deny 導線を Mac アプリから返すべきか
+- assessment API をローカルで持つか、Cloud Run で持つか
+
+## Recommendation summary
+
+おすすめは、**先に backend contract を作り、その後に menu bar app を薄く乗せる** こと。  
+今回の実装はその第一歩として十分筋が良い。Swift アプリは次のコミットで切ればいい。

--- a/tests/test_codex_approvals.py
+++ b/tests/test_codex_approvals.py
@@ -1,0 +1,35 @@
+from web_admin.operations.codex_approvals import ApprovalRequest, assess_approval_request, parse_approval_request
+
+
+def test_parse_requires_command() -> None:
+    try:
+        parse_approval_request({})
+    except Exception as exc:
+        assert str(exc) == "command is required"
+    else:
+        raise AssertionError("expected command validation error")
+
+
+def test_read_only_command_is_likely_allow() -> None:
+    assessment = assess_approval_request(ApprovalRequest(command="git diff -- README.md"))
+    assert assessment.risk_level == "low"
+    assert assessment.recommendation == "likely_allow"
+    assert "read_only" in assessment.categories
+
+
+def test_git_push_requires_inspection() -> None:
+    assessment = assess_approval_request(
+        ApprovalRequest(command="git push origin main", justification="push completed fix")
+    )
+    assert assessment.risk_level == "medium"
+    assert assessment.recommendation == "inspect_before_allow"
+    assert "write" in assessment.categories
+    assert "network" in assessment.categories
+
+
+def test_sudo_rm_rf_is_high_risk() -> None:
+    assessment = assess_approval_request(ApprovalRequest(command="sudo rm -rf /tmp/foo"))
+    assert assessment.risk_level == "high"
+    assert assessment.recommendation == "deny_or_inspect"
+    assert "privilege" in assessment.categories
+    assert "destructive" in assessment.categories

--- a/web_admin/api/openapi.py
+++ b/web_admin/api/openapi.py
@@ -33,6 +33,11 @@ def build_openapi_schema(*, backend: str | None = None) -> Dict[str, object]:
                 }
             },
             "/api/manual-run/": {"post": {"summary": "Trigger a background manual run"}},
+            "/api/codex/approval-assess/": {
+                "post": {
+                    "summary": "Assess a Codex approval request and return human decision support"
+                }
+            },
         },
         "x-machine-auth-policy": capabilities["machine_auth_policy"],
     }

--- a/web_admin/api/urls.py
+++ b/web_admin/api/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
     path("run-history/", views.run_history_detail, name="run_history"),
     path("watchlist/<str:work_id>/enabled/", views.watchlist_enabled_detail, name="watchlist_enabled"),
     path("manual-run/", views.manual_run_detail, name="manual_run"),
+    path("codex/approval-assess/", views.codex_approval_assess_detail, name="codex_approval_assess"),
     path("openapi.json", views.openapi_detail, name="openapi"),
 ]

--- a/web_admin/api/views.py
+++ b/web_admin/api/views.py
@@ -8,6 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from manga_watch.watchlist import WatchlistAddError
 from web_admin.operations import commands, queries
+from web_admin.operations.codex_approvals import ApprovalRequestError
 
 from .auth import machine_auth_required
 from .openapi import build_openapi_schema
@@ -37,6 +38,10 @@ def _watchlist_error_response(exc: WatchlistAddError) -> JsonResponse:
     status = 404 if exc.kind == "missing_work" else 400
     payload = {"ok": False, "error": exc.message, "detail": exc.to_dict()}
     return JsonResponse(payload, status=status)
+
+
+def _approval_error_response(exc: ApprovalRequestError) -> JsonResponse:
+    return JsonResponse({"ok": False, "error": str(exc)}, status=400)
 
 
 def _boolean_field(payload: Dict[str, Any], key: str) -> bool:
@@ -113,6 +118,21 @@ def manual_run_detail(request: HttpRequest):
     if request.method != "POST":
         return HttpResponseNotAllowed(["POST"])
     return JsonResponse({"ok": True, "result": commands.trigger_manual_run_command()})
+
+
+@csrf_exempt
+@machine_auth_required
+def codex_approval_assess_detail(request: HttpRequest):
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+    try:
+        payload = _json_body(request)
+        result = queries.assess_codex_approval(payload)
+    except ApiRequestError as exc:
+        return _json_request_error_response(exc)
+    except ApprovalRequestError as exc:
+        return _approval_error_response(exc)
+    return JsonResponse(result)
 
 
 @machine_auth_required

--- a/web_admin/operations/codex_approvals.py
+++ b/web_admin/operations/codex_approvals.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Mapping, Optional
+
+
+READ_ONLY_HINTS = (
+    "cat ",
+    "head ",
+    "tail ",
+    "less ",
+    "more ",
+    "grep ",
+    "find ",
+    "ls",
+    "pwd",
+    "git status",
+    "git diff",
+    "git show",
+)
+
+WRITE_HINTS = (
+    "rm ",
+    "mv ",
+    "cp ",
+    "sed -i",
+    "perl -i",
+    "tee ",
+    ">",
+    ">>",
+    "chmod ",
+    "chown ",
+    "git commit",
+    "git push",
+    "docker ",
+    "kubectl ",
+    "gcloud ",
+    "terraform ",
+)
+
+NETWORK_HINTS = (
+    "curl ",
+    "wget ",
+    "scp ",
+    "rsync ",
+    "gh api",
+    "git push",
+)
+
+PRIVILEGE_HINTS = (
+    "sudo ",
+    "su ",
+    "doas ",
+)
+
+SECRET_HINTS = (
+    ".env",
+    "id_rsa",
+    "id_ed25519",
+    "secret",
+    "token",
+    "password",
+    "private key",
+    "oauth",
+)
+
+DESTRUCTIVE_HINTS = (
+    "rm -rf",
+    "mkfs",
+    "dd ",
+    "shutdown",
+    "reboot",
+    "systemctl stop",
+    "drop table",
+)
+
+
+@dataclass(frozen=True)
+class ApprovalAssessment:
+    summary: str
+    recommendation: str
+    risk_level: str
+    requires_human_attention: bool
+    categories: List[str]
+    reasons: List[str]
+    allow_reasons: List[str]
+    deny_reasons: List[str]
+    command: str
+    working_directory: Optional[str] = None
+    source: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ApprovalRequest:
+    command: str
+    working_directory: Optional[str] = None
+    source: Optional[str] = None
+    justification: Optional[str] = None
+
+
+class ApprovalRequestError(ValueError):
+    pass
+
+
+def parse_approval_request(payload: Mapping[str, object]) -> ApprovalRequest:
+    command = str(payload.get("command") or "").strip()
+    if not command:
+        raise ApprovalRequestError("command is required")
+    working_directory = payload.get("working_directory")
+    source = payload.get("source")
+    justification = payload.get("justification")
+    return ApprovalRequest(
+        command=command,
+        working_directory=str(working_directory) if isinstance(working_directory, str) and working_directory.strip() else None,
+        source=str(source) if isinstance(source, str) and source.strip() else None,
+        justification=str(justification) if isinstance(justification, str) and justification.strip() else None,
+    )
+
+
+def assess_approval_request(request: ApprovalRequest) -> ApprovalAssessment:
+    command = request.command.strip()
+    lower = command.lower()
+
+    categories: List[str] = []
+    reasons: List[str] = []
+    allow_reasons: List[str] = []
+    deny_reasons: List[str] = []
+
+    def mark(category: str, reason: str) -> None:
+        if category not in categories:
+            categories.append(category)
+        reasons.append(reason)
+
+    for hint in READ_ONLY_HINTS:
+        if hint in lower:
+            mark("read_only", f"read-only っぽい操作を含む: `{hint.strip()}`")
+            allow_reasons.append("内容確認や調査目的の読み取り操作に見える")
+            break
+
+    for hint in WRITE_HINTS:
+        if hint in lower:
+            mark("write", f"ファイル変更または外部状態変更の可能性がある: `{hint.strip()}`")
+            deny_reasons.append("ファイル・git・infra の状態を変更する可能性がある")
+            break
+
+    for hint in NETWORK_HINTS:
+        if hint in lower:
+            mark("network", f"ネットワーク通信を伴う可能性がある: `{hint.strip()}`")
+            deny_reasons.append("外部送信やリモート変更が起きうる")
+            break
+
+    for hint in PRIVILEGE_HINTS:
+        if hint in lower:
+            mark("privilege", f"昇格権限を要求する可能性がある: `{hint.strip()}`")
+            deny_reasons.append("権限昇格は影響範囲が大きい")
+            break
+
+    for hint in SECRET_HINTS:
+        if hint in lower:
+            mark("secret", f"秘密情報や認証情報に触れる可能性がある: `{hint}`")
+            deny_reasons.append("秘密情報の閲覧・送信につながる可能性がある")
+            break
+
+    for hint in DESTRUCTIVE_HINTS:
+        if hint in lower:
+            mark("destructive", f"破壊的な操作の兆候がある: `{hint.strip()}`")
+            deny_reasons.append("復旧が面倒、または不可逆の可能性がある")
+            break
+
+    pipeline_markers = ["&&", "||", "|", ";"]
+    if any(marker in command for marker in pipeline_markers):
+        mark("compound", "複合コマンドで実行内容の影響範囲が広い")
+        deny_reasons.append("一度の許可で複数の操作が走る")
+
+    if not categories:
+        categories.append("unknown")
+        reasons.append("既知ルールに当てはまらず、目的と副作用を追加確認したい")
+        deny_reasons.append("未知コマンドなので、そのまま許可するには情報が足りない")
+
+    if "destructive" in categories or "privilege" in categories or "secret" in categories:
+        risk_level = "high"
+        recommendation = "deny_or_inspect"
+    elif "network" in categories or "write" in categories or "compound" in categories:
+        risk_level = "medium"
+        recommendation = "inspect_before_allow"
+    elif categories == ["read_only"]:
+        risk_level = "low"
+        recommendation = "likely_allow"
+    else:
+        risk_level = "medium"
+        recommendation = "inspect_before_allow"
+
+    if request.justification:
+        allow_reasons.append(f"Codex 側の説明: {request.justification}")
+
+    summary = _build_summary(command=command, categories=categories, risk_level=risk_level)
+    return ApprovalAssessment(
+        summary=summary,
+        recommendation=recommendation,
+        risk_level=risk_level,
+        requires_human_attention=risk_level != "low",
+        categories=categories,
+        reasons=_dedupe(reasons),
+        allow_reasons=_dedupe(allow_reasons),
+        deny_reasons=_dedupe(deny_reasons),
+        command=command,
+        working_directory=request.working_directory,
+        source=request.source,
+    )
+
+
+def _build_summary(*, command: str, categories: List[str], risk_level: str) -> str:
+    preview = command if len(command) <= 120 else command[:117] + "..."
+    labels = ", ".join(categories)
+    return f"risk={risk_level}; categories={labels}; command={preview}"
+
+
+def _dedupe(values: List[str]) -> List[str]:
+    result: List[str] = []
+    for value in values:
+        if value not in result:
+            result.append(value)
+    return result

--- a/web_admin/operations/queries.py
+++ b/web_admin/operations/queries.py
@@ -6,6 +6,7 @@ from manga_watch.status import build_status_report
 from manga_watch.storage import load_run_summaries, load_state, load_watchlist
 
 from .capabilities import capability_report
+from .codex_approvals import assess_approval_request, parse_approval_request
 
 
 def get_watchlist_data(*, watchlist_path: Optional[str] = None, backend: Optional[str] = None) -> Dict[str, object]:
@@ -41,6 +42,15 @@ def get_run_history(*, limit: int = 20, backend: Optional[str] = None) -> Dict[s
         "supported": True,
         "reason": None,
         "items": load_run_summaries(limit=limit, backend=backend) or [],
+    }
+
+
+def assess_codex_approval(payload: Dict[str, object]) -> Dict[str, object]:
+    request = parse_approval_request(payload)
+    assessment = assess_approval_request(request)
+    return {
+        "ok": True,
+        "assessment": assessment.to_dict(),
     }
 
 

--- a/web_admin/operations/schemas.py
+++ b/web_admin/operations/schemas.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
+from .codex_approvals import ApprovalAssessment
+
 
 @dataclass(frozen=True)
 class MachineAuthPolicy:
@@ -32,3 +34,15 @@ class CapabilityReport:
         payload = asdict(self)
         payload["machine_auth_policy"] = self.machine_auth_policy.to_dict()
         return payload
+
+
+@dataclass(frozen=True)
+class ApprovalAssessmentResponse:
+    ok: bool
+    assessment: ApprovalAssessment
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "assessment": self.assessment.to_dict(),
+        }


### PR DESCRIPTION
## Summary
- add a rule-based Codex approval assessment operation
- expose /api/codex/approval-assess/ via web_admin API and OpenAPI
- document the menu bar helper MVP and add initial tests

## Testing
- python3 inline smoke checks for approval assessment heuristics
- pytest test file added (pytest not installed in this environment)