### PR TITLE
Add keep-warm scheduler helper with 5-minute default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ GCP の deploy / run / verify の source of truth は [`doc/gcp-deploy.md`](doc/
 
 - Cloud Run Job `comic-crawler-job`: 定期クロールと手動実行の実体
 - Cloud Run Service `comic-crawler-service`: Discord interaction endpoint
-- Cloud Scheduler helper: `python3 scripts/print_cloud_scheduler_job.py create|update --schedule "<cron>"`
+- Cloud Scheduler helper (Cloud Run Job): `python3 scripts/print_cloud_scheduler_job.py create|update --schedule "<cron>"`
+- Keep-warm helper (Cloud Run Service): `python3 scripts/print_keep_warm_scheduler_job.py create|update --service-url "<service-url>"` (default schedule: `*/5 * * * *`)
 - Scheduler force-run: `gcloud scheduler jobs run comic-crawler-scheduled-run --project=star-light-breaker --location=asia-northeast1`
 
 root の受け入れ仕様書は Git 上の実ファイル名を `spec.md` にしていますが、文書名と cross-document 参照では `SPEC.md` と表記します。これは macOS などの case-insensitive filesystem で path 衝突を避けるためです。canonical docs や新しい issue / PR で `SPEC.md` と書かれている場合は、この `spec.md` を指します。旧 single-file spec への過去の言及は reference 扱いで、source of truth ではありません。

--- a/doc/gcp-deploy.md
+++ b/doc/gcp-deploy.md
@@ -353,6 +353,13 @@ gcloud scheduler jobs create http comic-crawler-service-keep-warm \
   --http-method=GET
 ```
 
+helper script で command shape を固定したい場合は以下。
+
+```bash
+python3 scripts/print_keep_warm_scheduler_job.py create \
+  --service-url "${SERVICE_URL}"
+```
+
 補足:
 
 - この ping は cold start 発生率を下げるための best effort であり、`min instances=1` ほどの保証はない

--- a/scripts/print_keep_warm_scheduler_job.py
+++ b/scripts/print_keep_warm_scheduler_job.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shlex
+
+DEFAULT_PROJECT = "star-light-breaker"
+DEFAULT_REGION = "asia-northeast1"
+DEFAULT_TIME_ZONE = "Asia/Tokyo"
+DEFAULT_SCHEDULER_JOB_NAME = "comic-crawler-service-keep-warm"
+DEFAULT_SCHEDULE = "*/5 * * * *"
+DEFAULT_SERVICE_PATH = "/healthz"
+
+
+def build_service_healthz_uri(*, service_url: str, service_path: str = DEFAULT_SERVICE_PATH) -> str:
+    normalized_base = service_url.rstrip("/")
+    normalized_path = service_path if service_path.startswith("/") else f"/{service_path}"
+    return f"{normalized_base}{normalized_path}"
+
+
+def build_gcloud_scheduler_keep_warm_command(
+    *,
+    action: str,
+    service_url: str,
+    project: str = DEFAULT_PROJECT,
+    region: str = DEFAULT_REGION,
+    scheduler_job_name: str = DEFAULT_SCHEDULER_JOB_NAME,
+    schedule: str = DEFAULT_SCHEDULE,
+    time_zone: str = DEFAULT_TIME_ZONE,
+    service_path: str = DEFAULT_SERVICE_PATH,
+) -> str:
+    normalized_schedule = schedule.strip()
+    if action not in {"create", "update"}:
+        raise ValueError(f"unsupported action: {action}")
+    if not normalized_schedule:
+        raise ValueError("schedule is required")
+
+    flags = [
+        f"--project={project}",
+        f"--location={region}",
+        f"--schedule={shlex.quote(normalized_schedule)}",
+        f"--time-zone={time_zone}",
+        f"--uri={build_service_healthz_uri(service_url=service_url, service_path=service_path)}",
+        "--http-method=GET",
+    ]
+    command = f"gcloud scheduler jobs {action} http {scheduler_job_name}"
+    return command + " \\\n  " + " \\\n  ".join(flags)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Print keep-warm Cloud Scheduler command for Cloud Run Service.")
+    parser.add_argument("action", choices=("create", "update"))
+    parser.add_argument("--service-url", required=True)
+    parser.add_argument("--project", default=DEFAULT_PROJECT)
+    parser.add_argument("--region", default=DEFAULT_REGION)
+    parser.add_argument("--time-zone", default=DEFAULT_TIME_ZONE)
+    parser.add_argument("--schedule", default=DEFAULT_SCHEDULE)
+    parser.add_argument("--scheduler-job", default=DEFAULT_SCHEDULER_JOB_NAME)
+    parser.add_argument("--service-path", default=DEFAULT_SERVICE_PATH)
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.schedule = args.schedule.strip()
+    if not args.schedule:
+        parser.error("--schedule must be a non-empty cron expression")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(
+        build_gcloud_scheduler_keep_warm_command(
+            action=args.action,
+            service_url=args.service_url,
+            project=args.project,
+            region=args.region,
+            scheduler_job_name=args.scheduler_job,
+            schedule=args.schedule,
+            time_zone=args.time_zone,
+            service_path=args.service_path,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_print_keep_warm_scheduler_job.py
+++ b/tests/test_print_keep_warm_scheduler_job.py
@@ -1,0 +1,55 @@
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+def load_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "print_keep_warm_scheduler_job.py"
+    spec = importlib.util.spec_from_file_location("print_keep_warm_scheduler_job", script_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("unable to load keep warm script")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PrintKeepWarmSchedulerJobTests(unittest.TestCase):
+    def test_default_schedule_is_five_minutes(self):
+        module = load_module()
+        self.assertEqual("*/5 * * * *", module.DEFAULT_SCHEDULE)
+
+    def test_build_command_uses_healthz_and_get(self):
+        module = load_module()
+        command = module.build_gcloud_scheduler_keep_warm_command(
+            action="create",
+            service_url="https://comic-crawler-service-abc.a.run.app",
+        )
+        self.assertIn("gcloud scheduler jobs create http comic-crawler-service-keep-warm", command)
+        self.assertIn("--schedule='*/5 * * * *'", command)
+        self.assertIn("--uri=https://comic-crawler-service-abc.a.run.app/healthz", command)
+        self.assertIn("--http-method=GET", command)
+
+    def test_main_rejects_blank_schedule(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/print_keep_warm_scheduler_job.py",
+                "create",
+                "--service-url",
+                "https://example.com",
+                "--schedule",
+                "   ",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).resolve().parent.parent,
+        )
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("--schedule must be a non-empty cron expression", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Cloud Run Service instances can scale to zero and experience cold starts, so a lightweight keep-warm ping is needed to reduce cold-start frequency. 
- The intent is to provide a canonical helper to create a Cloud Scheduler job that sends `GET /healthz` every 5 minutes by default.

### Description

- Add `scripts/print_keep_warm_scheduler_job.py`, a CLI helper that renders canonical `gcloud scheduler jobs create|update http` commands for a keep-warm ping and defaults to schedule `*/5 * * * *` and path `/healthz`.
- The helper accepts `create|update`, `--service-url` (required), and optional flags for project/region/schedule/time-zone/job name/path, and validates that the schedule is non-empty.
- Update `README.md` and `doc/gcp-deploy.md` to document the new helper and the recommended 5-minute keep-warm schedule.
- Add unit tests `tests/test_print_keep_warm_scheduler_job.py` to validate default schedule, command shape, and schedule validation, and update `tests/test_keep_warm_docs.py` expectations where applicable.

### Testing

- Ran `python -m unittest tests.test_print_keep_warm_scheduler_job tests.test_keep_warm_docs` and all tests passed (5 tests, `OK`).
- The new helper is exercised by unit tests that assert the default `*/5 * * * *` schedule, the `--uri` uses `/healthz`, and that a blank `--schedule` is rejected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6ceb38d20833281f209cb9c204a2f)