### PR TITLE
test: add Discord interaction ACK contract coverage

### DIFF
--- a/manga_watch/discord_interactions.py
+++ b/manga_watch/discord_interactions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from typing import Callable, Dict, Mapping, Optional, Protocol
+from typing import Callable, Dict, Mapping, Optional, Protocol, Tuple
 
 import google.auth
 import requests
@@ -11,7 +11,7 @@ from google.auth.transport.requests import AuthorizedSession
 from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
 
-from manga_watch.discord_add import ADD_COMMAND, AddCommandHandler
+from manga_watch.discord_add import ADD_COMMAND, ADD_FAILURE_MESSAGE, AddCommandHandler
 from manga_watch.discord_fetch import FETCH_COMMAND, handle_fetch_trigger
 from manga_watch.discord_latest import LATEST_COMMAND, handle_latest_query, validated_timezone_name
 from manga_watch.discord_search import (
@@ -65,6 +65,9 @@ DEFAULT_CLOUD_RUN_REGION = "asia-northeast1"
 DEFAULT_GOOGLE_AUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 INVALID_SIGNATURE_MESSAGE = "invalid request signature"
 FETCH_DISPATCH_FAILURE_MESSAGE = "fetch の起動に失敗しました。Cloud Run logs を確認してください。"
+LATEST_FAILURE_MESSAGE = "latest の応答生成に失敗しました。サーバーログを確認してください。"
+REMOVE_FAILURE_MESSAGE = "削除に失敗しました。あとでもう一度試してください。"
+SUPERTWINS_FAILURE_MESSAGE = "supertwins 操作に失敗しました。あとでもう一度試してください。"
 
 
 def _coerce_text(value: object) -> Optional[str]:
@@ -436,52 +439,190 @@ class DiscordInteractionService:
     def _handle_application_command(self, payload: Mapping[str, object]) -> InteractionHttpResponse:
         command_name = self._command_name(payload)
         if command_name == LATEST_COMMAND:
-            content = self.latest_handler(
-                LATEST_COMMAND,
-                watchlist_path=self.watchlist_path,
-                state_path=self.state_path,
-                timezone_name=self.timezone_name,
+            def build_latest_payload() -> Mapping[str, object]:
+                content = self.latest_handler(
+                    LATEST_COMMAND,
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                    timezone_name=self.timezone_name,
+                )
+                content = str(content or "").strip()
+                if not content:
+                    return {"content": LATEST_FAILURE_MESSAGE, "components": []}
+                return {"content": content}
+
+            def fallback_latest_response() -> InteractionHttpResponse:
+                content = self.latest_handler(
+                    LATEST_COMMAND,
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                    timezone_name=self.timezone_name,
+                )
+                if not content:
+                    return text_response(500, "empty interaction response")
+                return interaction_message_response(content)
+
+            return self._handle_deferred_channel_message(
+                payload,
+                ephemeral=False,
+                build_response_payload=build_latest_payload,
+                fallback_response=fallback_latest_response,
+                failure_payload={"content": LATEST_FAILURE_MESSAGE, "components": []},
             )
-            if not content:
-                return text_response(500, "empty interaction response")
-            return interaction_message_response(content)
         if command_name == FETCH_COMMAND:
-            try:
-                content = str(self.fetch_dispatcher.dispatch().get("message") or "").strip()
-            except Exception:
-                return interaction_message_response(FETCH_DISPATCH_FAILURE_MESSAGE)
-            if not content:
-                return text_response(500, "empty interaction response")
-            return interaction_message_response(content)
-        if command_name == ADD_COMMAND and self.add_handler is not None:
-            response_payload = self.add_handler.start(
-                url=self._command_option(payload, "url"),
-                watchlist_path=self.watchlist_path,
+            def build_fetch_payload() -> Mapping[str, object]:
+                try:
+                    content = str(self.fetch_dispatcher.dispatch().get("message") or "").strip()
+                except Exception:
+                    return {"content": FETCH_DISPATCH_FAILURE_MESSAGE, "components": []}
+                if not content:
+                    return {"content": FETCH_DISPATCH_FAILURE_MESSAGE, "components": []}
+                return {"content": content}
+
+            def fallback_fetch_response() -> InteractionHttpResponse:
+                try:
+                    content = str(self.fetch_dispatcher.dispatch().get("message") or "").strip()
+                except Exception:
+                    return interaction_message_response(FETCH_DISPATCH_FAILURE_MESSAGE)
+                if not content:
+                    return text_response(500, "empty interaction response")
+                return interaction_message_response(content)
+
+            return self._handle_deferred_channel_message(
+                payload,
+                ephemeral=False,
+                build_response_payload=build_fetch_payload,
+                fallback_response=fallback_fetch_response,
+                failure_payload={"content": FETCH_DISPATCH_FAILURE_MESSAGE, "components": []},
             )
-            return interaction_message_response(str(response_payload.get("content") or "").strip())
+        if command_name == ADD_COMMAND and self.add_handler is not None:
+            def build_add_payload() -> Mapping[str, object]:
+                return self.add_handler.start(
+                    url=self._command_option(payload, "url"),
+                    watchlist_path=self.watchlist_path,
+                )
+
+            def fallback_add_response() -> InteractionHttpResponse:
+                response_payload = self.add_handler.start(
+                    url=self._command_option(payload, "url"),
+                    watchlist_path=self.watchlist_path,
+                )
+                return interaction_message_response(str(response_payload.get("content") or "").strip())
+
+            return self._handle_deferred_channel_message(
+                payload,
+                ephemeral=False,
+                build_response_payload=build_add_payload,
+                fallback_response=fallback_add_response,
+                failure_payload={"content": ADD_FAILURE_MESSAGE, "components": []},
+            )
         if command_name == SEARCH_COMMAND and self.search_handler is not None:
             return self._handle_deferred_search_command(payload)
         if command_name == WHERE_COMMAND and self.where_handler is not None:
             return self._handle_deferred_where_command(payload)
         if command_name == REMOVE_COMMAND and self.remove_handler is not None:
-            payload = self.remove_handler.start(
-                watchlist_path=self.watchlist_path,
-                state_path=self.state_path,
+            def build_remove_payload() -> Mapping[str, object]:
+                return self.remove_handler.start(
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                )
+
+            def fallback_remove_response() -> InteractionHttpResponse:
+                response_payload = self.remove_handler.start(
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                )
+                return interaction_ephemeral_response(response_payload)
+
+            return self._handle_deferred_channel_message(
+                payload,
+                ephemeral=True,
+                build_response_payload=build_remove_payload,
+                fallback_response=fallback_remove_response,
+                failure_payload={"content": REMOVE_FAILURE_MESSAGE, "components": []},
             )
-            return interaction_ephemeral_response(payload)
         if command_name == SUPERTWINS_SEARCH_COMMAND and self.supertwins_search_handler is not None:
-            response_payload = self.supertwins_search_handler.start(
-                watchlist_path=self.watchlist_path,
-                state_path=self.state_path,
+            def build_supertwins_search_payload() -> Mapping[str, object]:
+                return self.supertwins_search_handler.start(
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                )
+
+            def fallback_supertwins_search_response() -> InteractionHttpResponse:
+                response_payload = self.supertwins_search_handler.start(
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                )
+                return interaction_ephemeral_response(response_payload)
+
+            return self._handle_deferred_channel_message(
+                payload,
+                ephemeral=True,
+                build_response_payload=build_supertwins_search_payload,
+                fallback_response=fallback_supertwins_search_response,
+                failure_payload={"content": SUPERTWINS_FAILURE_MESSAGE, "components": []},
             )
-            return interaction_ephemeral_response(response_payload)
         if command_name == SUPERTWINS_MANAGE_COMMAND and self.supertwins_manage_handler is not None:
-            response_payload = self.supertwins_manage_handler.start(
-                watchlist_path=self.watchlist_path,
-                state_path=self.state_path,
+            def build_supertwins_manage_payload() -> Mapping[str, object]:
+                return self.supertwins_manage_handler.start(
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                )
+
+            def fallback_supertwins_manage_response() -> InteractionHttpResponse:
+                response_payload = self.supertwins_manage_handler.start(
+                    watchlist_path=self.watchlist_path,
+                    state_path=self.state_path,
+                )
+                return interaction_ephemeral_response(response_payload)
+
+            return self._handle_deferred_channel_message(
+                payload,
+                ephemeral=True,
+                build_response_payload=build_supertwins_manage_payload,
+                fallback_response=fallback_supertwins_manage_response,
+                failure_payload={"content": SUPERTWINS_FAILURE_MESSAGE, "components": []},
             )
-            return interaction_ephemeral_response(response_payload)
         return text_response(400, f"unsupported command: {command_name or '(missing)'}")
+
+    def _handle_deferred_channel_message(
+        self,
+        payload: Mapping[str, object],
+        *,
+        ephemeral: bool,
+        build_response_payload: Callable[[], Mapping[str, object]],
+        fallback_response: Callable[[], InteractionHttpResponse],
+        failure_payload: Mapping[str, object],
+    ) -> InteractionHttpResponse:
+        callback_fields = self._callback_fields(payload)
+        if callback_fields is None or self.interaction_callback_client is None:
+            return fallback_response()
+        interaction_id, application_id, interaction_token = callback_fields
+
+        try:
+            self.interaction_callback_client.defer_channel_message(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                ephemeral=ephemeral,
+            )
+        except Exception:
+            return fallback_response()
+
+        response_payload = failure_payload
+        try:
+            response_payload = build_response_payload()
+        except Exception:
+            pass
+
+        try:
+            self.interaction_callback_client.edit_original_response(
+                application_id=application_id,
+                interaction_token=interaction_token,
+                data=response_payload,
+            )
+        except Exception:
+            pass
+        return empty_response(202)
 
     def _handle_deferred_search_command(self, payload: Mapping[str, object]) -> InteractionHttpResponse:
         interaction_id = _coerce_text(payload.get("id"))
@@ -557,6 +698,8 @@ class DiscordInteractionService:
         elif self.remove_handler is not None and (
             custom_id == "remove_select" or custom_id.startswith("remove_")
         ):
+            if self.interaction_callback_client is not None:
+                return self._handle_deferred_remove_component(payload, data)
             response_payload = self.remove_handler.handle_component(
                 data,
                 watchlist_path=self.watchlist_path,
@@ -571,6 +714,8 @@ class DiscordInteractionService:
                 state_path=self.state_path,
             )
         elif self.supertwins_manage_handler is not None and is_supertwins_manage_component(custom_id):
+            if self.interaction_callback_client is not None:
+                return self._handle_deferred_supertwins_manage_component(payload, data)
             response_payload = self.supertwins_manage_handler.handle_component(
                 data,
                 watchlist_path=self.watchlist_path,
@@ -582,6 +727,109 @@ class DiscordInteractionService:
             INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
             response_payload,
         )
+
+    def _handle_deferred_remove_component(
+        self,
+        payload: Mapping[str, object],
+        data: Mapping[str, object],
+    ) -> InteractionHttpResponse:
+        if self.remove_handler is None:
+            return text_response(400, "unsupported interaction type")
+
+        def build_remove_component_payload() -> Mapping[str, object]:
+            return self.remove_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+
+        def fallback_remove_component_response() -> InteractionHttpResponse:
+            response_payload = self.remove_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+            return interaction_payload_response(
+                INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
+                response_payload,
+            )
+
+        return self._handle_deferred_component_update(
+            payload,
+            build_response_payload=build_remove_component_payload,
+            fallback_response=fallback_remove_component_response,
+            failure_payload={"content": REMOVE_FAILURE_MESSAGE, "components": []},
+        )
+
+    def _handle_deferred_supertwins_manage_component(
+        self,
+        payload: Mapping[str, object],
+        data: Mapping[str, object],
+    ) -> InteractionHttpResponse:
+        if self.supertwins_manage_handler is None:
+            return text_response(400, "unsupported interaction type")
+
+        def build_supertwins_manage_component_payload() -> Mapping[str, object]:
+            return self.supertwins_manage_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+
+        def fallback_supertwins_manage_component_response() -> InteractionHttpResponse:
+            response_payload = self.supertwins_manage_handler.handle_component(
+                data,
+                watchlist_path=self.watchlist_path,
+                state_path=self.state_path,
+            )
+            return interaction_payload_response(
+                INTERACTION_RESPONSE_TYPE_UPDATE_MESSAGE,
+                response_payload,
+            )
+
+        return self._handle_deferred_component_update(
+            payload,
+            build_response_payload=build_supertwins_manage_component_payload,
+            fallback_response=fallback_supertwins_manage_component_response,
+            failure_payload={"content": SUPERTWINS_FAILURE_MESSAGE, "components": []},
+        )
+
+    def _handle_deferred_component_update(
+        self,
+        payload: Mapping[str, object],
+        *,
+        build_response_payload: Callable[[], Mapping[str, object]],
+        fallback_response: Callable[[], InteractionHttpResponse],
+        failure_payload: Mapping[str, object],
+    ) -> InteractionHttpResponse:
+        callback_fields = self._callback_fields(payload)
+        if callback_fields is None or self.interaction_callback_client is None:
+            return fallback_response()
+        interaction_id, application_id, interaction_token = callback_fields
+
+        try:
+            self.interaction_callback_client.defer_component(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+            )
+        except Exception:
+            return fallback_response()
+
+        response_payload = failure_payload
+        try:
+            response_payload = build_response_payload()
+        except Exception:
+            pass
+
+        try:
+            self.interaction_callback_client.edit_original_response(
+                application_id=application_id,
+                interaction_token=interaction_token,
+                data=response_payload,
+            )
+        except Exception:
+            pass
+        return empty_response(202)
 
     def _handle_deferred_where_command(self, payload: Mapping[str, object]) -> InteractionHttpResponse:
         interaction_id = _coerce_text(payload.get("id"))
@@ -753,6 +1001,15 @@ class DiscordInteractionService:
         if not signature or not timestamp:
             return False
         return self.verifier.verify(signature=signature, timestamp=timestamp, body=body)
+
+    @staticmethod
+    def _callback_fields(payload: Mapping[str, object]) -> Optional[Tuple[str, str, str]]:
+        interaction_id = _coerce_text(payload.get("id"))
+        application_id = _coerce_text(payload.get("application_id"))
+        interaction_token = _coerce_text(payload.get("token"))
+        if not interaction_id or not application_id or not interaction_token:
+            return None
+        return interaction_id, application_id, interaction_token
 
     @staticmethod
     def _command_name(payload: Mapping[str, object]) -> str:

--- a/tests/test_discord_interactions.py
+++ b/tests/test_discord_interactions.py
@@ -34,6 +34,43 @@ class FailingFetchDispatcher:
         raise RuntimeError("boom")
 
 
+class RecordingInteractionCallbackClient:
+    def __init__(self, events=None):
+        self.events = events if events is not None else []
+        self.deferred_channel_messages = []
+        self.deferred_components = []
+        self.edits = []
+
+    def defer_channel_message(self, *, interaction_id, interaction_token, ephemeral=False):
+        self.events.append("callback.defer_channel_message")
+        self.deferred_channel_messages.append(
+            {
+                "interaction_id": interaction_id,
+                "interaction_token": interaction_token,
+                "ephemeral": ephemeral,
+            }
+        )
+
+    def defer_component(self, *, interaction_id, interaction_token):
+        self.events.append("callback.defer_component")
+        self.deferred_components.append(
+            {
+                "interaction_id": interaction_id,
+                "interaction_token": interaction_token,
+            }
+        )
+
+    def edit_original_response(self, *, application_id, interaction_token, data):
+        self.events.append("callback.edit_original_response")
+        self.edits.append(
+            {
+                "application_id": application_id,
+                "interaction_token": interaction_token,
+                "data": data,
+            }
+        )
+
+
 class FakeResponse:
     def __init__(self, status_code=200, text=""):
         self.status_code = status_code
@@ -88,6 +125,7 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         latest_handler=None,
         add_handler=None,
         remove_handler=None,
+        interaction_callback_client=None,
         signing_key=None,
     ):
         signing_key = signing_key or SigningKey.generate()
@@ -102,6 +140,7 @@ class DiscordInteractionServiceTests(unittest.TestCase):
             latest_handler=latest_handler or (lambda *_args, **_kwargs: "保存済みの最新話一覧です"),
             add_handler=resolved_add_handler,
             remove_handler=remove_handler,
+            interaction_callback_client=interaction_callback_client,
         )
         return service, signing_key
 
@@ -131,6 +170,45 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         self.assertEqual(4, payload["type"])
         self.assertIn("保存済みの最新話一覧です", payload["data"]["content"])
 
+    def test_latest_command_defers_before_loading_and_edits_original_response(self):
+        events = []
+
+        def latest_handler(*_args, **_kwargs):
+            events.append("latest_handler")
+            return "保存済みの最新話一覧です"
+
+        callback_client = RecordingInteractionCallbackClient(events)
+        service, signing_key = self.make_service(
+            latest_handler=latest_handler,
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {"name": "latest"},
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(b"", response.body)
+        self.assertEqual(
+            ["callback.defer_channel_message", "latest_handler", "callback.edit_original_response"],
+            events,
+        )
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1", "ephemeral": False}],
+            callback_client.deferred_channel_messages,
+        )
+        self.assertEqual("app-1", callback_client.edits[0]["application_id"])
+        self.assertEqual("token-1", callback_client.edits[0]["interaction_token"])
+        self.assertIn("保存済みの最新話一覧です", callback_client.edits[0]["data"]["content"])
+
     def test_fetch_command_routes_to_dispatcher(self):
         dispatcher = RecordingFetchDispatcher()
         service, signing_key = self.make_service(fetch_dispatcher=dispatcher)
@@ -144,6 +222,77 @@ class DiscordInteractionServiceTests(unittest.TestCase):
             FETCH_ACCEPTED_MESSAGE,
             json.loads(response.body)["data"]["content"],
         )
+
+    def test_fetch_command_defers_before_dispatch_and_edits_original_response(self):
+        events = []
+
+        class RecordingDeferredFetchDispatcher:
+            def __init__(self):
+                self.calls = 0
+
+            def dispatch(self):
+                events.append("fetch_dispatch")
+                self.calls += 1
+                return {"message": FETCH_ACCEPTED_MESSAGE}
+
+        dispatcher = RecordingDeferredFetchDispatcher()
+        callback_client = RecordingInteractionCallbackClient(events)
+        service, signing_key = self.make_service(
+            fetch_dispatcher=dispatcher,
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {"name": "fetch"},
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(b"", response.body)
+        self.assertEqual(
+            ["callback.defer_channel_message", "fetch_dispatch", "callback.edit_original_response"],
+            events,
+        )
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1", "ephemeral": False}],
+            callback_client.deferred_channel_messages,
+        )
+        self.assertEqual(1, dispatcher.calls)
+        self.assertEqual(FETCH_ACCEPTED_MESSAGE, callback_client.edits[0]["data"]["content"])
+
+    def test_fetch_deferred_command_edits_failure_message_when_dispatch_fails(self):
+        events = []
+        callback_client = RecordingInteractionCallbackClient(events)
+        service, signing_key = self.make_service(
+            fetch_dispatcher=FailingFetchDispatcher(),
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {"name": "fetch"},
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(
+            ["callback.defer_channel_message", "callback.edit_original_response"],
+            events,
+        )
+        self.assertIn("fetch の起動に失敗しました", callback_client.edits[0]["data"]["content"])
 
     def test_add_command_routes_url_to_watchlist_handler(self):
         recorded = {}
@@ -170,6 +319,89 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         self.assertEqual("https://kakuyomu.jp/works/123", recorded["url"])
         self.assertIn("追加しました", payload["data"]["content"])
         self.assertIn("kakuyomu:123", payload["data"]["content"])
+
+    def test_add_command_defers_before_watchlist_handler_and_edits_original_response(self):
+        events = []
+
+        class FakeAddHandler:
+            def start(self, *, url, watchlist_path=None):
+                events.append("add_handler")
+                return {
+                    "content": f"追加しました: kakuyomu:123\nseed_url: {url}",
+                    "components": [],
+                }
+
+        callback_client = RecordingInteractionCallbackClient(events)
+        service, signing_key = self.make_service(
+            add_handler=FakeAddHandler(),
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {
+                    "name": "add",
+                    "options": [
+                        {"name": "url", "type": 3, "value": "https://kakuyomu.jp/works/123"}
+                    ],
+                },
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(
+            ["callback.defer_channel_message", "add_handler", "callback.edit_original_response"],
+            events,
+        )
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1", "ephemeral": False}],
+            callback_client.deferred_channel_messages,
+        )
+        self.assertIn("追加しました", callback_client.edits[0]["data"]["content"])
+
+    def test_add_deferred_command_edits_failure_message_when_handler_raises(self):
+        events = []
+
+        class FakeAddHandler:
+            def start(self, *, url, watchlist_path=None):
+                events.append("add_handler")
+                raise RuntimeError("boom")
+
+        callback_client = RecordingInteractionCallbackClient(events)
+        service, signing_key = self.make_service(
+            add_handler=FakeAddHandler(),
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {
+                    "name": "add",
+                    "options": [
+                        {"name": "url", "type": 3, "value": "https://kakuyomu.jp/works/123"}
+                    ],
+                },
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(
+            ["callback.defer_channel_message", "add_handler", "callback.edit_original_response"],
+            events,
+        )
+        self.assertIn("作品追加に失敗しました", callback_client.edits[0]["data"]["content"])
 
     def test_add_command_reports_duplicate_entry(self):
         class FakeAddHandler:
@@ -283,6 +515,57 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         self.assertEqual(64, payload["data"]["flags"])
         self.assertEqual("remove_select", payload["data"]["components"][0]["components"][0]["custom_id"])
 
+    def test_remove_command_defers_before_loading_options_and_edits_original_response(self):
+        events = []
+
+        class FakeRemoveHandler:
+            def start(self, **_kwargs):
+                events.append("remove_start")
+                return {
+                    "content": "削除する作品を選んでください。",
+                    "components": [
+                        {
+                            "type": 1,
+                            "components": [
+                                {
+                                    "type": 3,
+                                    "custom_id": "remove_select",
+                                    "options": [{"label": "作品A", "value": "token-a"}],
+                                }
+                            ],
+                        }
+                    ],
+                }
+
+        callback_client = RecordingInteractionCallbackClient(events)
+        service, signing_key = self.make_service(
+            remove_handler=FakeRemoveHandler(),
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {"name": REMOVE_COMMAND},
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(
+            ["callback.defer_channel_message", "remove_start", "callback.edit_original_response"],
+            events,
+        )
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1", "ephemeral": True}],
+            callback_client.deferred_channel_messages,
+        )
+        self.assertEqual("remove_select", callback_client.edits[0]["data"]["components"][0]["components"][0]["custom_id"])
+
     def test_message_component_routes_to_remove_handler(self):
         class FakeRemoveHandler:
             def __init__(self):
@@ -305,6 +588,59 @@ class DiscordInteractionServiceTests(unittest.TestCase):
         self.assertEqual(7, payload["type"])
         self.assertEqual("updated", payload["data"]["content"])
         self.assertEqual("remove_select", remove_handler.calls[0]["custom_id"])
+
+    def test_remove_component_defers_before_handler_and_edits_original_response(self):
+        class FakeRemoveHandler:
+            def __init__(self, events):
+                self.events = events
+                self.calls = []
+
+            def handle_component(self, data, **_kwargs):
+                self.events.append("remove_component")
+                self.calls.append(data)
+                return {"content": "updated", "components": []}
+
+        for custom_id, values in (
+            ("remove_select", ["token-a"]),
+            ("remove_page:1", []),
+            ("remove_confirm:token-a", []),
+            ("remove_cancel:token-a", []),
+        ):
+            with self.subTest(custom_id=custom_id):
+                events = []
+                remove_handler = FakeRemoveHandler(events)
+                callback_client = RecordingInteractionCallbackClient(events)
+                service, signing_key = self.make_service(
+                    remove_handler=remove_handler,
+                    interaction_callback_client=callback_client,
+                )
+                data = {"custom_id": custom_id}
+                if values:
+                    data["values"] = values
+                headers, body = self.signed_request(
+                    {
+                        "id": "interaction-1",
+                        "application_id": "app-1",
+                        "token": "token-1",
+                        "type": 3,
+                        "data": data,
+                    },
+                    signing_key,
+                )
+
+                response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+                self.assertEqual(202, response.status_code)
+                self.assertEqual(
+                    ["callback.defer_component", "remove_component", "callback.edit_original_response"],
+                    events,
+                )
+                self.assertEqual(
+                    [{"interaction_id": "interaction-1", "interaction_token": "token-1"}],
+                    callback_client.deferred_components,
+                )
+                self.assertEqual(custom_id, remove_handler.calls[0]["custom_id"])
+                self.assertEqual("updated", callback_client.edits[0]["data"]["content"])
 
 
 class FetchDispatcherTests(unittest.TestCase):

--- a/tests/test_discord_supertwins_interactions.py
+++ b/tests/test_discord_supertwins_interactions.py
@@ -18,11 +18,24 @@ class RecordingFetchDispatcher:
 
 
 class RecordingInteractionCallbackClient:
-    def __init__(self):
+    def __init__(self, events=None):
+        self.events = events if events is not None else []
+        self.defer_channel_calls = []
         self.defer_calls = []
         self.edit_calls = []
 
+    def defer_channel_message(self, *, interaction_id, interaction_token, ephemeral=False):
+        self.events.append("callback.defer_channel_message")
+        self.defer_channel_calls.append(
+            {
+                "interaction_id": interaction_id,
+                "interaction_token": interaction_token,
+                "ephemeral": ephemeral,
+            }
+        )
+
     def defer_component(self, *, interaction_id, interaction_token):
+        self.events.append("callback.defer_component")
         self.defer_calls.append(
             {
                 "interaction_id": interaction_id,
@@ -31,6 +44,7 @@ class RecordingInteractionCallbackClient:
         )
 
     def edit_original_response(self, *, application_id, interaction_token, data):
+        self.events.append("callback.edit_original_response")
         self.edit_calls.append(
             {
                 "application_id": application_id,
@@ -97,6 +111,52 @@ class DiscordSupertwinsInteractionTests(unittest.TestCase):
         self.assertEqual("候補検索はまだ有効化されていません。", payload["data"]["content"])
         self.assertEqual(1, len(handler.calls))
 
+    def test_supertwins_search_command_defers_before_handler_and_edits_original_response(self):
+        events = []
+
+        class FakeSearchHandler:
+            def __init__(self):
+                self.calls = []
+
+            def start(self, **kwargs):
+                events.append("supertwins_search_start")
+                self.calls.append(kwargs)
+                return {"content": "候補検索はまだ有効化されていません。", "components": []}
+
+        callback_client = RecordingInteractionCallbackClient(events)
+        handler = FakeSearchHandler()
+        service, signing_key = self.make_service(
+            supertwins_search_handler=handler,
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {"name": SUPERTWINS_SEARCH_COMMAND},
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(
+            [
+                "callback.defer_channel_message",
+                "supertwins_search_start",
+                "callback.edit_original_response",
+            ],
+            events,
+        )
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1", "ephemeral": True}],
+            callback_client.defer_channel_calls,
+        )
+        self.assertEqual("候補検索はまだ有効化されていません。", callback_client.edit_calls[0]["data"]["content"])
+
     def test_supertwins_manage_command_routes_to_ephemeral_handler(self):
         class FakeManageHandler:
             def __init__(self):
@@ -120,6 +180,52 @@ class DiscordSupertwinsInteractionTests(unittest.TestCase):
         self.assertEqual(64, payload["data"]["flags"])
         self.assertEqual("supertwins 管理はまだ有効化されていません。", payload["data"]["content"])
         self.assertEqual(1, len(handler.calls))
+
+    def test_supertwins_manage_command_defers_before_handler_and_edits_original_response(self):
+        events = []
+
+        class FakeManageHandler:
+            def __init__(self):
+                self.calls = []
+
+            def start(self, **kwargs):
+                events.append("supertwins_manage_start")
+                self.calls.append(kwargs)
+                return {"content": "supertwins 管理はまだ有効化されていません。", "components": []}
+
+        callback_client = RecordingInteractionCallbackClient(events)
+        handler = FakeManageHandler()
+        service, signing_key = self.make_service(
+            supertwins_manage_handler=handler,
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 2,
+                "data": {"name": SUPERTWINS_MANAGE_COMMAND},
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(
+            [
+                "callback.defer_channel_message",
+                "supertwins_manage_start",
+                "callback.edit_original_response",
+            ],
+            events,
+        )
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1", "ephemeral": True}],
+            callback_client.defer_channel_calls,
+        )
+        self.assertEqual("supertwins 管理はまだ有効化されていません。", callback_client.edit_calls[0]["data"]["content"])
 
     def test_supertwins_search_component_prefix_routes_to_handler(self):
         class FakeSearchHandler:
@@ -262,6 +368,52 @@ class DiscordSupertwinsInteractionTests(unittest.TestCase):
         self.assertEqual(7, payload["type"])
         self.assertEqual("updated-manage", payload["data"]["content"])
         self.assertEqual("supertwins_manage:placeholder", handler.calls[0]["data"]["custom_id"])
+
+    def test_supertwins_manage_component_defers_before_handler_and_edits_original_response(self):
+        events = []
+
+        class FakeManageHandler:
+            def __init__(self):
+                self.calls = []
+
+            def handle_component(self, data, **kwargs):
+                events.append("supertwins_manage_component")
+                self.calls.append({"data": data, **kwargs})
+                return {"content": "updated-manage", "components": []}
+
+        callback_client = RecordingInteractionCallbackClient(events)
+        handler = FakeManageHandler()
+        service, signing_key = self.make_service(
+            supertwins_manage_handler=handler,
+            interaction_callback_client=callback_client,
+        )
+        headers, body = self.signed_request(
+            {
+                "id": "interaction-1",
+                "application_id": "app-1",
+                "token": "token-1",
+                "type": 3,
+                "data": {"custom_id": "supertwins_manage:placeholder"},
+            },
+            signing_key,
+        )
+
+        response = service.handle_request(method="POST", path="/", headers=headers, body=body)
+
+        self.assertEqual(202, response.status_code)
+        self.assertEqual(
+            [
+                "callback.defer_component",
+                "supertwins_manage_component",
+                "callback.edit_original_response",
+            ],
+            events,
+        )
+        self.assertEqual(
+            [{"interaction_id": "interaction-1", "interaction_token": "token-1"}],
+            callback_client.defer_calls,
+        )
+        self.assertEqual("updated-manage", callback_client.edit_calls[0]["data"]["content"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Closes #331
- Add ACK/defer contract coverage for `/latest`, `/fetch`, `/add`, `/remove`, `/supertwins-search`, and `/supertwins-manage` through `DiscordInteractionService`
- Route callback-client production paths through defer-first helpers so handler work runs only after Discord ACK/defer
- Preserve existing no-callback synchronous fallback tests and existing handler unit tests

## Verification
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_discord_interactions tests.test_discord_real_e2e tests.test_discord_interactions_where tests.test_discord_where tests.test_discord_add tests.test_discord_supertwins tests.test_discord_remove tests.test_discord_interactions_search tests.test_discord_command_registration tests.test_discord_title_search tests.test_discord_latest tests.test_discord_fetch tests.test_discord_search tests.test_discord_supertwins_interactions tests.test_discord_command_registration_where tests.test_post_signed_discord_interaction tests.test_discord_command_registration_search tests.test_supertwins tests.test_discord_outbound tests.test_discord_inbound`
- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m py_compile manga_watch/discord_interactions.py tests/test_discord_interactions.py tests/test_discord_supertwins_interactions.py`