### PR TITLE
[codex] Fix comic-action feed latest parsing

### DIFF
--- a/manga_watch/sources/comic_action.py
+++ b/manga_watch/sources/comic_action.py
@@ -1,5 +1,6 @@
 import html
 import re
+import xml.etree.ElementTree as ET
 from typing import Optional, Tuple
 
 from .base import HttpClient, LatestEpisode, SourceAdapter, SourceParseError, WorkDescriptor
@@ -75,11 +76,45 @@ def extract_comic_action_series_id_from_seed_url(seed_url: str) -> Optional[str]
 def extract_comic_action_episode_url_from_feed(feed_text: str) -> Optional[str]:
     if not feed_text:
         return None
-    decoded = html.unescape(feed_text)
-    match = re.search(r"https?://(?:www\.)?comic-action\.com/episode/(\d+)", decoded)
-    if not match:
+
+    try:
+        root = ET.fromstring(html.unescape(feed_text))
+    except ET.ParseError:
         return None
-    return canonical_comic_action_episode_url(match.group(1))
+
+    channel = _first_child_named(root, "channel")
+    if channel is not None:
+        for item in _children_named(channel, "item"):
+            latest_url = parse_comic_action_episode_url(_child_text(item, "link"))
+            if latest_url:
+                return latest_url
+        return None
+
+    for entry in _children_named(root, "entry"):
+        for link in _children_named(entry, "link"):
+            latest_url = parse_comic_action_episode_url((link.get("href") or "").strip())
+            if latest_url:
+                return latest_url
+    return None
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _children_named(element: ET.Element, name: str) -> Tuple[ET.Element, ...]:
+    return tuple(child for child in element if _local_name(child.tag) == name)
+
+
+def _first_child_named(element: ET.Element, name: str) -> Optional[ET.Element]:
+    for child in _children_named(element, name):
+        return child
+    return None
+
+
+def _child_text(element: ET.Element, name: str) -> str:
+    child = _first_child_named(element, name)
+    return (child.text or "").strip() if child is not None else ""
 
 
 def extract_comic_action_next_update_label(html_text: str) -> Optional[str]:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -874,6 +874,53 @@ class SourceAdapterTests(unittest.TestCase):
             client.calls,
         )
 
+    def test_comic_action_fetch_latest_ignores_rss_channel_link(self):
+        adapter = ComicActionAdapter()
+        work = adapter.normalize("https://comic-action.com/rss/series/13933686331663374228")
+        client = StaticHttpClient(
+            {
+                "https://comic-action.com/rss/series/13933686331663374228": """
+                <rss version="2.0">
+                  <channel>
+                    <title>webアクション（ダンジョンの中のひと）</title>
+                    <link>https://comic-action.com/episode/13933686331665056851</link>
+                    <item>
+                      <title>第52話</title>
+                      <link>https://comic-action.com/episode/12207421983607886776</link>
+                      <description>ダンジョンの中のひと</description>
+                    </item>
+                    <item>
+                      <title>第51話</title>
+                      <link>https://comic-action.com/episode/2551460910007760899</link>
+                      <description>ダンジョンの中のひと</description>
+                    </item>
+                  </channel>
+                </rss>
+                """,
+                "https://comic-action.com/episode/12207421983607886776": """
+                <html>
+                  <head>
+                    <title>第52話 / ダンジョンの中のひと - 双見酔 | webアクション</title>
+                  </head>
+                  <body></body>
+                </html>
+                """,
+            }
+        )
+
+        latest = adapter.fetch_latest(work, client).to_dict()
+
+        self.assertEqual("https://comic-action.com/episode/12207421983607886776", latest["latestKey"])
+        self.assertEqual("第52話", latest["episodeTitle"])
+        self.assertEqual("ダンジョンの中のひと", latest["seriesTitle"])
+        self.assertEqual(
+            [
+                "https://comic-action.com/rss/series/13933686331663374228",
+                "https://comic-action.com/episode/12207421983607886776",
+            ],
+            client.calls,
+        )
+
     def test_comic_action_fetch_latest_extracts_next_update_label_from_latest_page(self):
         adapter = ComicActionAdapter()
         work = adapter.normalize("https://comic-action.com/episode/111")


### PR DESCRIPTION
## Summary

- Parse comic-action RSS/Atom feeds structurally instead of scanning the whole feed for the first episode URL
- Ignore RSS `channel/link` when selecting the latest episode, and use the first `item/link` or Atom `entry/link` instead
- Add a regression test for a feed whose channel link points to `第1話` while the first item points to `第52話`

## Root Cause

comic-action feeds can include a representative `channel/link` that points at an older/free episode. The previous parser searched the entire feed with a regex and treated the first episode URL as the latest, so a feed with `channel/link = 第1話` could be reported as a new latest episode after `第51話`.

## Validation

- `/Users/kentoku.matsunami/Documents/GitHub/comic_crawler/.venv/bin/python -m unittest tests.test_sources`