### PR TITLE
Add signed HTTP integration test for Discord interaction server

### DIFF
--- a/tests/test_prod_e2e.py
+++ b/tests/test_prod_e2e.py
@@ -15,6 +15,10 @@ class ProductionE2ETests(unittest.TestCase):
     def setUpClass(cls):
         cls.base_url = (os.environ.get("MANGA_WATCH_E2E_BASE_URL") or "").rstrip("/")
         cls.bearer_token = (os.environ.get("MANGA_WATCH_E2E_BEARER_TOKEN") or "").strip()
+        cls.expected_storage_backend = (
+            os.environ.get("MANGA_WATCH_E2E_EXPECTED_STORAGE_BACKEND") or "firestore"
+        ).strip()
+        cls.expected_work_id = (os.environ.get("MANGA_WATCH_E2E_EXPECTED_WORK_ID") or "").strip()
         if not cls.base_url:
             raise unittest.SkipTest("MANGA_WATCH_E2E_BASE_URL is not set")
         cls.session = requests.Session()
@@ -78,6 +82,55 @@ class ProductionE2ETests(unittest.TestCase):
                     timeout=15,
                 )
                 self.assertEqual(200, response.status_code)
+
+    def test_db_backed_read_returns_expected_content(self):
+        """DoD: read request reaches real storage and returns persisted result."""
+        if not self.bearer_token:
+            raise unittest.SkipTest("MANGA_WATCH_E2E_BEARER_TOKEN is not set")
+
+        headers = {"Authorization": f"Bearer {self.bearer_token}"}
+
+        capabilities = self.session.get(
+            f"{self.base_url}/api/capabilities/",
+            headers=headers,
+            timeout=15,
+        )
+        self.assertEqual(200, capabilities.status_code)
+        capabilities_payload = capabilities.json()
+        self.assertTrue(capabilities_payload.get("ok"))
+        self.assertEqual(
+            self.expected_storage_backend,
+            capabilities_payload["capabilities"]["storage_backend"],
+        )
+
+        state = self.session.get(
+            f"{self.base_url}/api/state/",
+            headers=headers,
+            timeout=15,
+        )
+        self.assertEqual(200, state.status_code)
+        state_payload = state.json()
+        self.assertTrue(state_payload.get("ok"))
+        self.assertIsInstance(state_payload.get("state"), dict)
+        self.assertIsInstance(state_payload["state"].get("works"), dict)
+
+        watchlist = self.session.get(
+            f"{self.base_url}/api/watchlist/",
+            headers=headers,
+            timeout=15,
+        )
+        self.assertEqual(200, watchlist.status_code)
+        watchlist_payload = watchlist.json()
+        self.assertTrue(watchlist_payload.get("ok"))
+        self.assertIsInstance(watchlist_payload.get("watchlist"), dict)
+        self.assertIsInstance(watchlist_payload["watchlist"].get("works"), list)
+
+        if self.expected_work_id:
+            works = watchlist_payload["watchlist"]["works"]
+            self.assertTrue(
+                any(str(item.get("id")) == self.expected_work_id for item in works),
+                msg=f"expected work id not found in watchlist: {self.expected_work_id}",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_prod_e2e.py
+++ b/tests/test_prod_e2e.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+
+import requests
+
+
+class ProductionE2ETests(unittest.TestCase):
+    """E2E checks against a deployed environment (Discord UI excluded).
+
+    Required env:
+    - MANGA_WATCH_E2E_BASE_URL (e.g. https://<service-url>)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = (os.environ.get("MANGA_WATCH_E2E_BASE_URL") or "").rstrip("/")
+        if not cls.base_url:
+            raise unittest.SkipTest("MANGA_WATCH_E2E_BASE_URL is not set")
+        cls.session = requests.Session()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.session.close()
+
+    def test_healthz_returns_ok(self):
+        response = self.session.get(f"{self.base_url}/healthz", timeout=15)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("ok", response.text)
+
+    def test_interaction_rejects_invalid_signature(self):
+        response = self.session.post(
+            f"{self.base_url}/",
+            data=b'{"type":1}',
+            headers={
+                "Content-Type": "application/json",
+                "X-Signature-Ed25519": "00" * 64,
+                "X-Signature-Timestamp": "1700000000",
+            },
+            timeout=15,
+        )
+        self.assertEqual(401, response.status_code)
+        self.assertEqual("invalid request signature", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prod_e2e.py
+++ b/tests/test_prod_e2e.py
@@ -14,6 +14,7 @@ class ProductionE2ETests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.base_url = (os.environ.get("MANGA_WATCH_E2E_BASE_URL") or "").rstrip("/")
+        cls.bearer_token = (os.environ.get("MANGA_WATCH_E2E_BEARER_TOKEN") or "").strip()
         if not cls.base_url:
             raise unittest.SkipTest("MANGA_WATCH_E2E_BASE_URL is not set")
         cls.session = requests.Session()
@@ -40,6 +41,43 @@ class ProductionE2ETests(unittest.TestCase):
         )
         self.assertEqual(401, response.status_code)
         self.assertEqual("invalid request signature", response.text)
+
+    def test_api_read_endpoints_require_auth_without_bearer(self):
+        read_paths = [
+            "/api/watchlist/",
+            "/api/state/",
+            "/api/health/",
+            "/api/capabilities/",
+            "/api/run-history/",
+            "/api/openapi.json",
+        ]
+        for path in read_paths:
+            with self.subTest(path=path):
+                response = self.session.get(f"{self.base_url}{path}", timeout=15)
+                self.assertEqual(401, response.status_code)
+                self.assertIn("missing bearer token", response.text)
+
+    def test_api_read_endpoints_return_200_with_bearer_token(self):
+        if not self.bearer_token:
+            raise unittest.SkipTest("MANGA_WATCH_E2E_BEARER_TOKEN is not set")
+
+        headers = {"Authorization": f"Bearer {self.bearer_token}"}
+        read_paths = [
+            "/api/watchlist/",
+            "/api/state/",
+            "/api/health/",
+            "/api/capabilities/",
+            "/api/run-history/",
+            "/api/openapi.json",
+        ]
+        for path in read_paths:
+            with self.subTest(path=path):
+                response = self.session.get(
+                    f"{self.base_url}{path}",
+                    headers=headers,
+                    timeout=15,
+                )
+                self.assertEqual(200, response.status_code)
 
 
 if __name__ == "__main__":

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -1,13 +1,9 @@
-import http.client
-import json
 import os
-import threading
 import unittest
 from unittest import mock
 
 from nacl_test_support import SigningKey
 
-from manga_watch.discord_interactions import DiscordInteractionService, DiscordRequestVerifier
 from manga_watch import run_service
 
 
@@ -172,67 +168,6 @@ class RunServiceTests(unittest.TestCase):
                 exit_code = run_service.main()
 
         self.assertEqual(2, exit_code)
-
-    def test_http_server_accepts_signed_discord_post(self):
-        """Pseudo-E2E for HTTP entrypoint using only local in-process components.
-
-        Notes for CI (GitHub Actions):
-        - This test does NOT call Discord API or Cloud Run/GCP endpoints.
-        - It starts ThreadingHTTPServer on 127.0.0.1 with an ephemeral port.
-        - The request is sent via http.client to that local server only.
-        - fetch_dispatcher is a no-op stub, so no external backend launch occurs.
-        - DB access is not required:
-          - `latest_handler` is an inline lambda that returns a fixed string.
-          - command registration / watchlist / storage initialization is not executed.
-        - Fixture test data is not required because request/response payloads are
-          built inline in this test.
-        """
-
-        class NoopFetchDispatcher:
-            def dispatch(self):
-                return {"message": "ok"}
-
-        signing_key = SigningKey.generate()
-        public_key = signing_key.verify_key.encode().hex()
-        service = DiscordInteractionService(
-            timezone_name="Asia/Tokyo",
-            fetch_dispatcher=NoopFetchDispatcher(),
-            verifier=DiscordRequestVerifier(public_key),
-            latest_handler=lambda *_args, **_kwargs: "最新話です",
-        )
-        server = run_service.ThreadingHTTPServer(("127.0.0.1", 0), run_service.build_request_handler(service))
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        try:
-            payload = {"type": 2, "data": {"name": "latest"}}
-            body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-            timestamp = "1700000000"
-            signature = signing_key.sign(timestamp.encode("utf-8") + body).signature.hex()
-
-            conn = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)
-            conn.request(
-                "POST",
-                "/",
-                body=body,
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Signature-Ed25519": signature,
-                    "X-Signature-Timestamp": timestamp,
-                },
-            )
-            response = conn.getresponse()
-            response_body = response.read()
-            conn.close()
-        finally:
-            server.shutdown()
-            server.server_close()
-            thread.join(timeout=2)
-
-        self.assertEqual(200, response.status)
-        parsed = json.loads(response_body)
-        self.assertEqual(4, parsed["type"])
-        self.assertIn("最新話です", parsed["data"]["content"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -181,6 +181,11 @@ class RunServiceTests(unittest.TestCase):
         - It starts ThreadingHTTPServer on 127.0.0.1 with an ephemeral port.
         - The request is sent via http.client to that local server only.
         - fetch_dispatcher is a no-op stub, so no external backend launch occurs.
+        - DB access is not required:
+          - `latest_handler` is an inline lambda that returns a fixed string.
+          - command registration / watchlist / storage initialization is not executed.
+        - Fixture test data is not required because request/response payloads are
+          built inline in this test.
         """
 
         class NoopFetchDispatcher:

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -1,9 +1,13 @@
+import http.client
+import json
 import os
+import threading
 import unittest
 from unittest import mock
 
 from nacl_test_support import SigningKey
 
+from manga_watch.discord_interactions import DiscordInteractionService, DiscordRequestVerifier
 from manga_watch import run_service
 
 
@@ -168,6 +172,52 @@ class RunServiceTests(unittest.TestCase):
                 exit_code = run_service.main()
 
         self.assertEqual(2, exit_code)
+
+    def test_http_server_accepts_signed_discord_post(self):
+        class NoopFetchDispatcher:
+            def dispatch(self):
+                return {"message": "ok"}
+
+        signing_key = SigningKey.generate()
+        public_key = signing_key.verify_key.encode().hex()
+        service = DiscordInteractionService(
+            timezone_name="Asia/Tokyo",
+            fetch_dispatcher=NoopFetchDispatcher(),
+            verifier=DiscordRequestVerifier(public_key),
+            latest_handler=lambda *_args, **_kwargs: "最新話です",
+        )
+        server = run_service.ThreadingHTTPServer(("127.0.0.1", 0), run_service.build_request_handler(service))
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            payload = {"type": 2, "data": {"name": "latest"}}
+            body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            timestamp = "1700000000"
+            signature = signing_key.sign(timestamp.encode("utf-8") + body).signature.hex()
+
+            conn = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)
+            conn.request(
+                "POST",
+                "/",
+                body=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Signature-Ed25519": signature,
+                    "X-Signature-Timestamp": timestamp,
+                },
+            )
+            response = conn.getresponse()
+            response_body = response.read()
+            conn.close()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        self.assertEqual(200, response.status)
+        parsed = json.loads(response_body)
+        self.assertEqual(4, parsed["type"])
+        self.assertIn("最新話です", parsed["data"]["content"])
 
 
 if __name__ == "__main__":

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -174,6 +174,15 @@ class RunServiceTests(unittest.TestCase):
         self.assertEqual(2, exit_code)
 
     def test_http_server_accepts_signed_discord_post(self):
+        """Pseudo-E2E for HTTP entrypoint using only local in-process components.
+
+        Notes for CI (GitHub Actions):
+        - This test does NOT call Discord API or Cloud Run/GCP endpoints.
+        - It starts ThreadingHTTPServer on 127.0.0.1 with an ephemeral port.
+        - The request is sent via http.client to that local server only.
+        - fetch_dispatcher is a no-op stub, so no external backend launch occurs.
+        """
+
         class NoopFetchDispatcher:
             def dispatch(self):
                 return {"message": "ok"}


### PR DESCRIPTION
### Motivation

- Ensure `run_service` correctly accepts real HTTP POSTs for Discord interactions and verifies Ed25519-signed requests end-to-end through `DiscordInteractionService`.

### Description

- Add `test_http_server_accepts_signed_discord_post` to `tests/test_run_service.py` that starts a local `ThreadingHTTPServer` with `run_service.build_request_handler` and sends a signed Discord interaction POST.
- Add imports for `http.client`, `json`, `threading`, and `DiscordInteractionService`/`DiscordRequestVerifier`, and include a small `NoopFetchDispatcher` used by the test to satisfy service construction.
- The test constructs an Ed25519 signature using `nacl_test_support.SigningKey`, posts the compact JSON body with `X-Signature-Ed25519` and `X-Signature-Timestamp` headers, and asserts the delegated interaction response is an immediate type `4` payload containing the expected text.
- Close the target issue by providing this pseudo-E2E coverage for the `/` interaction path (addresses #328).

### Testing

- Ran `python -m unittest tests.test_run_service tests.test_discord_interactions`, which initially surfaced a missing constructor dependency and was fixed by providing a `NoopFetchDispatcher` in the test.
- After the fix, the focused test run completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f17e6022cc8332862646994652acf1)